### PR TITLE
ENG-5806: Adds Sidecar Credentials resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ terraform import cyral_repository.my_resource_name myrepo
 - [Resource Repository Binding](./doc/resource_repository_binding.md)
 - [Resource Repository Local Account](./doc/resource_repository_local_account.md)
 - [Resource Sidecar](./doc/resource_sidecar.md)
+- [Resource Sidecar Credentials](./doc/resource_sidecar_credentials.md)
 
 ## Configuration Templates
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ resource "cyral_sidecar" "my_sidecar_name" {
     }
 }
 
+resource "cyral_sidecar_credentials" "my_sidecar_credentials_name" {
+  sidecar_id = cyral_sidecar.my_sidecar_name.id
+}
+
 locals {
     repositories = [cyral_repository.mongodb_repo, cyral_repository.mariadb_repo]
 }

--- a/cyral/provider.go
+++ b/cyral/provider.go
@@ -103,6 +103,7 @@ func Provider() *schema.Provider {
 			"cyral_repository_local_account":    resourceRepositoryLocalAccount(),
 			"cyral_repository_binding":          resourceRepositoryBinding(),
 			"cyral_sidecar":                     resourceSidecar(),
+			"cyral_sidecar_credentials":         resourceSidecarCredentials(),
 		},
 		ConfigureContextFunc: providerConfigure,
 	}

--- a/cyral/resource_cyral_sidecar_credentials.go
+++ b/cyral/resource_cyral_sidecar_credentials.go
@@ -1,0 +1,78 @@
+package cyral
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/cyralinc/terraform-provider-cyral/client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type CreateSidecarCredentialsRequest struct {
+	SidecarID string `json:"sidecarId"`
+}
+
+type CreateSidecarCredentialsResponse struct {
+	ClientID     string `json:"clientId"`
+	ClientSecret string `json:"clientSecret"`
+}
+
+func resourceSidecarCredentials() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSidecarCredentialsCreate,
+		ReadContext:   resourceSidecarCredentialsRead,
+		UpdateContext: resourceSidecarCredentialsUpdate,
+		DeleteContext: resourceSidecarCredentialsDelete,
+
+		Schema: map[string]*schema.Schema{
+			"sidecar_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+	}
+}
+
+func resourceSidecarCredentialsCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] Init resourceSidecarCredentialsCreate")
+	c := m.(*client.Client)
+
+	payload := CreateSidecarCredentialsRequest{d.Get("sidecar_id").(string)}
+
+	url := fmt.Sprintf("https://%s/v1/users/sidecarAccounts", c.ControlPlane)
+
+	body, err := c.DoRequest(url, http.MethodPost, payload)
+	if err != nil {
+		return createError("Unable to create sidecar credentials", fmt.Sprintf("%v", err))
+	}
+
+	response := CreateSidecarCredentialsResponse{}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return createError("Unable to unmarshall JSON", fmt.Sprintf("%v", err))
+	}
+	log.Printf("[DEBUG] Response body (unmarshalled): %#v", response)
+
+	d.SetId(response.ClientID)
+
+	return diag.Diagnostics{}
+}
+
+func resourceSidecarCredentialsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return diag.Diagnostics{}
+}
+
+func resourceSidecarCredentialsUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return diag.Diagnostics{}
+}
+
+func resourceSidecarCredentialsDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return diag.Diagnostics{}
+}

--- a/cyral/resource_cyral_sidecar_credentials.go
+++ b/cyral/resource_cyral_sidecar_credentials.go
@@ -2,7 +2,6 @@ package cyral
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -71,11 +70,9 @@ func resourceSidecarCredentialsCreate(ctx context.Context, d *schema.ResourceDat
 	}
 	log.Printf("[DEBUG] Response body (unmarshalled): %#v", response)
 
-	encodedClientSecret := base64.StdEncoding.EncodeToString([]byte(response.ClientSecret))
-
 	d.SetId(response.ClientID)
 	d.Set("client_id", response.ClientID)
-	d.Set("client_secret", encodedClientSecret)
+	d.Set("client_secret", response.ClientSecret)
 
 	return resourceSidecarCredentialsRead(ctx, d, m)
 }

