### PR TITLE
ENG-6845: Remove unnecessary PreCheck from Terraform Provider Tests

### DIFF
--- a/cyral/data_source_cyral_saml_configuration_test.go
+++ b/cyral/data_source_cyral_saml_configuration_test.go
@@ -2,7 +2,6 @@ package cyral
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -10,26 +9,20 @@ import (
 )
 
 const (
-	EnvVarSAMLMetadataURL = "CYRAL_TF_SAML_METADATA_URL"
-	Base64Doc             = "PG1kOkVudGl0eURlc2NyaXB0b3IgeG1sbnM6bWQ9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDptZXRhZGF0YSIgZW50aXR5SUQ9Imh0dHA6Ly93d3cub2t0YS5jb20vZXhrMXNhZm84a3JFQXA4aTA1ZDciPgo8bWQ6SURQU1NPRGVzY3JpcHRvciBXYW50QXV0aG5SZXF1ZXN0c1NpZ25lZD0iZmFsc2UiIHByb3RvY29sU3VwcG9ydEVudW1lcmF0aW9uPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6cHJvdG9jb2wiPgo8bWQ6S2V5RGVzY3JpcHRvciB1c2U9InNpZ25pbmciPgo8ZHM6S2V5SW5mbyB4bWxuczpkcz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC8wOS94bWxkc2lnIyI+CjxkczpYNTA5RGF0YT4KPGRzOlg1MDlDZXJ0aWZpY2F0ZT5NSUlEcURDQ0FwQ2dBd0lCQWdJR0FYcWJuaktnTUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdVTVFzd0NRWURWUVFHRXdKVlV6RVRNQkVHIEExVUVDQXdLUTJGc2FXWnZjbTVwWVRFV01CUUdBMVVFQnd3TlUyRnVJRVp5WVc1amFYTmpiekVOTUFzR0ExVUVDZ3dFVDJ0MFlURVUgTUJJR0ExVUVDd3dMVTFOUFVISnZkbWxrWlhJeEZUQVRCZ05WQkFNTURHUmxkaTAyTVRJMk5UY3lOekVjTUJvR0NTcUdTSWIzRFFFSiBBUllOYVc1bWIwQnZhM1JoTG1OdmJUQWVGdzB5TVRBM01USXhOalEyTlRSYUZ3MHpNVEEzTVRJeE5qUTNOVE5hTUlHVU1Rc3dDUVlEIFZRUUdFd0pWVXpFVE1CRUdBMVVFQ0F3S1EyRnNhV1p2Y201cFlURVdNQlFHQTFVRUJ3d05VMkZ1SUVaeVlXNWphWE5qYnpFTk1Bc0cgQTFVRUNnd0VUMnQwWVRFVU1CSUdBMVVFQ3d3TFUxTlBVSEp2ZG1sa1pYSXhGVEFUQmdOVkJBTU1ER1JsZGkwMk1USTJOVGN5TnpFYyBNQm9HQ1NxR1NJYjNEUUVKQVJZTmFXNW1iMEJ2YTNSaExtTnZiVENDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DIGdnRUJBS1Q1WDQvMEZqL3p6MXloTUZoY2VNVlh1RUZVWU1JYllpNUtaNE1OcTd0SjYwQjh6SkMvVm42YjdWRHNORk9ibGE2a05URXUgNEFxelAxWnNBQ2FWSmVKSjJZSlAzWWFEOHplN3dkMTQ2dmdaZnRHSmg1a2xUekZ2YWdUck11MHloVjBaTk5CUE1rYXFXT1V0MnhYRSAyVnZnalFrVTZ1Y0JHRjFwMy84eXhqVFlHaDd1eS83ZXIzaHZqK0s5cGNlUkMyQW1NaHZGaGVvbnk3MVdTVUIxZHZTY0kzNUZ4TzkxIDhjVDRSbkRrYmhpOVhXNXpSaXBzL0VjS2JqSEI1VzVpL2l2UGltbjdjLy8xUXBQV2FjdUFtNVRCNDBpRjA4ODFVSkd4OERXTmo5SnogUEU4T0h4YkJlMjJrVC93RUp2aEZwbnpFK0QzM2l5N01TdmhENE1uNHZva0NBd0VBQVRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQSBsWUF0cmZKU2FjODk3RnJFZW5ZNHZxaFU3ajFVRlJQMXZzdXRiN2dXdWUwSmZOSU0yK3VORWJLM09wcDFCb05qTzkwcUJsQVVOSlhuIGFkQ0JBd000NHR2WTZOZjhtRGx4c3YwdXFrOEU1RWZDVERGemh5Vlg1bDhPVVZnNzdlYzZORThISk53SXdWMXhMenpIaUgxOGQ3ZVUgbzhZem41a0VaeHhLNzhWUnBOOXE3UkwzamJOMUtWRDU4cXpiRWRucWFXVU43Z3EreXI0K2hKenpKZnZ3TDdOd1ZpaVRBRDliZTAvVSAzRDA0SnRRa0Z0blZseTB6YUI5TElPWE9iL3FpRUl4WElNMU1OVVpLc1hNQkU0WHVGdnVMUzV6SFZyd1JIZVovVXhZNEFMS1NuQnRDIGZnandxd21WbCt0Z0liSjBvRmRBVmdEbDVZSVRFUzBKTHY5WEl3PT08L2RzOlg1MDlDZXJ0aWZpY2F0ZT4KPC9kczpYNTA5RGF0YT4KPC9kczpLZXlJbmZvPgo8L21kOktleURlc2NyaXB0b3I+CjxtZDpOYW1lSURGb3JtYXQ+dXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6MS4xOm5hbWVpZC1mb3JtYXQ6dW5zcGVjaWZpZWQ8L21kOk5hbWVJREZvcm1hdD4KPG1kOk5hbWVJREZvcm1hdD51cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoxLjE6bmFtZWlkLWZvcm1hdDplbWFpbEFkZHJlc3M8L21kOk5hbWVJREZvcm1hdD4KPG1kOlNpbmdsZVNpZ25PblNlcnZpY2UgQmluZGluZz0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOmJpbmRpbmdzOkhUVFAtUE9TVCIgTG9jYXRpb249Imh0dHBzOi8vZGV2LTYxMjY1NzI3Lm9rdGEuY29tL2FwcC9kZXYtNjEyNjU3MjdfdGVzdF8xL2V4azFzYWZvOGtyRUFwOGkwNWQ3L3Nzby9zYW1sIi8+CjxtZDpTaW5nbGVTaWduT25TZXJ2aWNlIEJpbmRpbmc9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDpiaW5kaW5nczpIVFRQLVJlZGlyZWN0IiBMb2NhdGlvbj0iaHR0cHM6Ly9kZXYtNjEyNjU3Mjcub2t0YS5jb20vYXBwL2Rldi02MTI2NTcyN190ZXN0XzEvZXhrMXNhZm84a3JFQXA4aTA1ZDcvc3NvL3NhbWwiLz4KPC9tZDpJRFBTU09EZXNjcmlwdG9yPgo8L21kOkVudGl0eURlc2NyaXB0b3I+"
+	TestMetadataURL = "https://some-test-metadata-url.com"
+	Base64Doc       = "PG1kOkVudGl0eURlc2NyaXB0b3IgeG1sbnM6bWQ9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDptZXRhZGF0YSIgZW50aXR5SUQ9Imh0dHA6Ly93d3cub2t0YS5jb20vZXhrMXNhZm84a3JFQXA4aTA1ZDciPgo8bWQ6SURQU1NPRGVzY3JpcHRvciBXYW50QXV0aG5SZXF1ZXN0c1NpZ25lZD0iZmFsc2UiIHByb3RvY29sU3VwcG9ydEVudW1lcmF0aW9uPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6cHJvdG9jb2wiPgo8bWQ6S2V5RGVzY3JpcHRvciB1c2U9InNpZ25pbmciPgo8ZHM6S2V5SW5mbyB4bWxuczpkcz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC8wOS94bWxkc2lnIyI+CjxkczpYNTA5RGF0YT4KPGRzOlg1MDlDZXJ0aWZpY2F0ZT5NSUlEcURDQ0FwQ2dBd0lCQWdJR0FYcWJuaktnTUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdVTVFzd0NRWURWUVFHRXdKVlV6RVRNQkVHIEExVUVDQXdLUTJGc2FXWnZjbTVwWVRFV01CUUdBMVVFQnd3TlUyRnVJRVp5WVc1amFYTmpiekVOTUFzR0ExVUVDZ3dFVDJ0MFlURVUgTUJJR0ExVUVDd3dMVTFOUFVISnZkbWxrWlhJeEZUQVRCZ05WQkFNTURHUmxkaTAyTVRJMk5UY3lOekVjTUJvR0NTcUdTSWIzRFFFSiBBUllOYVc1bWIwQnZhM1JoTG1OdmJUQWVGdzB5TVRBM01USXhOalEyTlRSYUZ3MHpNVEEzTVRJeE5qUTNOVE5hTUlHVU1Rc3dDUVlEIFZRUUdFd0pWVXpFVE1CRUdBMVVFQ0F3S1EyRnNhV1p2Y201cFlURVdNQlFHQTFVRUJ3d05VMkZ1SUVaeVlXNWphWE5qYnpFTk1Bc0cgQTFVRUNnd0VUMnQwWVRFVU1CSUdBMVVFQ3d3TFUxTlBVSEp2ZG1sa1pYSXhGVEFUQmdOVkJBTU1ER1JsZGkwMk1USTJOVGN5TnpFYyBNQm9HQ1NxR1NJYjNEUUVKQVJZTmFXNW1iMEJ2YTNSaExtTnZiVENDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DIGdnRUJBS1Q1WDQvMEZqL3p6MXloTUZoY2VNVlh1RUZVWU1JYllpNUtaNE1OcTd0SjYwQjh6SkMvVm42YjdWRHNORk9ibGE2a05URXUgNEFxelAxWnNBQ2FWSmVKSjJZSlAzWWFEOHplN3dkMTQ2dmdaZnRHSmg1a2xUekZ2YWdUck11MHloVjBaTk5CUE1rYXFXT1V0MnhYRSAyVnZnalFrVTZ1Y0JHRjFwMy84eXhqVFlHaDd1eS83ZXIzaHZqK0s5cGNlUkMyQW1NaHZGaGVvbnk3MVdTVUIxZHZTY0kzNUZ4TzkxIDhjVDRSbkRrYmhpOVhXNXpSaXBzL0VjS2JqSEI1VzVpL2l2UGltbjdjLy8xUXBQV2FjdUFtNVRCNDBpRjA4ODFVSkd4OERXTmo5SnogUEU4T0h4YkJlMjJrVC93RUp2aEZwbnpFK0QzM2l5N01TdmhENE1uNHZva0NBd0VBQVRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQSBsWUF0cmZKU2FjODk3RnJFZW5ZNHZxaFU3ajFVRlJQMXZzdXRiN2dXdWUwSmZOSU0yK3VORWJLM09wcDFCb05qTzkwcUJsQVVOSlhuIGFkQ0JBd000NHR2WTZOZjhtRGx4c3YwdXFrOEU1RWZDVERGemh5Vlg1bDhPVVZnNzdlYzZORThISk53SXdWMXhMenpIaUgxOGQ3ZVUgbzhZem41a0VaeHhLNzhWUnBOOXE3UkwzamJOMUtWRDU4cXpiRWRucWFXVU43Z3EreXI0K2hKenpKZnZ3TDdOd1ZpaVRBRDliZTAvVSAzRDA0SnRRa0Z0blZseTB6YUI5TElPWE9iL3FpRUl4WElNMU1OVVpLc1hNQkU0WHVGdnVMUzV6SFZyd1JIZVovVXhZNEFMS1NuQnRDIGZnandxd21WbCt0Z0liSjBvRmRBVmdEbDVZSVRFUzBKTHY5WEl3PT08L2RzOlg1MDlDZXJ0aWZpY2F0ZT4KPC9kczpYNTA5RGF0YT4KPC9kczpLZXlJbmZvPgo8L21kOktleURlc2NyaXB0b3I+CjxtZDpOYW1lSURGb3JtYXQ+dXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6MS4xOm5hbWVpZC1mb3JtYXQ6dW5zcGVjaWZpZWQ8L21kOk5hbWVJREZvcm1hdD4KPG1kOk5hbWVJREZvcm1hdD51cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoxLjE6bmFtZWlkLWZvcm1hdDplbWFpbEFkZHJlc3M8L21kOk5hbWVJREZvcm1hdD4KPG1kOlNpbmdsZVNpZ25PblNlcnZpY2UgQmluZGluZz0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOmJpbmRpbmdzOkhUVFAtUE9TVCIgTG9jYXRpb249Imh0dHBzOi8vZGV2LTYxMjY1NzI3Lm9rdGEuY29tL2FwcC9kZXYtNjEyNjU3MjdfdGVzdF8xL2V4azFzYWZvOGtyRUFwOGkwNWQ3L3Nzby9zYW1sIi8+CjxtZDpTaW5nbGVTaWduT25TZXJ2aWNlIEJpbmRpbmc9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDpiaW5kaW5nczpIVFRQLVJlZGlyZWN0IiBMb2NhdGlvbj0iaHR0cHM6Ly9kZXYtNjEyNjU3Mjcub2t0YS5jb20vYXBwL2Rldi02MTI2NTcyN190ZXN0XzEvZXhrMXNhZm84a3JFQXA4aTA1ZDcvc3NvL3NhbWwiLz4KPC9tZDpJRFBTU09EZXNjcmlwdG9yPgo8L21kOkVudGl0eURlc2NyaXB0b3I+"
 )
 
 func TestAccSAMLConfigurationDataSource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck: func() {
-			if v := os.Getenv(EnvVarSAMLMetadataURL); v == "" {
-				t.Skip(fmt.Sprintf(
-					"Acceptance tests skipped unless env '%s' set", EnvVarSAMLMetadataURL))
-			}
-		},
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccSAMLConfigurationConfig_EmptyMetadata(),
 				ExpectError: regexp.MustCompile(`Error: Invalid combination of arguments`),
 			},
 			{
-				Config:      testAccSAMLConfigurationConfig_BothMetadataType(Base64Doc),
+				Config:      testAccSAMLConfigurationConfig_BothMetadataType(),
 				ExpectError: regexp.MustCompile(`Error: Invalid combination of arguments`),
 			},
 			{
@@ -37,8 +30,8 @@ func TestAccSAMLConfigurationDataSource(t *testing.T) {
 				Check:  testAccSAMLConfigurationCheck_MetadataURL(),
 			},
 			{
-				Config: testAccSAMLConfigurationConfig_MetadataBase64Doc(Base64Doc),
-				Check:  testAccSAMLConfigurationCheck_MetadataBase64Doc(Base64Doc),
+				Config: testAccSAMLConfigurationConfig_MetadataBase64Doc(),
+				Check:  testAccSAMLConfigurationCheck_MetadataBase64Doc(),
 			},
 		},
 	})
