### PR TITLE
Fix tests timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ docker/clean:
 	rm -rf ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}
 
 local/test:
-	$(GOTEST) github.com/cyralinc/terraform-provider-cyral/... -v -race
+	$(GOTEST) github.com/cyralinc/terraform-provider-cyral/... -v -race -timeout 20m
 
 docker-compose/build: docker-compose/lint
 	docker-compose build --build-arg VERSION="$(VERSION+sha)" build


### PR DESCRIPTION
## Description of the change

This PR updates the tests timeout to 20m so that all of the tests can run in the e2e-tests without causing a panic.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing
Tested all the tests running `make`.