--- a/cyral/resource_cyral_sidecar_credentials.go
+++ b/cyral/resource_cyral_sidecar_credentials.go
@@ -2,6 +2,7 @@ package cyral
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -70,9 +71,11 @@ func resourceSidecarCredentialsCreate(ctx context.Context, d *schema.ResourceDat
 	}
 	log.Printf("[DEBUG] Response body (unmarshalled): %#v", response)
 
+	encodedClientSecret := base64.StdEncoding.EncodeToString([]byte(response.ClientSecret))
+
 	d.SetId(response.ClientID)
 	d.Set("client_id", response.ClientID)
-	d.Set("client_secret", response.ClientSecret) // TODO: encrypt client secret
+	d.Set("client_secret", encodedClientSecret)
 
 	return resourceSidecarCredentialsRead(ctx, d, m)
 }

--- a/cyral/resource_cyral_sidecar_credentials_test.go
+++ b/cyral/resource_cyral_sidecar_credentials_test.go
@@ -1,0 +1,55 @@
+package cyral
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccSidecarCredentialsResource(t *testing.T) {
+	testConfig, testFunc := setupSidecarCredentialsTest()
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testConfig,
+				Check:  testFunc,
+			},
+		},
+	})
+}
+
+func setupSidecarCredentialsTest() (string, resource.TestCheckFunc) {
+	configuration := createSidecarCredentialsConfig()
+
+	testFunction := resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttrPair(
+			"cyral_sidecar_credentials.test_sidecar_credentials", "sidecar_id",
+			"cyral_sidecar.test_sidecar", "id"),
+		resource.TestCheckResourceAttrSet(
+			"cyral_sidecar_credentials.test_sidecar_credentials",
+			"client_id"),
+		resource.TestCheckResourceAttrSet(
+			"cyral_sidecar_credentials.test_sidecar_credentials",
+			"client_secret"),
+		resource.TestCheckResourceAttrPair(
+			"cyral_sidecar_credentials.test_sidecar_credentials", "id",
+			"cyral_sidecar_credentials.test_sidecar_credentials", "client_id"),
+	)
+
+	return configuration, testFunction
+}
+
+func createSidecarCredentialsConfig() string {
+	return `
+	resource "cyral_sidecar" "test_sidecar" {
+		name = "sidecar-test"
+		deployment_method = "docker"
+	}
+	
+	resource "cyral_sidecar_credentials" "test_sidecar_credentials" {
+		sidecar_id = cyral_sidecar.test_sidecar.id
+	}
+	`
+}

