### PR TITLE
ENG-7170: Terraform provider creates a new identity map instead of updating old one when state changes

### DIFF
--- a/cyral/resource_cyral_repository_identity_map.go
+++ b/cyral/resource_cyral_repository_identity_map.go
@@ -271,6 +271,7 @@ func resourceRepositoryIdentityMap(deprecate bool) *schema.Resource {
 			"identity_name": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"access_duration": {
 				Type:     schema.TypeSet,

--- a/cyral/resource_cyral_repository_identity_map.go
+++ b/cyral/resource_cyral_repository_identity_map.go
@@ -256,14 +256,17 @@ func resourceRepositoryIdentityMap(deprecate bool) *schema.Resource {
 			"repository_id": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"repository_local_account_id": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"identity_type": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"identity_name": {
 				Type:     schema.TypeString,


### PR DESCRIPTION

## Description of the change

- Changes identity map resource to delete previous resource and create new one on update
- CHanges id for identity map resource to be independent of fields

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing
Created, updated, deleted identity maps with valid and invalid parameters, all worked as intended.
