### PR TITLE
Fixes README.md with correct parameters for cyral provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ terraform {
 }
 
 provider "cyral" {
-    auth0_domain = "some-name.auth0.com"
-    auth0_audience = "cyral-api.com"
+    client_id = "some-client-id"
+    client_secret = "some-client-secret"
     control_plane = "some-cp.cyral.com:8000"
 }
 
@@ -115,7 +115,7 @@ resource "cyral_repository_binding" "repo_binding" {
 
 resource "cyral_datamap" "my_datamap_name" {
     mapping {
-        label = "CNN"
+        label = "CCN"
         data_location {
             repo = cyral_repository.my_repo_name.name
             attributes = ["applications.customers.credit_card_number"]


### PR DESCRIPTION
## Description of the change

This PR is intended to fix the parameters of 'cyral' provider specified in the README.md, replacing 'auth0_domain' and 'auth0_audience' with 'client_id' and 'client_secret'. The PR also corrects a typo in the CCN label for the datamap resource.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing
> Description of testing