--- a/cyral/resource_cyral_sidecar_test.go
+++ b/cyral/resource_cyral_sidecar_test.go
@@ -83,8 +83,8 @@ func setupSidecarTest(integrationData SidecarData, includeAWSSection bool) (stri
 	configuration := formatSidecarDataIntoConfig(integrationData, includeAWSSection)
 
 	testFunction := resource.ComposeTestCheckFunc(
-		resource.TestCheckResourceAttr("cyral_sidecar.test_repo_binding_sidecar", "name", integrationData.Name),
-		resource.TestCheckResourceAttr("cyral_sidecar.test_repo_binding_sidecar", "deployment_method", integrationData.SidecarProperty.DeploymentMethod),
+		resource.TestCheckResourceAttr("cyral_sidecar.test_sidecar", "name", integrationData.Name),
+		resource.TestCheckResourceAttr("cyral_sidecar.test_sidecar", "deployment_method", integrationData.SidecarProperty.DeploymentMethod),
 	)
 
 	return configuration, testFunction
@@ -93,7 +93,7 @@ func setupSidecarTest(integrationData SidecarData, includeAWSSection bool) (stri
 func formatSidecarDataIntoConfig(data SidecarData, includeAWSSection bool) string {
 	if includeAWSSection {
 		return fmt.Sprintf(`
-	resource "cyral_sidecar" "test_repo_binding_sidecar" {
+	resource "cyral_sidecar" "test_sidecar" {
 		name = "%s"
 		deployment_method = "%s"
 		aws_configuration {
@@ -109,7 +109,7 @@ func formatSidecarDataIntoConfig(data SidecarData, includeAWSSection bool) strin
 			data.SidecarProperty.Subnets)
 	}
 	return fmt.Sprintf(`
-      resource "cyral_sidecar" "test_repo_binding_sidecar" {
+      resource "cyral_sidecar" "test_sidecar" {
       	name = "%s"
       	deployment_method = "%s"
       }`, data.Name, data.SidecarProperty.DeploymentMethod)

--- a/doc/resource_sidecar_credentials.md
+++ b/doc/resource_sidecar_credentials.md
@@ -1,0 +1,25 @@
+# Sidecar Credentials
+
+CRUD operations for Cyral sidecar credentials.
+
+## Usage
+
+```hcl
+resource "cyral_sidecar_credentials" "SOME_RESOURCE_NAME" {
+  sidecar_id = cyral_sidecar.SOME_SIDECAR_RESOURCE_NAME.id
+}
+```
+
+## Variables
+
+| Name         | Default | Description                                                | Required |
+| :----------- | :-----: | :--------------------------------------------------------  | :------: |
+| `sidecar_id` |         | ID of the sidecar which the credentials will be generated. |   Yes    |
+
+## Outputs
+
+| Name            | Description                                     |
+| :-------------- | :---------------------------------------------- |
+| `id`            | Unique ID of the resource in the Control Plane. |
+| `client_id`     | Sidecar client ID.                              |
+| `client_secret` | Sidecar client Secret.                          |

--- a/doc/resource_sidecar_credentials.md
+++ b/doc/resource_sidecar_credentials.md
@@ -21,5 +21,5 @@ resource "cyral_sidecar_credentials" "SOME_RESOURCE_NAME" {
 | Name            | Description                                     |
 | :-------------- | :---------------------------------------------- |
 | `id`            | Unique ID of the resource in the Control Plane. |
-| `client_id`     | Sidecar client ID.                              |
-| `client_secret` | Sidecar client Secret.                          |
+| `client_id`     | Sidecar Client ID.                              |
+| `client_secret` | Sidecar Client Secret encoded using base 64     |

--- a/doc/resource_sidecar_credentials.md
+++ b/doc/resource_sidecar_credentials.md
@@ -10,6 +10,12 @@ resource "cyral_sidecar_credentials" "SOME_RESOURCE_NAME" {
 }
 ```
 
+Consider using a remote backend to encrypt the state of this resource if it sounds appropriate.
+
+## See also
+
+- [Remote Backends](https://www.terraform.io/docs/language/settings/backends/remote.html)
+
 ## Variables
 
 | Name         | Default | Description                                                | Required |
@@ -22,4 +28,4 @@ resource "cyral_sidecar_credentials" "SOME_RESOURCE_NAME" {
 | :-------------- | :---------------------------------------------- |
 | `id`            | Unique ID of the resource in the Control Plane. |
 | `client_id`     | Sidecar Client ID.                              |
-| `client_secret` | Sidecar Client Secret encoded using base 64     |
+| `client_secret` | Sidecar Client Secret.                          |

--- a/scripts/create-keycloak-service-account.sh
+++ b/scripts/create-keycloak-service-account.sh
@@ -12,7 +12,7 @@ then
 	exit 1
 fi
 
-ROLE_IDS=$(echo $ROLE_IDS | jq '[.roles | map(select(.name | contains("Modify Integrations", "Modify Policies", "Modify Roles","Modify Sidecars and Repositories", "View Sidecars and Repositories"))) | .[].id]' -c)
+ROLE_IDS=$(echo $ROLE_IDS | jq '[.roles | map(select(.name | contains("Modify Integrations", "Modify Policies", "Modify Roles","Modify Sidecars and Repositories", "View Sidecars and Repositories", "Modify Users"))) | .[].id]' -c)
 
 if [[ $? -ne 0 ]]
 then


### PR DESCRIPTION
## Description of the change

Adds a new resource to the provider, responsible for generating sidecar credentials.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Jira issue referenced in commit message and/or PR title

### Testing
Tested running "go test -v -run=^TestAccSidecarCredentialsResource$" and through manual terraform configuration file.
