### PR TITLE
ENG-546 Fix error handling issues

### DIFF
--- a/cyral/provider.go
+++ b/cyral/provider.go
@@ -79,7 +79,7 @@ func providerConfigure(d *schema.ResourceData, terraformVersion string) (interfa
 	token, err := readTokenInfo(config.auth0Domain, config.auth0ClientID,
 		config.auth0ClientSecret, config.auth0Audience)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	config.token = token.AccessToken


### PR DESCRIPTION
The error our customer was facing was due to a wrong test order in error handling. Tests below were in the wrong order, thus it would get a null pointer in case the request pointed to an invalid address:

https://github.com/cyralinc/terraform-provider-cyral/blob/fc4c3c669c184f0c03e24eef993cccaf063339c6/cyral/resource_cyral_repository.go#L81-L87