### PR TITLE
Remove extraneous comma in cyral_repository_conf_auth docs

### DIFF
--- a/doc/resource_repository_conf_auth.md
+++ b/doc/resource_repository_conf_auth.md
@@ -7,7 +7,7 @@ CRUD operations for Repository Authentication Configuration.
 ```hcl
 resource "cyral_repository_conf_auth" "my-repository-conf-auth" {
     repository_id = ""
-    allow_native_auth = true|false,
+    allow_native_auth = true|false
     client_tls = "enable|disable|enabledAndVerifyCertificate"
     identity_provider = ""
     repo_tls = "enable|disable|enabledAndVerifyCertificate"


### PR DESCRIPTION
## Description of the change

Remove extraneous comma in `cyral_repository_conf_auth` docs. Closes #70.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing
No tests required as this is just a fix for existing docs.
