### PR TITLE
ci(pre-commit): enforce conventional-commits message structure

### DIFF
--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -1,0 +1,2 @@
+extends:
+  - "@commitlint/config-conventional"

--- a/.cz.json
+++ b/.cz.json
@@ -1,0 +1,4 @@
+{
+  "maxHeaderWidth": 72,
+  "path": "cz-conventional-changelog"
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,3 +18,4 @@ jobs:
           go-version: 1.15
       - uses: actions/setup-python@v2
       - uses: pre-commit/action@v2.0.0
+      - uses: wagoid/commitlint-github-action@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,9 @@ repos:
       - id: go-fmt
       - id: go-mod-tidy
       - id: go-build
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v5.0.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ["@commitlint/config-conventional"]

--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ the hooks by running the following command in the root of the repository:
 pre-commit install
 ```
 
+This repository following `Conventional Commits` for message formatting.
+See: https://www.conventionalcommits.org/en/v1.0.0/
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+You can use commitizen to help generate commit messages.
+See: http://commitizen.github.io/cz-cli/
+
 ### Running Project Built Locally
 
 #### Terraform v0.12


### PR DESCRIPTION
This adds pre-commit and ci checks to ensure that commit messages follow
[`conventional-commits`](https://www.conventionalcommits.org/en/v1.0.0/).

From their site: Conventional Commits is:
`A specification for adding human and machine readable meaning to commit messages`

Commit messages must follow the following format:
```
<type>[optional scope]: <description>

[optional body]

[optional footer(s)]
```

In general, this means that you will provide a topic:
* feat
* fix
* ci
* refactor

Followed by a description.

Following this standard allows for automatic semantic versioning and
release note generation.

* `.commitlintrc.yaml` - defines the commit message format for linting
* `.cz.json` - configuration for [`commitizen-cli`](http://commitizen.github.io/cz-cli/)

## Description of the change

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing
> Description of testing
