### PR TITLE
chore: builds linux and mac binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .terraform
 # Provider binary
 terraform-provider-cyral
+out/

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,17 @@ install:
 	GOOS=darwin GOARCH=amd64 $(GOBUILD) -o out/darwin_amd64/terraform-provider-cyral_v$(VERSION) .
 	GOOS=linux GOARCH=amd64 $(GOBUILD) -o out/linux_amd64/terraform-provider-cyral_v$(VERSION) .
 
+docker-go-build:
+	docker-compose run app $(GOFMT) -w .
+	docker-compose run -e GOOS=darwin -e GOARCH=amd64 app $(GOBUILD) -o out/darwin_amd64/terraform-provider-cyral_v$(VERSION) .
+	docker-compose run -e GOOS=linux -e GOARCH=amd64 app $(GOBUILD) -o out/linux_amd64/terraform-provider-cyral_v$(VERSION) .
+
 clean:
 	$(GOCLEAN) -i github.com/cyralinc/terraform-provider-cyral/...
+	rm -rf ./out
+
+docker-go-clean:
+	docker-compose run app $(GOCLEAN) -i github.com/cyralinc/terraform-provider-cyral/...
 	rm -rf ./out
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,17 @@ GOTEST=$(GOCMD) test
 GOGET=$(GOCMD) get
 GOINSTALL=$(GOCMD) install
 PROTOC=protoc
+VERSION=$(shell cat VERSION)
 
 all: install test
 
 install:
 	$(GOFMT) -w .
-	$(GOBUILD) -o terraform-provider-cyral .
+	GOOS=darwin GOARCH=amd64 $(GOBUILD) -o out/darwin_amd64/terraform-provider-cyral_v$(VERSION) .
+	GOOS=linux GOARCH=amd64 $(GOBUILD) -o out/linux_amd64/terraform-provider-cyral_v$(VERSION) .
 
 clean:
 	$(GOCLEAN) -i github.com/cyralinc/terraform-provider-cyral/...
+	rm -rf ./out
 
 test:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,8 @@
+version: "2"
+
+services:
+  app:
+    image: golang:1.14-alpine
+    volumes:
+      - .:/go/src/cyral
+    working_dir: /go/src/cyral


### PR DESCRIPTION
This makes the following changes:
* It builds binaries for both Linux (linux_amd64) & MacOS (darwin_amd_64)
* The files are places in `out/<platform>` to match the directory structure that TF expects
* It reads in the `VERSION` and appends that to the file names to match TFs expectations

It also adds a `docker-compose.yaml` file that allows for builds inside of docker
* `make docker-go-build` will run the commands in the docker-compose container.