### PR TITLE
Change cyral_repository to cyral_sidecar for the sidecar_id

### DIFF
--- a/docs/resources/repository_binding.md
+++ b/docs/resources/repository_binding.md
@@ -10,7 +10,7 @@ Allows [binding repositories to sidecars](https://cyral.com/docs/sidecars/sideca
 resource "cyral_repository_binding" "some_resource_name" {
     enabled = true|false
     repository_id = cyral_repository.SOME_REPOSITORY_RESOURCE_NAME.id
-    sidecar_id    = cyral_repository.SOME_SIDECAR_RESOURCE_NAME.id
+    sidecar_id    = cyral_sidecar.SOME_SIDECAR_RESOURCE_NAME.id
     listener_port = 0
     listener_host = "0.0.0.0"
 }


### PR DESCRIPTION
## Description of the change

Modified the doc example from 
...
sidecar_id    = cyral_resource.SOME_SIDECAR_RESOURCE_NAME.id

to 
...
sidecar_id    = cyral_sidecar.SOME_SIDECAR_RESOURCE_NAME.id

## Type of change

- [ x ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

ran terraform apply with the new change and it rolled out correctly