### PR TITLE
docs: update examples to use for_each instead of count

### DIFF
--- a/docs/resources/integration_splunk.md
+++ b/docs/resources/integration_splunk.md
@@ -22,7 +22,7 @@ resource "cyral_integration_splunk" "some_resource_name" {
 * `port` - (Required) Splunk Host Port.
 * `host` - (Required) Splunk Host.
 * `index` - (Required) Splunk data index name.
-* `use_tls` - (Required) Should the comunication with Splunk use TLS encryption?
+* `use_tls` - (Required) Should the communication with Splunk use TLS encryption?
 
 ## Attribute Reference
 

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -17,25 +17,37 @@ resource "cyral_repository" "some_resource_name" {
 }
 ```
 
-You may also use the same resource declaration to handle multiple repositories at once by using a `local` variable and `count` parameter:
+You may also use the same resource declaration to handle multiple repositories at once by using a `local` variable and `for_each` parameter:
 
 
 ```hcl
 locals {
-    repos = [
-        ["mongodb", "mongodb.cyral.com", 27017, "mymongodb"],
-        ["mariadb", "mariadb.cyral.com", 3310, "mymariadb"],
-        ["postgresql", "postgresql.cyral.com", 5432, "mypostgresql"]
-    ]
+  repos = {
+    mymongodb = {
+      host = "mongodb.cyral.com"
+      port = 27017
+      type = "mongodb"
+    }
+    mymariadb = {
+      host = "mariadb.cyral.com"
+      port = 3310
+      type = "mariadb"
+    }
+    mypostgresql = {
+      host = "postgresql.cyral.com"
+      port = 5432
+      type = "postgresql"
+    }
+  }
 }
 
 resource "cyral_repository" "repositories" {
-    count = length(local.repos)
+  for_each = local.repos
 
-    type  = local.repos[count.index][0]
-    host  = local.repos[count.index][1]
-    port  = local.repos[count.index][2]
-    name  = local.repos[count.index][3]
+  name  = each.key
+  type  = each.value.type
+  host  = each.value.host
+  port  = each.value.port
 }
 ```
 

--- a/docs/resources/repository_conf_auth.md
+++ b/docs/resources/repository_conf_auth.md
@@ -17,7 +17,7 @@ resource "cyral_repository_conf_auth" "some_resource_name" {
 ## Argument Reference
 
 * `repository_id` - (Required) The ID of the repository to be configured.
-* `allow_native_auth` - (Optional) Should the comunication allow native authentication?
+* `allow_native_auth` - (Optional) Should the communication allow native authentication?
 * `client_tls` - (Optional) Is the repo Client using TLS?
 * `identity_provider` - (Optional) The name of the identity provider.
 * `repo_tls` - (Optional) Is TLS enabled for the repository?


### PR DESCRIPTION
Using for_each seems to provide better documentation and does not result in index-based changes
impacting plans.

## Description of the change

This updates the examples in the documentation to use `for_each` instead of `count`.  In general, 
we've found this to be more resilient as well as provide self-documentation.

## Type of change
- [X] Documentation (non-breaking change that fixes an issue)

## Checklists

### Development

- [X] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing
Documentation change - visually reviewed.