@@ -51,13 +44,13 @@ func testAccSAMLConfigurationConfig_EmptyMetadata() string {
 	`
 }
 
-func testAccSAMLConfigurationConfig_BothMetadataType(base64Doc string) string {
+func testAccSAMLConfigurationConfig_BothMetadataType() string {
 	return fmt.Sprintf(`
 	data "cyral_saml_configuration" "test_saml_configuration" {
 		saml_metadata_url = "%s"
 		base_64_saml_metadata_document = "%s"
 	}
-	`, os.Getenv(EnvVarSAMLMetadataURL), base64Doc)
+	`, TestMetadataURL, Base64Doc)
 }
 
 func testAccSAMLConfigurationConfig_MetadataURL() string {
@@ -65,27 +58,61 @@ func testAccSAMLConfigurationConfig_MetadataURL() string {
 	data "cyral_saml_configuration" "test_saml_configuration" {
 		saml_metadata_url = "%s"
 	}
-	`, os.Getenv(EnvVarSAMLMetadataURL))
+	`, TestMetadataURL)
 }
 
 func testAccSAMLConfigurationCheck_MetadataURL() resource.TestCheckFunc {
 	return resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr("data.cyral_saml_configuration.test_saml_configuration",
-			"saml_metadata_url", os.Getenv(EnvVarSAMLMetadataURL)),
+			"saml_metadata_url", TestMetadataURL),
+		resource.TestCheckNoResourceAttr("data.cyral_saml_configuration.test_saml_configuration",
+			"base_64_saml_metadata_document"),
 	)
 }
 
