### PR TITLE
ENG-547 Add support for import

### DIFF
--- a/cyral/config.go
+++ b/cyral/config.go
@@ -1,14 +1,107 @@
 package cyral
 
-// Config contains the provider configuration parameters.
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// Config contains the provider configuration parameters stored
+// during provider initialization.
 type Config struct {
-	auth0Domain       string
-	auth0ClientID     string
-	auth0ClientSecret string
-	auth0Audience     string
-	token             string
-	tokenType         string
-	controlPlane      string
-	terraformVersion  string
-	repoID            string
+	Auth0Domain   string
+	Auth0Audience string
+	controlPlane  string
+
+	terraformVersion string
+}
+
+// CyralClient stores data for all existing resources. Also, this is
+// the struct that is passed along resources CRUD operations.
+type CyralClient struct {
+	Token        string
+	TokenType    string
+	ControlPlane string
+
+	Repository Repository
+}
+
+// Repository struct stores data for resource repository.
+type Repository struct {
+	Name string
+}
+
+// Client configures and returns a fully initialized CyralClient.
+func (c *Config) Client() (interface{}, error) {
+	auth0ClientID, err := c.getEnv("AUTH0_CLIENT_ID")
+	if err != nil {
+		return nil, err
+	}
+	auth0ClientSecret, err := c.getEnv("AUTH0_CLIENT_SECRET")
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := c.readTokenInfo(c.Auth0Domain, auth0ClientID, auth0ClientSecret, c.Auth0Audience)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CyralClient{
+		ControlPlane: c.controlPlane,
+		Token:        token.AccessToken,
+		TokenType:    token.TokenType,
+		Repository:   Repository{},
+	}, nil
+}
+
+func (c *Config) readTokenInfo(domain, clientID, clientSecret, audience string) (auth0TokenResponse, error) {
+	url := fmt.Sprintf("https://%s/oauth/token", domain)
+	audienceURL := fmt.Sprintf("https://%s", audience)
+	tokenReq := auth0TokenRequest{
+		Audience:     audienceURL,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		GrantType:    "client_credentials",
+	}
+
+	payloadBytes, err := json.Marshal(tokenReq)
+	if err != nil {
+		return auth0TokenResponse{}, fmt.Errorf("failed to encode readToken payload: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(string(payloadBytes)))
+	if err != nil {
+		return auth0TokenResponse{}, fmt.Errorf("unable to create auth0 request; err: %v", err)
+	}
+
+	req.Header.Add("content-type", "application/json")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return auth0TokenResponse{}, fmt.Errorf("unable execute auth0 request; err: %v", err)
+	}
+
+	defer res.Body.Close()
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return auth0TokenResponse{}, fmt.Errorf("unable to read data from request body; err: %v", err)
+	}
+
+	token := auth0TokenResponse{}
+	err = json.Unmarshal(body, &token)
+	if err != nil {
+		return auth0TokenResponse{}, fmt.Errorf("unable to get access token from json; err: %v", err)
+	}
+
+	return token, nil
+}
+
+func (c *Config) getEnv(key string) (string, error) {
+	if value, ok := os.LookupEnv(key); ok {
+		return value, nil
+	}
+	return "", fmt.Errorf("missing environment variable: %s", key)
 }

--- a/cyral/resource_cyral_repository.go
+++ b/cyral/resource_cyral_repository.go
@@ -60,13 +60,13 @@ func resourceCyralRepository() *schema.Resource {
 }
 
 func resourceCyralRepositoryCreate(d *schema.ResourceData, m interface{}) error {
-	config := m.(*Config)
-	repoData, err := getRepoData(config, d)
+	c := m.(*CyralClient)
+	repoData, err := getRepoData(c, d)
 	if err != nil {
 		return err
 	}
 
-	url := fmt.Sprintf("https://%s/repos", config.controlPlane)
+	url := fmt.Sprintf("https://%s/repos", c.ControlPlane)
 	payloadBytes, err := json.Marshal(repoData)
 	if err != nil {
 		return fmt.Errorf("failed to encode 'create repo' payload: %v", err)
@@ -78,7 +78,7 @@ func resourceCyralRepositoryCreate(d *schema.ResourceData, m interface{}) error 
 	}
 
 	req.Header.Add("content-type", "application/json")
-	req.Header.Add("Authorization", fmt.Sprintf("%s %s", config.tokenType, config.token))
+	req.Header.Add("Authorization", fmt.Sprintf("%s %s", c.TokenType, c.Token))
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -107,15 +107,15 @@ func resourceCyralRepositoryCreate(d *schema.ResourceData, m interface{}) error 
 	}
 
 	id := jsonMap["ID"]
