### PR TITLE
Changes keycloak service account initialization script

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,6 @@ A `Service Account` for the Terraform provider must be created using the [script
 curl https://raw.githubusercontent.com/cyralinc/terraform-provider-cyral/main/scripts/create-service-account-keycloak.sh -O
 bash create-service-account-keycloak.sh
 ```
-or
-
-```bash
-curl https://raw.githubusercontent.com/cyralinc/terraform-provider-cyral/main/scripts/create-service-account-keycloak.sh | bash
-```
 
 ## Usage Example
 

--- a/README.md
+++ b/README.md
@@ -25,25 +25,16 @@ This provider is compatible with both Auth0 or Keycloak-based CPs. Some initial 
 
 ### Keycloak
 
-A `Service Account` for the Terraform provider must be created using the following steps:
+A `Service Account` for the Terraform provider must be created using the [script provided in the scripts folder](./scripts/create-service-account-keycloak.sh). To run it, you can just:
 
+```bash
+curl raw.githubusercontent.com/cyralinc/terraform-provider-cyral/main/scripts/create-service-account-keycloak.sh -O
+bash create-service-account-keycloak.sh
 ```
-# Define the target control plane
-export CONTROL_PLANE=mycontrolplane.cyral.com
+or
 
-# Get a token from the CP (use the UI or some API)
-export TOKEN="Authorization: Bearer ..."
-
-# Get role ids necessary to run the provider
-export ROLE_IDS=`curl -X GET https://$CONTROL_PLANE:8000/v1/users/roles -H "$TOKEN" -H "Content-type:Application/JSON" | jq '[.roles | map(select(.name | contains("Modify Integrations", "Modify Policies", "Modify Roles","Modify Sidecars and Repositories", "View Sidecars and Repositories"))) | .[].id]' -c`
-
-# Create/update a service account for Terraform and return the necessary parameters
-# client_id and client_secret that will be used in the provider
-curl -X POST https://$CONTROL_PLANE:8000/v1/users/serviceAccounts -d '{"displayName":"terraform","roleIds":'"$ROLE_IDS"'}' -H "$TOKEN" -H "Content-type:Application/JSON" | jq
-
-echo "Use both `client_id` and `client_secret` returned above to set up your provider."
-echo "See the provider documentation in https://github.com/cyralinc/terraform-provider-cyral/blob/main/doc/provider.md how to set those two parameters."
-echo
+```bash
+curl raw.githubusercontent.com/cyralinc/terraform-provider-cyral/main/scripts/create-service-account-keycloak.sh | bash
 ```
 
 ## Usage Example

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ This provider is compatible with both Auth0 or Keycloak-based CPs. Some initial 
 A `Service Account` for the Terraform provider must be created using the [script provided in the scripts folder](./scripts/create-service-account-keycloak.sh). To run it, you can just:
 
 ```bash
-curl raw.githubusercontent.com/cyralinc/terraform-provider-cyral/main/scripts/create-service-account-keycloak.sh -O
+curl https://raw.githubusercontent.com/cyralinc/terraform-provider-cyral/main/scripts/create-service-account-keycloak.sh -O
 bash create-service-account-keycloak.sh
 ```
 or
 
 ```bash
-curl raw.githubusercontent.com/cyralinc/terraform-provider-cyral/main/scripts/create-service-account-keycloak.sh | bash
+curl https://raw.githubusercontent.com/cyralinc/terraform-provider-cyral/main/scripts/create-service-account-keycloak.sh | bash
 ```
 
 ## Usage Example

--- a/scripts/create-service-account-keycloak.sh
+++ b/scripts/create-service-account-keycloak.sh
@@ -1,0 +1,36 @@
+[ ! -z ${CONTROL_PLANE+x} ] || read -p "Enter your control plane: " CONTROL_PLANE
+
+[ ! -z ${TOKEN+x} ] || read -p "Enter the token gotten from the CP (use the UI or some API): " TOKEN
+HEADER="Authorization:Bearer $TOKEN"
+
+
+# Get role ids necessary to run the provider
+echo "Getting role IDs..."
+ROLE_IDS=$(curl -X GET https://$CONTROL_PLANE:8000/v1/users/roles -H "$HEADER" -H "Content-type:Application/JSON" --fail --show-error)
+if [[ $? -ne 0 ]]
+then
+	echo "Error getting the role IDs."
+	exit 1
+fi
+
+ROLE_IDS=$(echo $ROLE_IDS | jq '[.roles | map(select(.name | contains("Modify Integrations", "Modify Policies", "Modify Roles","Modify Sidecars and Repositories", "View Sidecars and Repositories"))) | .[].id]' -c)
+
+if [[ $? -ne 0 ]]
+then
+	echo "Error unmarshalling the role IDs"
+	echo "$ROLE_IDS"
+	exit 1
+fi
+
+# Create/update a service account for Terraform and return the necessary parameters
+# client_id and client_secret that will be used in the provider
+curl -X POST https://$CONTROL_PLANE:8000/v1/users/serviceAccounts -d '{"displayName":"terraform","roleIds":'"$ROLE_IDS"'}' -H "$HEADER" -H "Content-type:Application/JSON" | jq
+if [[ $? -ne 0 ]]
+then
+	echo "Error creating the service account"
+	exit 1
+fi
+
+echo "Use both \`clientId\` and \`clientSecret\` returned above to set up your provider."
+echo "See the provider documentation in https://github.com/cyralinc/terraform-provider-cyral/blob/main/doc/provider.md how to set those two parameters."
+echo


### PR DESCRIPTION
## Description of the change

Changes service account creation script to prompt for user input and to check for errors at each step. Changes README to suggest using the script instead of having the script in the markdown itself.

The script asks the user for both the CP target and the token, but takes prioritarely from environment variables named `CONTROL_PLANE` and `TOKEN`. The token is to be inserted without the `Authorization: Bearer` because the script already handles that.

Closes #54

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing
Created a service account using both the prompted and the env var based approaches, did it successfully. Errors cause errors and are properly printed on the screen.

Did not test the changes to the README because the script is not on the `main` branch, but should work once it is.
