### PR TITLE
ENG-1337 Add supported Terraform version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ terraform import cyral_repository.my_resource_name myrepo
 - [Provider](./doc/provider.md)
 - [Resource Repository](./doc/resource_repository.md)
 
+## Prerequisites
+
+Our existing provider was created to support Terraform v0.12. Therefore, this version of Terraform must be installed in your environment. In the future, we plan to add support for newer versions as well.
+
 ## Build Instructions
 
 In order to build and distribute this provider, follow the steps below:


### PR DESCRIPTION
We need to inform that this provider is only compatible with TF 0.12.x and in the future we will add support for newer versions as well.