### PR TITLE
ENG-8168: Deprecate properties field from policy resource

### DIFF
--- a/cyral/resource_cyral_policy.go
+++ b/cyral/resource_cyral_policy.go
@@ -68,8 +68,8 @@ func resourcePolicy() *schema.Resource {
 				Required: true,
 			},
 			"properties": {
-				Type:     schema.TypeSet,
-				Optional: true,
+				Type:       schema.TypeSet,
+				Optional:   true,
 				Deprecated: "This field might be removed in a future release.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/cyral/resource_cyral_policy.go
+++ b/cyral/resource_cyral_policy.go
@@ -70,6 +70,7 @@ func resourcePolicy() *schema.Resource {
 			"properties": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Deprecated: "This field might be removed in a future release.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {

--- a/cyral/resource_cyral_policy.go
+++ b/cyral/resource_cyral_policy.go
@@ -70,7 +70,7 @@ func resourcePolicy() *schema.Resource {
 			"properties": {
 				Type:       schema.TypeSet,
 				Optional:   true,
-				Deprecated: "This field might be removed in a future release.",
+				Deprecated: "This argument will be removed in a future release.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {

--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -21,7 +21,7 @@ resource "cyral_policy" "some_resource_name" {
 - `enabled` - (Optional) Boolean that causes a policy to be enabled or disabled.
 - `name` - (Required) Policy name that will be used internally in Control Plane (ex: `your_policy_name`).
 - `tags` - (Optional) Tags that can be used to organize and/or classify your policies (ex: `[your_tag1, your_tag2]`).
-- `properties` - (Optional) Policy properties requiring a `name` and a `description`. **This argument is deprecated and might be removed in a future release.**
+- `properties` - (Optional) Policy properties requiring a `name` and a `description`. **This argument is deprecated and will be removed in a future release.**
 
 For more information, see the [Policy Guide](https://cyral.com/docs/policy#policy).
 

--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -20,8 +20,8 @@ resource "cyral_policy" "some_resource_name" {
 - `description` - (Optional) String that describes the policy (ex: `your_policy_description`).
 - `enabled` - (Optional) Boolean that causes a policy to be enabled or disabled.
 - `name` - (Required) Policy name that will be used internally in Control Plane (ex: `your_policy_name`).
-- `properties` - (Optional) Policy properties requiring a `name` and a `description`.
 - `tags` - (Optional) Tags that can be used to organize and/or classify your policies (ex: `[your_tag1, your_tag2]`).
+- `properties` - (Optional) Policy properties requiring a `name` and a `description`. **This argument is deprecated and might be removed in a future release.**
 
 For more information, see the [Policy Guide](https://cyral.com/docs/policy#policy).
 


### PR DESCRIPTION
## Description of the change

The field `property` is available through the Terraform provider as part of the `policy` resource, but it is not in use by the backend. To avoid breaking compatibility we are deprecating it for now and it will be removed in the next major release.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Jira issue referenced in commit message and/or PR title

### Testing

Manual deployment of policy resource with local provider. Deprecation warning was displayed as expected.