-	config.repoID = id
+	c.Repository.Name = id
 	d.SetId(id)
 
 	return resourceCyralRepositoryRead(d, m)
 }
 
 func resourceCyralRepositoryRead(d *schema.ResourceData, m interface{}) error {
-	config := m.(*Config)
-	repoData, err := resourceCyralRepositoryFindByID(config, d.Id())
+	c := m.(*CyralClient)
+	repoData, err := resourceCyralRepositoryFindByID(c, d.Id())
 
 	if err != nil {
 		return err
@@ -137,13 +137,13 @@ func resourceCyralRepositoryRead(d *schema.ResourceData, m interface{}) error {
 func resourceCyralRepositoryUpdate(d *schema.ResourceData, m interface{}) error {
 	// TODO Warn users if they modify `require_tls` parameter in .tf, as it
 	// is not possible to change it once the repo is created.
-	config := m.(*Config)
-	repoData, err := getRepoData(config, d)
+	c := m.(*CyralClient)
+	repoData, err := getRepoData(c, d)
 	if err != nil {
 		return err
 	}
 
-	url := fmt.Sprintf("https://%s/repos/%s", config.controlPlane, d.Id())
+	url := fmt.Sprintf("https://%s/repos/%s", c.ControlPlane, d.Id())
 	payloadBytes, err := json.Marshal(repoData)
 	if err != nil {
 		return fmt.Errorf("failed to encode 'update repo' payload: %v", err)
@@ -155,7 +155,7 @@ func resourceCyralRepositoryUpdate(d *schema.ResourceData, m interface{}) error 
 	}
 
 	req.Header.Add("content-type", "application/json")
-	req.Header.Add("Authorization", fmt.Sprintf("%s %s", config.tokenType, config.token))
+	req.Header.Add("Authorization", fmt.Sprintf("%s %s", c.TokenType, c.Token))
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("unable to execute 'update repo' request. Check the control plane address; err: %v", err)
@@ -174,8 +174,8 @@ func resourceCyralRepositoryUpdate(d *schema.ResourceData, m interface{}) error 
 }
 
 func resourceCyralRepositoryDelete(d *schema.ResourceData, m interface{}) error {
-	config := m.(*Config)
-	url := fmt.Sprintf("https://%s/repos/%s", config.controlPlane, d.Id())
+	c := m.(*CyralClient)
+	url := fmt.Sprintf("https://%s/repos/%s", c.ControlPlane, d.Id())
 
 	req, err := http.NewRequest(http.MethodDelete, url, nil)
 	if err != nil {
@@ -183,7 +183,7 @@ func resourceCyralRepositoryDelete(d *schema.ResourceData, m interface{}) error 
 	}
 
 	req.Header.Add("content-type", "application/json")
-	req.Header.Add("Authorization", fmt.Sprintf("%s %s", config.tokenType, config.token))
+	req.Header.Add("Authorization", fmt.Sprintf("%s %s", c.TokenType, c.Token))
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("unable execute 'delete repo' request. Check the control plane address; err: %v", err)
@@ -196,8 +196,8 @@ func resourceCyralRepositoryDelete(d *schema.ResourceData, m interface{}) error 
 	return nil
 }
 
-func resourceCyralRepositoryFindByID(config *Config, id string) (*resourceCyralRepositoryData, error) {
-	url := fmt.Sprintf("https://%s/repos/%s", config.controlPlane, id)
+func resourceCyralRepositoryFindByID(c *CyralClient, id string) (*resourceCyralRepositoryData, error) {
+	url := fmt.Sprintf("https://%s/repos/%s", c.ControlPlane, id)
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -205,7 +205,7 @@ func resourceCyralRepositoryFindByID(config *Config, id string) (*resourceCyralR
 	}
 
 	req.Header.Add("content-type", "application/json")
-	req.Header.Add("Authorization", fmt.Sprintf("%s %s", config.tokenType, config.token))
+	req.Header.Add("Authorization", fmt.Sprintf("%s %s", c.TokenType, c.Token))
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("unable to execute findRepoByID request. Check the control plane address; err: %v", err)
@@ -265,7 +265,7 @@ func validateGetRepoRequest(repoRespJSON getRepoResponse) error {
 	return nil
 }
 
-func getRepoData(config *Config, d *schema.ResourceData) (resourceCyralRepositoryData, error) {
+func getRepoData(c *CyralClient, d *schema.ResourceData) (resourceCyralRepositoryData, error) {
 	repoType := d.Get("type").(string)
 	err := containsRepoType(repoType)
 	if err != nil {


### PR DESCRIPTION
Add support for import using the repo ID.

For a given `main.tf`:

```hql
provider "cyral" {
    auth0_domain = "dev-cyral.auth0.com"
    auth0_audience = "cyral-api.com"
    control_plane = "mb200404-flxport-a01.dev.cyral.com"
}

resource "cyral_repository" "some_name" {
    host = "some_host"
    port = 65000
    type = "mariadb"
    name = "some_random_repo_name"
}
```

The following command would map an existing repo with id `1bIPPQXMjoikyLvzExT2n8ht8af` to resource `cyral_repository.some_name`:

```bash
terraform import cyral_repository.some_name 1bIPPQXMjoikyLvzExT2n8ht8af
```

This solution works fine and shows that the existing `read` function works perfectly (no changes in other parts of our code required besides those proposed few lines), but it may be inconvenient as users will have to handle internal IDs. Thus, I appreciate some opinions.