-func testAccSAMLConfigurationConfig_MetadataBase64Doc(base64Doc string) string {
+func testAccSAMLConfigurationConfig_MetadataBase64Doc() string {
 	return fmt.Sprintf(`
 	data "cyral_saml_configuration" "test_saml_configuration" {
 		base_64_saml_metadata_document = "%s"
 	}
-	`, base64Doc)
+	`, Base64Doc)
 }
 
-func testAccSAMLConfigurationCheck_MetadataBase64Doc(base64Doc string) resource.TestCheckFunc {
+func testAccSAMLConfigurationCheck_MetadataBase64Doc() resource.TestCheckFunc {
 	return resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr("data.cyral_saml_configuration.test_saml_configuration",
-			"base_64_saml_metadata_document", base64Doc),
+			"base_64_saml_metadata_document", Base64Doc),
+		resource.TestCheckNoResourceAttr("data.cyral_saml_configuration.test_saml_configuration",
+			"samlMetadataURL"),
+		resource.TestCheckResourceAttrSet("data.cyral_saml_configuration.test_saml_configuration",
+			"disable_using_jwks_url"),
+		resource.TestCheckResourceAttrSet("data.cyral_saml_configuration.test_saml_configuration",
+			"name_id_policy_format"),
+		resource.TestCheckResourceAttrSet("data.cyral_saml_configuration.test_saml_configuration",
+			"hide_on_login_page"),
+		resource.TestCheckResourceAttrSet("data.cyral_saml_configuration.test_saml_configuration",
+			"back_channel_supported"),
+		resource.TestCheckResourceAttrSet("data.cyral_saml_configuration.test_saml_configuration",
+			"disable_post_binding_response"),
+		resource.TestCheckResourceAttrSet("data.cyral_saml_configuration.test_saml_configuration",
+			"disable_post_binding_authn_request"),
+		resource.TestCheckResourceAttrSet("data.cyral_saml_configuration.test_saml_configuration",
+			"disable_post_binding_logout"),
+		resource.TestCheckResourceAttrSet("data.cyral_saml_configuration.test_saml_configuration",
+			"disable_want_authn_requests_signed"),
+		resource.TestCheckResourceAttrSet("data.cyral_saml_configuration.test_saml_configuration",
+			"disable_want_assertions_signed"),
+		resource.TestCheckResourceAttrSet("data.cyral_saml_configuration.test_saml_configuration",
+			"want_assertions_encrypted"),
+		resource.TestCheckResourceAttrSet("data.cyral_saml_configuration.test_saml_configuration",
+			"disable_force_authentication"),
+		resource.TestCheckResourceAttrSet("data.cyral_saml_configuration.test_saml_configuration",
+			"disable_validate_signature"),
+		resource.TestCheckResourceAttrSet("data.cyral_saml_configuration.test_saml_configuration",
+			"single_sign_on_service_url"),
+		resource.TestCheckResourceAttrSet("data.cyral_saml_configuration.test_saml_configuration",
+			"signing_certificate"),
+		resource.TestCheckResourceAttrSet("data.cyral_saml_configuration.test_saml_configuration",
+			"allowed_clock_skew"),
 	)
 }

--- a/cyral/resource_cyral_integration_sso_test.go
+++ b/cyral/resource_cyral_integration_sso_test.go
@@ -2,7 +2,6 @@ package cyral
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -10,19 +9,13 @@ import (
 )
 
 const (
-	EnvVarSSOURL = "CYRAL_TF_SSO_URL"
+	TestSingleSignOnURL = "https://some-test-sso-url.com"
 )
 
 func TestAccSSOIntegrationResource(t *testing.T) {
 	samlDisplayName := "tf-test-saml-integration"
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck: func() {
-			if v := os.Getenv(EnvVarSSOURL); v == "" {
-				t.Skip(fmt.Sprintf(
-					"Acceptance tests skipped unless env '%s' set", EnvVarSSOURL))
-			}
-		},
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccSSOIntegrationConfig_EmptySamlp(),
@@ -109,13 +102,13 @@ func testAccSSOIntegrationConfig_ADFS_DefaultValues() string {
 			}
 		}
 	}
-	`, os.Getenv(EnvVarSSOURL))
+	`, TestSingleSignOnURL)
 }
 
 func testAccSSOIntegrationCheck_ADFS_DefaultValues() resource.TestCheckFunc {
 	return resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr("cyral_integration_sso_adfs.test_saml_integration",
-			"samlp.0.config.0.single_sign_on_service_url", os.Getenv(EnvVarSSOURL)),
+			"samlp.0.config.0.single_sign_on_service_url", TestSingleSignOnURL),
 	)
 }
 
@@ -128,13 +121,13 @@ func testAccSSOIntegrationConfig_AAD_DefaultValues() string {
 			}
 		}
 	}
-	`, os.Getenv(EnvVarSSOURL))
+	`, TestSingleSignOnURL)
 }
 
 func testAccSSOIntegrationCheck_AAD_DefaultValues() resource.TestCheckFunc {
 	return resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr("cyral_integration_sso_aad.test_saml_integration",
-			"samlp.0.config.0.single_sign_on_service_url", os.Getenv(EnvVarSSOURL)),
+			"samlp.0.config.0.single_sign_on_service_url", TestSingleSignOnURL),
 	)
 }
 
@@ -147,13 +140,13 @@ func testAccSSOIntegrationConfig_Forgerock_DefaultValues() string {
 			}
 		}
 	}
-	`, os.Getenv(EnvVarSSOURL))
+	`, TestSingleSignOnURL)
 }
 
 func testAccSSOIntegrationCheck_Forgerock_DefaultValues() resource.TestCheckFunc {
 	return resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr("cyral_integration_sso_forgerock.test_saml_integration",
-			"samlp.0.config.0.single_sign_on_service_url", os.Getenv(EnvVarSSOURL)),
+			"samlp.0.config.0.single_sign_on_service_url", TestSingleSignOnURL),
 	)
 }
 
@@ -166,13 +159,13 @@ func testAccSSOIntegrationConfig_GSuite_DefaultValues() string {
 			}
 		}
 	}
-	`, os.Getenv(EnvVarSSOURL))
+	`, TestSingleSignOnURL)
 }
 
 func testAccSSOIntegrationCheck_GSuite_DefaultValues() resource.TestCheckFunc {
 	return resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr("cyral_integration_sso_gsuite.test_saml_integration",
-			"samlp.0.config.0.single_sign_on_service_url", os.Getenv(EnvVarSSOURL)),
+			"samlp.0.config.0.single_sign_on_service_url", TestSingleSignOnURL),
 	)
 }
 
@@ -185,13 +178,13 @@ func testAccSSOIntegrationConfig_PingOne_DefaultValues() string {
 			}
 		}
 	}
-	`, os.Getenv(EnvVarSSOURL))
+	`, TestSingleSignOnURL)
 }
 
 func testAccSSOIntegrationCheck_PingOne_DefaultValues() resource.TestCheckFunc {
 	return resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr("cyral_integration_sso_ping_one.test_saml_integration",
-			"samlp.0.config.0.single_sign_on_service_url", os.Getenv(EnvVarSSOURL)),
+			"samlp.0.config.0.single_sign_on_service_url", TestSingleSignOnURL),
 	)
 }
 
@@ -204,13 +197,13 @@ func testAccSSOIntegrationConfig_Okta_DefaultValues() string {
 			}
 		}
 	}
-	`, os.Getenv(EnvVarSSOURL))
+	`, TestSingleSignOnURL)
 }
 
 func testAccSSOIntegrationCheck_Okta_DefaultValues() resource.TestCheckFunc {
 	return resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr("cyral_integration_sso_okta.test_saml_integration",
-			"samlp.0.config.0.single_sign_on_service_url", os.Getenv(EnvVarSSOURL)),
+			"samlp.0.config.0.single_sign_on_service_url", TestSingleSignOnURL),
 	)
 }
 
@@ -226,7 +219,7 @@ func testAccSSOIntegrationConfig_Updated(samlDisplayName string) string {
 			}
 		}
 	}
-	`, samlDisplayName, os.Getenv(EnvVarSSOURL))
+	`, samlDisplayName, TestSingleSignOnURL)
 }
 
 func testAccSSOIntegrationCheck_Updated(samlDisplayName string) resource.TestCheckFunc {
@@ -236,7 +229,7 @@ func testAccSSOIntegrationCheck_Updated(samlDisplayName string) resource.TestChe
 		resource.TestCheckResourceAttr("cyral_integration_sso_okta.test_saml_integration",
 			"samlp.0.disabled", "true"),
 		resource.TestCheckResourceAttr("cyral_integration_sso_okta.test_saml_integration",
-			"samlp.0.config.0.single_sign_on_service_url", os.Getenv(EnvVarSSOURL)),
+			"samlp.0.config.0.single_sign_on_service_url", TestSingleSignOnURL),
 		resource.TestCheckResourceAttr("cyral_integration_sso_okta.test_saml_integration",
 			"samlp.0.config.0.back_channel_supported", "true"),
 	)
@@ -252,7 +245,7 @@ func testAccSSOIntegrationConfig_NotEmptyAlias() string {
 			}
 		}
 	}
-	`, os.Getenv(EnvVarSSOURL))
+	`, TestSingleSignOnURL)
 }
 
 func testAccSSOIntegrationCheck_NotEmptyAlias() resource.TestCheckFunc {
@@ -263,6 +256,6 @@ func testAccSSOIntegrationCheck_NotEmptyAlias() resource.TestCheckFunc {
 			"cyral_integration_sso_okta.test_saml_integration", "id",
 			"cyral_integration_sso_okta.test_saml_integration", "draft_alias"),
 		resource.TestCheckResourceAttr("cyral_integration_sso_okta.test_saml_integration",
-			"samlp.0.config.0.single_sign_on_service_url", os.Getenv(EnvVarSSOURL)),
+			"samlp.0.config.0.single_sign_on_service_url", TestSingleSignOnURL),
 	)
 }


### PR DESCRIPTION
## Description of the change

Removes unnecessary PreCheck from `TestAccSAMLConfigurationDataSource` and `TestAccSSOIntegrationResource` tests, so that the nightly tests can be executed without any test being skipped.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Jira issue referenced in commit message and/or PR title

### Testing
Tested running "go test -v -run=^TestAccSAMLConfigurationDataSource$" and "go test -v -run=^TestAccSSOIntegrationResource$" using the `Edge` Control Plane.