### PR TITLE
Temporarily disable test

### DIFF
--- a/cyral/data_source_cyral_saml_certificate_test.go
+++ b/cyral/data_source_cyral_saml_certificate_test.go
@@ -1,4 +1,4 @@
-package cyral
+/*package cyral
 
 import (
 	"fmt"
@@ -101,3 +101,4 @@ func testResourceAttrFunction(resource, attr string, checkFunc func(string) erro
 		return checkFunc(at)
 	}
 }
+*/

--- a/cyral/data_source_cyral_saml_certificate_test.go
+++ b/cyral/data_source_cyral_saml_certificate_test.go
@@ -1,5 +1,6 @@
-/*package cyral
+package cyral
 
+/*
 import (
 	"fmt"
 	"testing"


### PR DESCRIPTION
## Description of the change

Temporarily disabling `TestAccSAMLCertificateDataSource` until we fix the SAML integration.
