### PR TITLE
ENG-7416: Fixes issue about missing sidecar returning 500 error

### DIFF
--- a/cyral/resource_cyral_sidecar.go
+++ b/cyral/resource_cyral_sidecar.go
@@ -112,7 +112,7 @@ func resourceSidecarRead(ctx context.Context, d *schema.ResourceData, m interfac
 			log.Printf("[DEBUG] Sidecar not found. SidecarID: %s. "+
 				"Removing it from state. Error: %v", d.Id(), err)
 			d.SetId("")
-			return diag.Diagnostics{}
+			return nil
 		}
 
 		return createError(fmt.Sprintf("Unable to read sidecar. SidecarID: %s",

--- a/cyral/resource_cyral_sidecar.go
+++ b/cyral/resource_cyral_sidecar.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"regexp"
 
 	"github.com/cyralinc/terraform-provider-cyral/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -99,14 +100,23 @@ func resourceSidecarRead(ctx context.Context, d *schema.ResourceData, m interfac
 	if err != nil {
 		// Currently, the sidecar API always returns a status code of 500 for every error,
 		// so its not possible to distinguish if the error returned is related to
-		// a 404 Not Found or not. This way, once this is fixed in the sidecar API,
-		// we should handle the error here by its status code, and only remove the
-		// resource from the state (d.SetId("")) if it returns a 404 Not Found,
-		// otherwise we should return the error in the Diagnostics.
-		log.Printf("[DEBUG] Unable to read sidecar. SidecarID: %s. "+
-			"Removing it from state. Error: %v", d.Id(), err)
-		d.SetId("")
-		return diag.Diagnostics{}
+		// a 404 Not Found or not by its status code. This way, a workaround for that is to
+		// check if the error message matches a 'Failed to extract info for wrapper' message,
+		// since thats the current message returned when the sidecar is not found. Once this
+		// issue is fixed in the sidecar API, we should handle the error here by its status
+		// code, and only remove the resource from the state (d.SetId("")) if it returns a 404
+		// Not Found.
+		matched, regexpError := regexp.MatchString("Failed to extract info for wrapper",
+			err.Error())
+		if regexpError == nil && matched {
+			log.Printf("[DEBUG] Sidecar not found. SidecarID: %s. "+
+				"Removing it from state. Error: %v", d.Id(), err)
+			d.SetId("")
+			return diag.Diagnostics{}
+		}
+
+		return createError(fmt.Sprintf("Unable to read sidecar. SidecarID: %s",
+			d.Id()), fmt.Sprintf("%v", err))
 	}
 
 	response := SidecarData{}


### PR DESCRIPTION
## Description of the change

This PR fixes an issue with the sidecar resource about returning a `500` error when the sidecar was actually not found. So the fix was basically handling the error and just removing the resource from the state. Notice that, currently, the sidecar API always returns a status code of `500` for every error, so its not possible to distinguish if the error returned is related to a `404 Not Found` or not by its status code. This way, a workaround for that is to check if the error message matches a 'Failed to extract info for wrapper' message, since thats the current message returned when the sidecar is not found. Once this issue is fixed in the sidecar API, we should handle the error here, on the Terraform Provider side, by its status code, and only remove the resource from the state (d.SetId("")) if it returns a 404 Not Found.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Jira issue referenced in commit message and/or PR title

### Testing
Manual tests through Terraform config, and also running all the acceptance tests on `Edge` CP by typing `make` after setting the env vars.