### PR TITLE
Add CYRAL_TF_CONTROL_PLANE env var support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ local/install: local/build
 	cp out/linux_amd64/$(BINARY) ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/linux_amd64
 
 docker/test:
-	docker-compose run -e CYRAL_TF_CP_URL=$(CYRAL_TF_CP_URL) -e CYRAL_TF_CLIENT_ID=$(CYRAL_TF_CLIENT_ID) \
+	docker-compose run -e CYRAL_TF_CONTROL_PLANE=$(CYRAL_TF_CONTROL_PLANE) -e CYRAL_TF_CLIENT_ID=$(CYRAL_TF_CLIENT_ID) \
 	  -e CYRAL_TF_CLIENT_SECRET=$(CYRAL_TF_CLIENT_SECRET) -e TF_ACC=true \
 	  app $(GOTEST) github.com/cyralinc/terraform-provider-cyral/... -v -race
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The test framework requires basic configuration before it can be executed as fol
 
 ```bash
 # Set the control plane DNS name and port (default 8000):
-export CYRAL_TF_CP_URL=mycp.cyral.com:8000
+export CYRAL_TF_CONTROL_PLANE=mycp.cyral.com:8000
 
 # Set Keycloak client and secret ID:
 export CYRAL_TF_CLIENT_ID=?

--- a/cyral/provider.go
+++ b/cyral/provider.go
@@ -15,6 +15,7 @@ const (
 	auth0              = "auth0"
 	EnvVarClientID     = "CYRAL_TF_CLIENT_ID"
 	EnvVarClientSecret = "CYRAL_TF_CLIENT_SECRET"
+	EnvVarCPURL        = "CYRAL_TF_CONTROL_PLANE"
 )
 
 // Provider defines and initializes the Cyral provider
@@ -73,8 +74,9 @@ func Provider() *schema.Provider {
 				DefaultFunc:   schema.EnvDefaultFunc(EnvVarClientSecret, nil),
 			},
 			"control_plane": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc(EnvVarCPURL, nil),
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{

--- a/cyral/provider_test.go
+++ b/cyral/provider_test.go
@@ -1,7 +1,6 @@
 package cyral
 
 import (
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -9,9 +8,6 @@ import (
 
 const (
 	EnvVarTFAcc = "TF_ACC"
-
-	// Ex: mycontrolplane.cyral.com:8000
-	EnvVarCPURL = "CYRAL_TF_CP_URL"
 )
 
 func TestAccProvider(t *testing.T) {
@@ -22,20 +18,6 @@ func TestAccProvider(t *testing.T) {
 
 var providerFactories = map[string]func() (*schema.Provider, error){
 	"cyral": func() (*schema.Provider, error) {
-		p := Provider()
-		p.Schema["control_plane"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Required:    true,
-			DefaultFunc: schema.EnvDefaultFunc(EnvVarCPURL, nil),
-		}
-		return p, nil
+		return Provider(), nil
 	},
-}
-
-// Deprecated: This function should be removed in the future, since the resource.Test on pkg.go.dev
-// already execute this before each acceptance test.
-func testAccPreCheck(t *testing.T) {
-	if v := os.Getenv(EnvVarTFAcc); v == "" {
-		t.Fatalf("%q must be set for acceptance tests", EnvVarTFAcc)
-	}
 }

--- a/cyral/resource_cyral_datamap_test.go
+++ b/cyral/resource_cyral_datamap_test.go
@@ -24,7 +24,6 @@ func TestAccDatamapResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testConfig,

--- a/cyral/resource_cyral_integration_datadog_test.go
+++ b/cyral/resource_cyral_integration_datadog_test.go
@@ -23,7 +23,6 @@ func TestAccDatadogIntegrationResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testConfig,

--- a/cyral/resource_cyral_integration_elk_test.go
+++ b/cyral/resource_cyral_integration_elk_test.go
@@ -25,7 +25,6 @@ func TestAccELKIntegrationResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testConfig,

--- a/cyral/resource_cyral_integration_hcvault_test.go
+++ b/cyral/resource_cyral_integration_hcvault_test.go
@@ -29,7 +29,6 @@ func TestAccHCVaultIntegrationResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testConfig,

--- a/cyral/resource_cyral_integration_logstash_test.go
+++ b/cyral/resource_cyral_integration_logstash_test.go
@@ -47,7 +47,6 @@ func TestAccLogstashIntegrationResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testConfig,

--- a/cyral/resource_cyral_integration_looker_test.go
+++ b/cyral/resource_cyral_integration_looker_test.go
@@ -25,7 +25,6 @@ func TestAccLookerIntegrationResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testConfig,

--- a/cyral/resource_cyral_integration_okta_test.go
+++ b/cyral/resource_cyral_integration_okta_test.go
@@ -33,7 +33,6 @@ func TestAccOktaIntegrationResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testConfig,

--- a/cyral/resource_cyral_integration_pager_duty_test.go
+++ b/cyral/resource_cyral_integration_pager_duty_test.go
@@ -25,7 +25,6 @@ func TestAccPagerDutyIntegrationResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testConfig,

--- a/cyral/resource_cyral_integration_slack_alerts_test.go
+++ b/cyral/resource_cyral_integration_slack_alerts_test.go
@@ -23,7 +23,6 @@ func TestAccSlackAlertsIntegrationResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testConfig,

--- a/cyral/resource_cyral_integration_splunk_test.go
+++ b/cyral/resource_cyral_integration_splunk_test.go
@@ -31,7 +31,6 @@ func TestAccSplunkIntegrationResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testConfig,

--- a/cyral/resource_cyral_integration_sumo_logic_test.go
+++ b/cyral/resource_cyral_integration_sumo_logic_test.go
@@ -23,7 +23,6 @@ func TestAccSumoLogicIntegrationResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testConfig,

--- a/cyral/resource_cyral_integration_teams_test.go
+++ b/cyral/resource_cyral_integration_teams_test.go
@@ -23,7 +23,6 @@ func TestAccMsTeamsIntegrationResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testConfig,

--- a/cyral/resource_cyral_policy_rule_test.go
+++ b/cyral/resource_cyral_policy_rule_test.go
@@ -38,7 +38,6 @@ func TestAccPolicyRuleResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testConfig,

--- a/cyral/resource_cyral_policy_test.go
+++ b/cyral/resource_cyral_policy_test.go
@@ -37,7 +37,6 @@ func TestAccPolicyResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testConfig,

--- a/cyral/resource_cyral_repository_binding_test.go
+++ b/cyral/resource_cyral_repository_binding_test.go
@@ -33,7 +33,6 @@ func TestAccRepositoryBindingResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testConfig,

--- a/cyral/resource_cyral_repository_conf_auth_test.go
+++ b/cyral/resource_cyral_repository_conf_auth_test.go
@@ -32,7 +32,6 @@ func TestAccRepositoryConfAuthDataResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testConfig,

--- a/cyral/resource_cyral_repository_identity_map_test.go
+++ b/cyral/resource_cyral_repository_identity_map_test.go
@@ -44,7 +44,6 @@ func TestAccRepositoryIdentityMapResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testConfig,

--- a/cyral/resource_cyral_repository_local_account_test.go
+++ b/cyral/resource_cyral_repository_local_account_test.go
@@ -93,7 +93,6 @@ func TestAccRepositoryAccountEnviromentVariable(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testConfigEnviromentVariable,
@@ -113,7 +112,6 @@ func TestAccRepositoryAccountAwsHashicorpVault(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testConfigHashicorpVault,
@@ -133,7 +131,6 @@ func TestAccRepositoryAccountCyralStorage(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testConfigCyralStorage,
@@ -153,7 +150,6 @@ func TestAccRepositoryAccountAwsSecretResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testConfigAwsSecret,
@@ -173,7 +169,6 @@ func TestAccRepositoryAccountAwsIamResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testConfigAwsIam,

--- a/cyral/resource_cyral_repository_test.go
+++ b/cyral/resource_cyral_repository_test.go
@@ -27,7 +27,6 @@ func TestAccRepositoryResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testConfig,

--- a/cyral/resource_cyral_sidecar_test.go
+++ b/cyral/resource_cyral_sidecar_test.go
@@ -51,7 +51,6 @@ func TestAccSidecarResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testConfig,


### PR DESCRIPTION
## Description of the change

1. Add variable to allow direct assignments to `provider.control_plane` variable: `CYRAL_TF_CONTROL_PLANE`;
2. Replace test env var `CYRAL_TF_CP_URL` by `CYRAL_TF_CONTROL_PLANE`;
3. Remove deprecated code.

Closes #138.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing
Successful run of existing tests.
