### PR TITLE
ENG-7853: Modifying repository_binding resource is not removing old resource

### DIFF
--- a/cyral/resource_cyral_repository_binding.go
+++ b/cyral/resource_cyral_repository_binding.go
@@ -40,10 +40,12 @@ func resourceRepositoryBinding() *schema.Resource {
 			"sidecar_id": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"repository_id": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"listener_port": {
 				Type:     schema.TypeInt,

--- a/cyral/resource_cyral_repository_binding_test.go
+++ b/cyral/resource_cyral_repository_binding_test.go
@@ -12,7 +12,7 @@ var initialRepositoryBindingConfig RepoBindingData = RepoBindingData{
 	RepositoryID: "1",
 	Enabled:      false,
 	Listener: Listener{
-		Host: "local-repo-binding.local",
+		Host: "host.com",
 		Port: 3333,
 	},
 }
@@ -22,7 +22,7 @@ var updatedRepositoryBindingConfig RepoBindingData = RepoBindingData{
 	RepositoryID: "2",
 	Enabled:      true,
 	Listener: Listener{
-		Host: "local-repo-binding-update.local",
+		Host: "host-updated.com",
 		Port: 3334,
 	},
 }
@@ -49,8 +49,22 @@ func TestAccRepositoryBindingResource(t *testing.T) {
 func setupRepositoryBindingTest(integrationData RepoBindingData) (string, resource.TestCheckFunc) {
 	configuration := formatRepoBindingDataIntoConfig(integrationData)
 
+	sidecarResource := fmt.Sprintf("cyral_sidecar.test_repo_binding_sidecar_%s",
+		integrationData.SidecarID)
+	repositoryResource := fmt.Sprintf("cyral_repository.test_repo_binding_repository_%s",
+		integrationData.RepositoryID)
+
 	testFunction := resource.ComposeTestCheckFunc(
-		resource.TestCheckResourceAttr("cyral_repository_binding.repo_binding", "enabled", fmt.Sprintf("%t", integrationData.Enabled)),
+		resource.TestCheckResourceAttr("cyral_repository_binding.repo_binding", "enabled",
+			fmt.Sprintf("%t", integrationData.Enabled)),
+		resource.TestCheckResourceAttrPair("cyral_repository_binding.repo_binding", "repository_id",
+			repositoryResource, "id"),
+		resource.TestCheckResourceAttrPair("cyral_repository_binding.repo_binding", "sidecar_id",
+			sidecarResource, "id"),
+		resource.TestCheckResourceAttr("cyral_repository_binding.repo_binding", "listener_host",
+			integrationData.Listener.Host),
+		resource.TestCheckResourceAttr("cyral_repository_binding.repo_binding", "listener_port",
+			fmt.Sprintf("%d", integrationData.Listener.Port)),
 	)
 
 	return configuration, testFunction
@@ -58,22 +72,35 @@ func setupRepositoryBindingTest(integrationData RepoBindingData) (string, resour
 
 func formatRepoBindingDataIntoConfig(data RepoBindingData) string {
 	return fmt.Sprintf(`
-	resource "cyral_repository" "test_repo_binding_repository" {	
+	resource "cyral_sidecar" "test_repo_binding_sidecar_1" {
+		name = "tf-provider-repo-binding-sidecar-1"
+		deployment_method = "cloudFormation"
+	}
+
+	resource "cyral_repository" "test_repo_binding_repository_1" {
+		name  = "tf-provider-repo-binding-repo-1"	
 		type  = "mongodb"
 		host  = "mongodb.cyral.com"
 		port  = 27017
-		name  = "tf-provider-repo-binding-repo"
 	}
-	
-	resource "cyral_sidecar" "test_repo_binding_sidecar" {
-		name = "tf-provider-repo-binding-sidecar"
+
+	resource "cyral_sidecar" "test_repo_binding_sidecar_2" {
+		name = "tf-provider-repo-binding-sidecar-2"
 		deployment_method = "cloudFormation"
+	}
+
+	resource "cyral_repository" "test_repo_binding_repository_2" {	
+		name  = "tf-provider-repo-binding-repo-2"
+		type  = "mongodb"
+		host  = "mongodb.cyral.com"
+		port  = 27017
 	}
 
 	resource "cyral_repository_binding" "repo_binding" {
 		enabled = %t
-		repository_id = cyral_repository.test_repo_binding_repository.id
-		listener_port = cyral_repository.test_repo_binding_repository.port
-		sidecar_id    = cyral_sidecar.test_repo_binding_sidecar.id
-	}`, data.Enabled)
+		sidecar_id    = cyral_sidecar.test_repo_binding_sidecar_%s.id
+		repository_id = cyral_repository.test_repo_binding_repository_%s.id
+		listener_host = "%s"
+		listener_port = %d
+	}`, data.Enabled, data.SidecarID, data.RepositoryID, data.Listener.Host, data.Listener.Port)
 }


### PR DESCRIPTION
## Description of the change

This PR fixes an issue with the repository binding resource, which was being duplicated when updating the sidecar_id or the repository_id arguments. See #145 .

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Jira issue referenced in commit message and/or PR title

### Testing
Tested manually and by running the automated tests.
