### PR TITLE
ENG-8392: Change repo local account resource to support Kubernetes Secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ vendor/
 
 # IDEs
 .idea/
+__debug_bin

--- a/cyral/provider.go
+++ b/cyral/provider.go
@@ -87,7 +87,7 @@ func Provider() *schema.Provider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"cyral_datamap":                     resourceDatamap(),
-			"cyral_identity_map":                resourceRepositoryIdentityMap(true),
+			"cyral_identity_map":                resourceRepositoryIdentityMap("Use `cyral_repository_identity_map` instead."),
 			"cyral_integration_datadog":         resourceIntegrationDatadog(),
 			"cyral_integration_elk":             resourceIntegrationELK(),
 			"cyral_integration_hc_vault":        resourceIntegrationHCVault(),
@@ -117,7 +117,7 @@ func Provider() *schema.Provider {
 			"cyral_repository_binding":          resourceRepositoryBinding(),
 			"cyral_repository_conf_analysis":    resourceRepositoryConfAnalysis(),
 			"cyral_repository_conf_auth":        resourceRepositoryConfAuth(),
-			"cyral_repository_identity_map":     resourceRepositoryIdentityMap(false),
+			"cyral_repository_identity_map":     resourceRepositoryIdentityMap(""),
 			"cyral_repository_local_account":    resourceRepositoryLocalAccount(),
 			"cyral_role":                        resourceRole(),
 			"cyral_role_sso_groups":             resourceRoleSSOGroups(),

--- a/cyral/resource_cyral_repository_identity_map.go
+++ b/cyral/resource_cyral_repository_identity_map.go
@@ -197,13 +197,7 @@ var ReadRepositoryIdentityMapConfig = ResourceOperationConfig{
 	ResponseData: &RepositoryIdentityMapAPIResponse{},
 }
 
-func resourceRepositoryIdentityMap(deprecate bool) *schema.Resource {
-	deprecationMessage := ""
-
-	if deprecate {
-		deprecationMessage = "Use `cyral_repository_identity_map` instead."
-	}
-
+func resourceRepositoryIdentityMap(deprecationMessage string) *schema.Resource {
 	return &schema.Resource{
 		DeprecationMessage: deprecationMessage,
 		CreateContext: CreateResource(

--- a/cyral/resource_cyral_repository_identity_map_test.go
+++ b/cyral/resource_cyral_repository_identity_map_test.go
@@ -105,7 +105,7 @@ func formatRepositoryIdentityMapDataIntoConfig(data RepositoryIdentityMapResourc
 
 	resource "cyral_repository_local_account" "tf_test_repository_account" {
 		repository_id = cyral_repository.test_repo_repository.id
-		enviroment_variable {
+		environment_variable {
 			database_name = "tf_test_db_name"
 			local_account = "tf_test_repo_account"
 			variable_name = "CYRAL_DBSECRETS_TF_TEST_VARIABLE_NAME"

--- a/cyral/resource_cyral_repository_local_account.go
+++ b/cyral/resource_cyral_repository_local_account.go
@@ -275,20 +275,20 @@ func (repoAccount *RepositoryLocalAccountResource) ReadFromSchema(d *schema.Reso
 	log.Printf("[DEBUG] RepositoryLocalAccountResource - ReadFromSchema END")
 }
 
-var ReadRepositoryLocalAccountConfig = ResourceOperationConfig{
-	Name:       "RepositoryLocalAccountResourceRead",
-	HttpMethod: http.MethodGet,
-	CreateURL: func(d *schema.ResourceData, c *client.Client) string {
-		repository_id := d.Get("repository_id")
-		return fmt.Sprintf(
-			"https://%s/v1/repos/%s/repoAccounts/%s",
-			c.ControlPlane, repository_id, d.Id(),
-		)
-	},
-	ResponseData: &RepositoryLocalAccountResource{},
-}
-
 func resourceRepositoryLocalAccount() *schema.Resource {
+	ReadRepositoryLocalAccountConfig := ResourceOperationConfig{
+		Name:       "RepositoryLocalAccountResourceRead",
+		HttpMethod: http.MethodGet,
+		CreateURL: func(d *schema.ResourceData, c *client.Client) string {
+			repository_id := d.Get("repository_id")
+			return fmt.Sprintf(
+				"https://%s/v1/repos/%s/repoAccounts/%s",
+				c.ControlPlane, repository_id, d.Id(),
+			)
+		},
+		ResponseData: &RepositoryLocalAccountResource{},
+	}
+
 	secretManagersTypes := []string{
 		"aws_iam",
 		"aws_secrets_manager",

--- a/cyral/resource_cyral_repository_local_account.go
+++ b/cyral/resource_cyral_repository_local_account.go
@@ -299,7 +299,11 @@ func resourceRepositoryLocalAccount() *schema.Resource {
 		"kubernetes_secret",
 	}
 
+	databaseNameDescription := "Database name that the local account corresponds to."
+	localAccountDescription := "Local account name."
+
 	awsIAMSchema := &schema.Schema{
+		Description:  "Credential option to set the local account from AWS IAM.",
 		Type:         schema.TypeSet,
 		Optional:     true,
 		ExactlyOneOf: secretManagersTypes,
@@ -307,22 +311,26 @@ func resourceRepositoryLocalAccount() *schema.Resource {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"database_name": {
-					Type:     schema.TypeString,
-					Optional: true,
+					Description: databaseNameDescription,
+					Type:        schema.TypeString,
+					Optional:    true,
 				},
 				"local_account": {
-					Type:     schema.TypeString,
-					Required: true,
+					Description: localAccountDescription,
+					Type:        schema.TypeString,
+					Required:    true,
 				},
 				"role_arn": {
-					Type:     schema.TypeString,
-					Required: true,
+					Description: "AWS IAM role ARN.",
+					Type:        schema.TypeString,
+					Required:    true,
 				},
 			},
 		},
 	}
 
 	awsSecretsManagerSchema := &schema.Schema{
+		Description:  "Credential option to set the local account from AWS Secrets Manager.",
 		Type:         schema.TypeSet,
 		Optional:     true,
 		ExactlyOneOf: secretManagersTypes,
@@ -330,22 +338,26 @@ func resourceRepositoryLocalAccount() *schema.Resource {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"database_name": {
-					Type:     schema.TypeString,
-					Optional: true,
+					Description: databaseNameDescription,
+					Type:        schema.TypeString,
+					Optional:    true,
 				},
 				"local_account": {
-					Type:     schema.TypeString,
-					Required: true,
+					Description: localAccountDescription,
+					Type:        schema.TypeString,
+					Required:    true,
 				},
 				"secret_arn": {
-					Type:     schema.TypeString,
-					Required: true,
+					Description: "ARN of the AWS Secret Manager that stores the credential.",
+					Type:        schema.TypeString,
+					Required:    true,
 				},
 			},
 		},
 	}
 
 	cyralStorageSchema := &schema.Schema{
+		Description:  "Credential option to set the local account from Cyral Storage.",
 		Type:         schema.TypeSet,
 		Optional:     true,
 		ExactlyOneOf: secretManagersTypes,
@@ -353,23 +365,27 @@ func resourceRepositoryLocalAccount() *schema.Resource {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"database_name": {
-					Type:     schema.TypeString,
-					Optional: true,
+					Description: databaseNameDescription,
+					Type:        schema.TypeString,
+					Optional:    true,
 				},
 				"local_account": {
-					Type:     schema.TypeString,
-					Required: true,
+					Description: localAccountDescription,
+					Type:        schema.TypeString,
+					Required:    true,
 				},
 				"password": {
-					Type:      schema.TypeString,
-					Required:  true,
-					Sensitive: true,
+					Description: "Local account password.",
+					Type:        schema.TypeString,
+					Required:    true,
+					Sensitive:   true,
 				},
 			},
 		},
 	}
 
 	hashicorpVaultSchema := &schema.Schema{
+		Description:  "Credential option to set the local account from Hashicorp Vault.",
 		Type:         schema.TypeSet,
 		Optional:     true,
 		ExactlyOneOf: secretManagersTypes,
@@ -377,16 +393,19 @@ func resourceRepositoryLocalAccount() *schema.Resource {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"database_name": {
-					Type:     schema.TypeString,
-					Optional: true,
+					Description: databaseNameDescription,
+					Type:        schema.TypeString,
+					Optional:    true,
 				},
 				"local_account": {
-					Type:     schema.TypeString,
-					Required: true,
+					Description: localAccountDescription,
+					Type:        schema.TypeString,
+					Required:    true,
 				},
 				"path": {
-					Type:     schema.TypeString,
-					Required: true,
+					Description: "Hashicorp Vault path.",
+					Type:        schema.TypeString,
+					Required:    true,
 				},
 			},
 		},
@@ -394,6 +413,7 @@ func resourceRepositoryLocalAccount() *schema.Resource {
 
 	// Deprecated: should be removed in the next MAJOR release
 	environmentVariableSchemaDeprecated := &schema.Schema{
+		Description:  "Credential option to set the local account from Environment Variable.",
 		Type:         schema.TypeSet,
 		Optional:     true,
 		ExactlyOneOf: secretManagersTypes,
@@ -402,22 +422,26 @@ func resourceRepositoryLocalAccount() *schema.Resource {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"database_name": {
-					Type:     schema.TypeString,
-					Optional: true,
+					Description: databaseNameDescription,
+					Type:        schema.TypeString,
+					Optional:    true,
 				},
 				"local_account": {
-					Type:     schema.TypeString,
-					Required: true,
+					Description: localAccountDescription,
+					Type:        schema.TypeString,
+					Required:    true,
 				},
 				"variable_name": {
-					Type:     schema.TypeString,
-					Required: true,
+					Description: "Name of the environment variable that will store credentials.",
+					Type:        schema.TypeString,
+					Required:    true,
 				},
 			},
 		},
 	}
 
 	environmentVariableSchema := &schema.Schema{
+		Description:  "Credential option to set the local account from Environment Variable.",
 		Type:         schema.TypeSet,
 		Optional:     true,
 		ExactlyOneOf: secretManagersTypes,
@@ -425,22 +449,26 @@ func resourceRepositoryLocalAccount() *schema.Resource {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"database_name": {
-					Type:     schema.TypeString,
-					Optional: true,
+					Description: databaseNameDescription,
+					Type:        schema.TypeString,
+					Optional:    true,
 				},
 				"local_account": {
-					Type:     schema.TypeString,
-					Required: true,
+					Description: localAccountDescription,
+					Type:        schema.TypeString,
+					Required:    true,
 				},
 				"variable_name": {
-					Type:     schema.TypeString,
-					Required: true,
+					Description: "Name of the environment variable that will store credentials.",
+					Type:        schema.TypeString,
+					Required:    true,
 				},
 			},
 		},
 	}
 
 	kubernetesSecretSchema := &schema.Schema{
+		Description:  "Credential option to set the local account from Kubernetes Secret.",
 		Type:         schema.TypeSet,
 		Optional:     true,
 		ExactlyOneOf: secretManagersTypes,
@@ -448,26 +476,31 @@ func resourceRepositoryLocalAccount() *schema.Resource {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"database_name": {
-					Type:     schema.TypeString,
-					Optional: true,
+					Description: databaseNameDescription,
+					Type:        schema.TypeString,
+					Optional:    true,
 				},
 				"local_account": {
-					Type:     schema.TypeString,
-					Required: true,
+					Description: localAccountDescription,
+					Type:        schema.TypeString,
+					Required:    true,
 				},
 				"secret_name": {
-					Type:     schema.TypeString,
-					Required: true,
+					Description: "Name of the secret in kubernetes.",
+					Type:        schema.TypeString,
+					Required:    true,
 				},
 				"secret_key": {
-					Type:     schema.TypeString,
-					Required: true,
+					Description: "Name of the key that stores the credentials within the secret.",
+					Type:        schema.TypeString,
+					Required:    true,
 				},
 			},
 		},
 	}
 
 	return &schema.Resource{
+		Description: "Provides a resource to handle [repository local accounts](https://cyral.com/docs/using-cyral/sso-auth-users#give-your-sidecar-access-to-the-local-account).",
 		CreateContext: CreateResource(
 			ResourceOperationConfig{
 				Name:       "RepositoryLocalAccountResourceCreate",
@@ -512,10 +545,16 @@ func resourceRepositoryLocalAccount() *schema.Resource {
 			},
 		),
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Description: "ID of this resource in Cyral environment.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 			"repository_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Description: "ID of the repository that will be used by the local account.",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
 			},
 			"aws_iam":              awsIAMSchema,
 			"aws_secrets_manager":  awsSecretsManagerSchema,

--- a/cyral/resource_cyral_repository_local_account.go
+++ b/cyral/resource_cyral_repository_local_account.go
@@ -217,7 +217,6 @@ func (resource *CreateRepoAccountResponse) ReadFromSchema(d *schema.ResourceData
 }
 
 type RepositoryLocalAccountResource struct {
-	RepoID              *string                      `json:"-"`
 	AwsIAM              *AwsIAMResource              `json:"awsIAM,omitempty"`
 	AwsSecretsManager   *AwsSecretsManagerResource   `json:"awsSecretsManager,omitempty"`
 	CyralStorage        *CyralStorageResource        `json:"cyralStorage,omitempty"`
@@ -228,10 +227,6 @@ type RepositoryLocalAccountResource struct {
 
 func (repoAccount RepositoryLocalAccountResource) WriteToSchema(d *schema.ResourceData) {
 	log.Printf("[DEBUG] RepositoryLocalAccountResource - WriteToSchema START")
-
-	if repoAccount.RepoID != nil {
-		d.Set("repository_id", repoAccount.RepoID)
-	}
 
 	if repoAccount.AwsIAM != nil {
 		repoAccount.AwsIAM.WriteToSchema(d)
@@ -275,9 +270,6 @@ func (repoAccount *RepositoryLocalAccountResource) ReadFromSchema(d *schema.Reso
 	} else if _, hasKubernetesSecret := d.GetOk("kubernetes_secret"); hasKubernetesSecret {
 		repoAccount.KubernetesSecret = &KubernetesSecretResource{}
 		repoAccount.KubernetesSecret.ReadFromSchema(d)
-	} else if data, hasRepoId := d.GetOk("repository_id"); hasRepoId {
-		repoId := data.(string)
-		repoAccount.RepoID = &repoId
 	}
 
 	log.Printf("[DEBUG] RepositoryLocalAccountResource - ReadFromSchema END")
@@ -523,6 +515,7 @@ func resourceRepositoryLocalAccount() *schema.Resource {
 			"repository_id": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"aws_iam":              awsIAMSchema,
 			"aws_secrets_manager":  awsSecretsManagerSchema,

--- a/cyral/resource_cyral_repository_local_account_test.go
+++ b/cyral/resource_cyral_repository_local_account_test.go
@@ -2,201 +2,315 @@ package cyral
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-var initialRepoAccountConfigAwsIam RepositoryLocalAccountResource = RepositoryLocalAccountResource{
+var initialRepoAccountConfigAwsIAM = RepositoryLocalAccountResource{
 	AwsIAM: &AwsIAMResource{
-		DatabaseName: "tf_test_db_name",
-		RepoAccount:  "tf_test_repo_account",
-		RoleArn:      "tf_test_role_arn",
+		DatabaseName: "tf-test-db-name",
+		RepoAccount:  "tf-test-repo-account",
+		RoleArn:      "tf-test-role-arn",
 	},
 }
 
-var updateRepoAccountConfigAwsIam RepositoryLocalAccountResource = RepositoryLocalAccountResource{
+var updatedRepoAccountConfigAwsIAM = RepositoryLocalAccountResource{
 	AwsIAM: &AwsIAMResource{
-		DatabaseName: "tf_test_update_db_name",
-		RepoAccount:  "tf_test_update_repo_account",
-		RoleArn:      "tf_test_update_role_arn",
+		DatabaseName: "tf-test-db-name-updated",
+		RepoAccount:  "tf-test-repo-account-updated",
+		RoleArn:      "tf-test-role-arn-updated",
 	},
 }
 
-var initialRepoAccountConfigAwsSecret RepositoryLocalAccountResource = RepositoryLocalAccountResource{
-	AwsSecretsManager: &AwsSecretsResource{
-		DatabaseName: "tf_test_db_name",
-		RepoAccount:  "tf_test_repo_account",
-		SecretArn:    "tf_test_secret_arn",
+var initialRepoAccountConfigAwsSecretsManager = RepositoryLocalAccountResource{
+	AwsSecretsManager: &AwsSecretsManagerResource{
+		DatabaseName: "tf-test-db-name",
+		RepoAccount:  "tf-test-repo-account",
+		SecretArn:    "tf-test-secret-arn",
 	},
 }
 
-var updateRepoAccountConfigAwsSecret RepositoryLocalAccountResource = RepositoryLocalAccountResource{
-	AwsSecretsManager: &AwsSecretsResource{
-		DatabaseName: "tf_test_update_db_name",
-		RepoAccount:  "tf_test_update_repo_account",
-		SecretArn:    "tf_test_update_secret_arn",
+var updatedRepoAccountConfigAwsSecretsManager = RepositoryLocalAccountResource{
+	AwsSecretsManager: &AwsSecretsManagerResource{
+		DatabaseName: "tf-test-db-name-updated",
+		RepoAccount:  "tf-test-repo-account-updated",
+		SecretArn:    "tf-test-secret-arn-updated",
 	},
 }
 
-var initialRepoAccountConfigCyralStorage RepositoryLocalAccountResource = RepositoryLocalAccountResource{
+var initialRepoAccountConfigCyralStorage = RepositoryLocalAccountResource{
 	CyralStorage: &CyralStorageResource{
-		DatabaseName: "tf_test_db_name",
-		RepoAccount:  "tf_test_repo_account",
-		Password:     "tf_test_pasword",
+		DatabaseName: "tf-test-db-name",
+		RepoAccount:  "tf-test-repo-account",
+		Password:     "tf-test-pasword",
 	},
 }
 
-var updateRepoAccountConfigCyralStorage RepositoryLocalAccountResource = RepositoryLocalAccountResource{
+var updatedRepoAccountConfigCyralStorage = RepositoryLocalAccountResource{
 	CyralStorage: &CyralStorageResource{
-		DatabaseName: "tf_test_update_db_name",
-		RepoAccount:  "tf_test_update_repo_account",
-		Password:     "tf_test_update_pasword",
+		DatabaseName: "tf-test-db-name-updated",
+		RepoAccount:  "tf-test-repo-account-updated",
+		Password:     "tf-test-pasword-updated",
 	},
 }
 
-var initialRepoAccountConfigHashicorpVault RepositoryLocalAccountResource = RepositoryLocalAccountResource{
+var initialRepoAccountConfigHashicorpVault = RepositoryLocalAccountResource{
 	HashicorpVault: &HashicorpVaultResource{
-		DatabaseName: "tf_test_db_name",
-		RepoAccount:  "tf_test_repo_account",
-		Path:         "tf_test_path",
+		DatabaseName: "tf-test-db-name",
+		RepoAccount:  "tf-test-repo-account",
+		Path:         "tf-test-path",
 	},
 }
 
-var updateRepoAccountConfigHashicorpVault RepositoryLocalAccountResource = RepositoryLocalAccountResource{
+var updatedRepoAccountConfigHashicorpVault = RepositoryLocalAccountResource{
 	HashicorpVault: &HashicorpVaultResource{
-		DatabaseName: "tf_test_update_db_name",
-		RepoAccount:  "tf_test_update_repo_account",
-		Path:         "tf_test_update_path",
+		DatabaseName: "tf-test-db-name-updated",
+		RepoAccount:  "tf-test-repo-account-updated",
+		Path:         "tf-test-path-updated",
 	},
 }
 
-var initialRepoAccountConfigEnviromentVariable RepositoryLocalAccountResource = RepositoryLocalAccountResource{
-	EnviromentVariable: &EnviromentVariableResource{
-		DatabaseName: "tf_test_db_name",
-		RepoAccount:  "tf_test_repo_account",
+var initialRepoAccountConfigEnvironmentVariable = RepositoryLocalAccountResource{
+	EnvironmentVariable: &EnvironmentVariableResource{
+		DatabaseName: "tf-test-db-name",
+		RepoAccount:  "tf-test-repo-account",
 		VariableName: "CYRAL_DBSECRETS_TF_TEST_VARIABLE_NAME",
 	},
 }
 
-var updateRepoAccountConfigEnviromentVariable RepositoryLocalAccountResource = RepositoryLocalAccountResource{
-	EnviromentVariable: &EnviromentVariableResource{
-		DatabaseName: "tf_test_update_db_name",
-		RepoAccount:  "tf_test_update_repo_account",
-		VariableName: "CYRAL_DBSECRETS_TF_TEST_UPDATE_VARIABLE_NAME",
+var updatedRepoAccountConfigEnvironmentVariable = RepositoryLocalAccountResource{
+	EnvironmentVariable: &EnvironmentVariableResource{
+		DatabaseName: "tf-test-db-name-updated",
+		RepoAccount:  "tf-test-repo-account-updated",
+		VariableName: "CYRAL_DBSECRETS_TF_TEST_VARIABLE_NAME_UPDATED",
 	},
 }
 
-func TestAccRepositoryAccountEnviromentVariable(t *testing.T) {
-	testConfigEnviromentVariable, testFuncEnviromentVariable := setupRepositoryAccountTest(initialRepoAccountConfigEnviromentVariable)
-	testUpdateConfigEnviromentVariable, testUpdateFuncEnviromentVariable := setupRepositoryAccountTest(updateRepoAccountConfigEnviromentVariable)
+var initialRepoAccountConfigKubernetesSecret = RepositoryLocalAccountResource{
+	KubernetesSecret: &KubernetesSecretResource{
+		DatabaseName: "tf-test-db-name",
+		RepoAccount:  "tf-test-repo-account",
+		SecretName:   "tf-test-db-secrets",
+		SecretKey:    "tf-test-secret-key",
+	},
+}
 
+var updatedRepoAccountConfigKubernetesSecret = RepositoryLocalAccountResource{
+	KubernetesSecret: &KubernetesSecretResource{
+		DatabaseName: "tf-test-db-name-updated",
+		RepoAccount:  "tf-test-repo-account-updated",
+		SecretName:   "db-secrets-updated",
+		SecretKey:    "tf-test-secret-key-updated",
+	},
+}
+
+func TestAccRepositoryLocalAccountResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testConfigEnviromentVariable,
-				Check:  testFuncEnviromentVariable,
+				Config:      testAccRepositoryLocalAccountConfig_MultipleSecretManagers(),
+				ExpectError: regexp.MustCompile("Error: Invalid combination of arguments"),
 			},
 			{
-				Config: testUpdateConfigEnviromentVariable,
-				Check:  testUpdateFuncEnviromentVariable,
+				Config:      testAccRepositoryLocalAccountConfig_MultipleSecretManagersOfSameType(),
+				ExpectError: regexp.MustCompile("Error: Too many .* blocks"),
 			},
 		},
 	})
 }
 
-func TestAccRepositoryAccountAwsHashicorpVault(t *testing.T) {
-	testConfigHashicorpVault, testFuncHashicorpVault := setupRepositoryAccountTest(initialRepoAccountConfigHashicorpVault)
-	testUpdateConfigHashicorpVault, testUpdateFuncHashicorpVault := setupRepositoryAccountTest(updateRepoAccountConfigHashicorpVault)
+func testAccRepositoryLocalAccountConfig_MultipleSecretManagers() string {
+	return `
+	resource "cyral_repository" "tf_test_repository" {
+		type = "postgresql"
+		host = "http://postgres.local/"
+		port = 5432
+		name = "tf-test-postgres-multiple-secret-managers"
+	}
+
+	resource "cyral_repository_local_account" "tf_test_repository_account" {
+		repository_id = cyral_repository.tf_test_repository.id
+		aws_iam {
+			database_name = "some-db-name"
+			local_account = "some-local-account"
+			role_arn = "some-role-arn"
+		}
+		kubernetes_secret {
+			database_name = "some-db-name"
+			local_account = "some-local-account-2"
+			secret_name = "some-secret-name"
+			secret_key = "some-secret-key"
+		}
+	}
+	`
+}
+
+func testAccRepositoryLocalAccountConfig_MultipleSecretManagersOfSameType() string {
+	return `
+	resource "cyral_repository" "tf_test_repository" {
+		type = "postgresql"
+		host = "http://postgres.local/"
+		port = 5432
+		name = "tf-test-postgres-multiple-secret-managers"
+	}
+
+	resource "cyral_repository_local_account" "tf_test_repository_account" {
+		repository_id = cyral_repository.tf_test_repository.id
+		kubernetes_secret {
+			database_name = "some-db-name-1"
+			local_account = "some-local-account-1"
+			secret_name = "some-secret-name-1"
+			secret_key = "some-secret-key-1"
+		}
+		kubernetes_secret {
+			database_name = "some-db-name-2"
+			local_account = "some-local-account-2"
+			secret_name = "some-secret-name-2"
+			secret_key = "some-secret-key-2"
+		}
+	}
+	`
+}
+
+func TestAccRepositoryLocalAccountResource_KubernetesSecret(t *testing.T) {
+	testInitialConfig, testInitialCheck :=
+		setupRepositoryLocalAccountTest(initialRepoAccountConfigKubernetesSecret)
+	testUpdatedConfig, testUpdatedCheck :=
+		setupRepositoryLocalAccountTest(updatedRepoAccountConfigKubernetesSecret)
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testConfigHashicorpVault,
-				Check:  testFuncHashicorpVault,
+				Config: testInitialConfig,
+				Check:  testInitialCheck,
 			},
 			{
-				Config: testUpdateConfigHashicorpVault,
-				Check:  testUpdateFuncHashicorpVault,
+				Config: testUpdatedConfig,
+				Check:  testUpdatedCheck,
 			},
 		},
 	})
 }
 
-func TestAccRepositoryAccountCyralStorage(t *testing.T) {
-	testConfigCyralStorage, testFuncCyralStorage := setupRepositoryAccountTest(initialRepoAccountConfigCyralStorage)
-	testUpdateConfigCyralStorage, testUpdateFuncCyralStorage := setupRepositoryAccountTest(updateRepoAccountConfigCyralStorage)
+func TestAccRepositoryLocalAccountResource_EnvironmentVariable(t *testing.T) {
+	testInitialConfig, testInitialCheck :=
+		setupRepositoryLocalAccountTest(initialRepoAccountConfigEnvironmentVariable)
+	testUpdatedConfig, testUpdatedCheck :=
+		setupRepositoryLocalAccountTest(updatedRepoAccountConfigEnvironmentVariable)
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testConfigCyralStorage,
-				Check:  testFuncCyralStorage,
+				Config: testInitialConfig,
+				Check:  testInitialCheck,
 			},
 			{
-				Config: testUpdateConfigCyralStorage,
-				Check:  testUpdateFuncCyralStorage,
+				Config: testUpdatedConfig,
+				Check:  testUpdatedCheck,
 			},
 		},
 	})
 }
 
-func TestAccRepositoryAccountAwsSecretResource(t *testing.T) {
-	testConfigAwsSecret, testFuncAwsSecret := setupRepositoryAccountTest(initialRepoAccountConfigAwsSecret)
-	testUpdateConfigAwsSecret, testUpdateFuncAwsSecret := setupRepositoryAccountTest(updateRepoAccountConfigAwsSecret)
+func TestAccRepositoryLocalAccountResource_HashicorpVault(t *testing.T) {
+	testInitialConfig, testInitialCheck :=
+		setupRepositoryLocalAccountTest(initialRepoAccountConfigHashicorpVault)
+	testUpdatedConfig, testUpdatedCheck :=
+		setupRepositoryLocalAccountTest(updatedRepoAccountConfigHashicorpVault)
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testConfigAwsSecret,
-				Check:  testFuncAwsSecret,
+				Config: testInitialConfig,
+				Check:  testInitialCheck,
 			},
 			{
-				Config: testUpdateConfigAwsSecret,
-				Check:  testUpdateFuncAwsSecret,
+				Config: testUpdatedConfig,
+				Check:  testUpdatedCheck,
 			},
 		},
 	})
 }
 
-func TestAccRepositoryAccountAwsIamResource(t *testing.T) {
-	testConfigAwsIam, testFuncAwsIam := setupRepositoryAccountTest(initialRepoAccountConfigAwsIam)
-	testUpdateConfigAwsIam, testUpdateFuncAwsIam := setupRepositoryAccountTest(updateRepoAccountConfigAwsIam)
+func TestAccRepositoryLocalAccountResource_CyralStorage(t *testing.T) {
+	testInitialConfig, testInitialCheck :=
+		setupRepositoryLocalAccountTest(initialRepoAccountConfigCyralStorage)
+	testUpdatedConfig, testUpdatedCheck :=
+		setupRepositoryLocalAccountTest(updatedRepoAccountConfigCyralStorage)
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testConfigAwsIam,
-				Check:  testFuncAwsIam,
+				Config: testInitialConfig,
+				Check:  testInitialCheck,
 			},
 			{
-				Config: testUpdateConfigAwsIam,
-				Check:  testUpdateFuncAwsIam,
+				Config: testUpdatedConfig,
+				Check:  testUpdatedCheck,
 			},
 		},
 	})
 }
 
-func setupRepositoryAccountTest(integrationData RepositoryLocalAccountResource) (string, resource.TestCheckFunc) {
-	configuration := formatRepoAccountIntoConfig(integrationData)
+func TestAccRepositoryLocalAccountResource_AwsSecretsManager(t *testing.T) {
+	testInitialConfig, testInitialCheck :=
+		setupRepositoryLocalAccountTest(initialRepoAccountConfigAwsSecretsManager)
+	testUpdatedConfig, testUpdatedCheck :=
+		setupRepositoryLocalAccountTest(updatedRepoAccountConfigAwsSecretsManager)
 
-	testFunction := getTestFunctionForRepositoryLocalAccountResource(integrationData)
-
-	return configuration, testFunction
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testInitialConfig,
+				Check:  testInitialCheck,
+			},
+			{
+				Config: testUpdatedConfig,
+				Check:  testUpdatedCheck,
+			},
+		},
+	})
 }
 
-func formatRepoAccountIntoConfig(data RepositoryLocalAccountResource) string {
-	return fmt.Sprintf(`
-	  %s
-	  `, formatRepoAccountAuthConfig(data))
+func TestAccRepositoryLocalAccountResource_AwsIAM(t *testing.T) {
+	testInitialConfig, testInitialCheck :=
+		setupRepositoryLocalAccountTest(initialRepoAccountConfigAwsIAM)
+	testUpdatedConfig, testUpdatedCheck :=
+		setupRepositoryLocalAccountTest(updatedRepoAccountConfigAwsIAM)
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testInitialConfig,
+				Check:  testInitialCheck,
+			},
+			{
+				Config: testUpdatedConfig,
+				Check:  testUpdatedCheck,
+			},
+		},
+	})
 }
 
-func formatRepoAccountAuthConfig(data RepositoryLocalAccountResource) string {
+func setupRepositoryLocalAccountTest(
+	data RepositoryLocalAccountResource,
+) (string, resource.TestCheckFunc) {
+	testConfig := formatRepositoryLocalAccountIntoConfig(data)
+	testCheck := getTestCheckForRepositoryLocalAccountResource(data)
+
+	return testConfig, testCheck
+}
+
+func formatRepositoryLocalAccountIntoConfig(data RepositoryLocalAccountResource) string {
 	const RepositoryAccountTemplate = `
 	resource "cyral_repository" "tf_test_repository" {
 		type = "mysql"
@@ -208,89 +322,185 @@ func formatRepoAccountAuthConfig(data RepositoryLocalAccountResource) string {
 	resource "cyral_repository_local_account" "tf_test_repository_account" {
 		repository_id = cyral_repository.tf_test_repository.id
 		%s
-	}`
+	}
+	`
 
 	name := ""
 	config := ""
 
 	if data.AwsIAM != nil {
-		name = "tf-test-mysql-aws_iam"
+		name = "tf-test-mysql-aws-iam"
 		config = fmt.Sprintf(`aws_iam {
 			database_name = "%s"
 			local_account = "%s"
 			role_arn      = "%s"
-		  }`, data.AwsIAM.DatabaseName, data.AwsIAM.RepoAccount, data.AwsIAM.RoleArn)
+		  }`,
+			data.AwsIAM.DatabaseName,
+			data.AwsIAM.RepoAccount,
+			data.AwsIAM.RoleArn,
+		)
 	} else if data.AwsSecretsManager != nil {
-		name = "tf-test-mysql-aws_secrets_manager"
-
+		name = "tf-test-mysql-aws-secrets-manager"
 		config = fmt.Sprintf(`aws_secrets_manager {
 			database_name = "%s"
 			local_account = "%s"
 			secret_arn    = "%s"
-		  }`, data.AwsSecretsManager.DatabaseName, data.AwsSecretsManager.RepoAccount, data.AwsSecretsManager.SecretArn)
+		  }`,
+			data.AwsSecretsManager.DatabaseName,
+			data.AwsSecretsManager.RepoAccount,
+			data.AwsSecretsManager.SecretArn,
+		)
 	} else if data.CyralStorage != nil {
-		name = "tf-test-mysql-cyral_storage"
-
+		name = "tf-test-mysql-cyral-storage"
 		config = fmt.Sprintf(`cyral_storage {
 			database_name = "%s"
 			local_account = "%s"
 			password      = "%s"
-		  }`, data.CyralStorage.DatabaseName, data.CyralStorage.RepoAccount, data.CyralStorage.Password)
+			}`,
+			data.CyralStorage.DatabaseName,
+			data.CyralStorage.RepoAccount,
+			data.CyralStorage.Password,
+		)
 	} else if data.HashicorpVault != nil {
-		name = "tf-test-mysql-hashicorp_vault"
-
+		name = "tf-test-mysql-hashicorp-vault"
 		config = fmt.Sprintf(`hashicorp_vault {
 			database_name = "%s"
 			local_account = "%s"
 			path          = "%s"
-		  }`, data.HashicorpVault.DatabaseName, data.HashicorpVault.RepoAccount, data.HashicorpVault.Path)
-	} else if data.EnviromentVariable != nil {
-		name = "tf-test-mysql-enviroment_variable"
-
-		config = fmt.Sprintf(`enviroment_variable {
+			}`,
+			data.HashicorpVault.DatabaseName,
+			data.HashicorpVault.RepoAccount,
+			data.HashicorpVault.Path,
+		)
+	} else if data.EnvironmentVariable != nil {
+		name = "tf-test-mysql-environment-variable"
+		config = fmt.Sprintf(`environment_variable {
 			database_name = "%s"
 			local_account = "%s"
 			variable_name = "%s"
-		  }`, data.EnviromentVariable.DatabaseName, data.EnviromentVariable.RepoAccount, data.EnviromentVariable.VariableName)
+		  }`,
+			data.EnvironmentVariable.DatabaseName,
+			data.EnvironmentVariable.RepoAccount,
+			data.EnvironmentVariable.VariableName,
+		)
+	} else if data.KubernetesSecret != nil {
+		name = "tf-test-mysql-kubernetes-secret"
+		config = fmt.Sprintf(`kubernetes_secret {
+			database_name = "%s"
+			local_account = "%s"
+			secret_name = "%s"
+			secret_key = "%s"
+		  }`,
+			data.KubernetesSecret.DatabaseName,
+			data.KubernetesSecret.RepoAccount,
+			data.KubernetesSecret.SecretName,
+			data.KubernetesSecret.SecretKey,
+		)
 	}
 
 	return fmt.Sprintf(RepositoryAccountTemplate, name, config)
 }
 
-func getTestFunctionForRepositoryLocalAccountResource(data RepositoryLocalAccountResource) resource.TestCheckFunc {
-	var testFunc resource.TestCheckFunc
+func getTestCheckForRepositoryLocalAccountResource(
+	data RepositoryLocalAccountResource,
+) resource.TestCheckFunc {
+	var testCheckFunc resource.TestCheckFunc
 
 	if data.AwsIAM != nil {
-		testFunc = resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr("cyral_repository_local_account.tf_test_repository_account", "aws_iam.0.database_name", data.AwsIAM.DatabaseName),
-			resource.TestCheckResourceAttr("cyral_repository_local_account.tf_test_repository_account", "aws_iam.0.local_account", data.AwsIAM.RepoAccount),
-			resource.TestCheckResourceAttr("cyral_repository_local_account.tf_test_repository_account", "aws_iam.0.role_arn", data.AwsIAM.RoleArn),
+		testCheckFunc = resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"cyral_repository_local_account.tf_test_repository_account",
+				"aws_iam.0.database_name", data.AwsIAM.DatabaseName,
+			),
+			resource.TestCheckResourceAttr(
+				"cyral_repository_local_account.tf_test_repository_account",
+				"aws_iam.0.local_account", data.AwsIAM.RepoAccount,
+			),
+			resource.TestCheckResourceAttr(
+				"cyral_repository_local_account.tf_test_repository_account",
+				"aws_iam.0.role_arn", data.AwsIAM.RoleArn,
+			),
 		)
 	} else if data.AwsSecretsManager != nil {
-		testFunc = resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr("cyral_repository_local_account.tf_test_repository_account", "aws_secrets_manager.0.database_name", data.AwsSecretsManager.DatabaseName),
-			resource.TestCheckResourceAttr("cyral_repository_local_account.tf_test_repository_account", "aws_secrets_manager.0.local_account", data.AwsSecretsManager.RepoAccount),
-			resource.TestCheckResourceAttr("cyral_repository_local_account.tf_test_repository_account", "aws_secrets_manager.0.secret_arn", data.AwsSecretsManager.SecretArn),
+		testCheckFunc = resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"cyral_repository_local_account.tf_test_repository_account",
+				"aws_secrets_manager.0.database_name", data.AwsSecretsManager.DatabaseName,
+			),
+			resource.TestCheckResourceAttr(
+				"cyral_repository_local_account.tf_test_repository_account",
+				"aws_secrets_manager.0.local_account", data.AwsSecretsManager.RepoAccount,
+			),
+			resource.TestCheckResourceAttr(
+				"cyral_repository_local_account.tf_test_repository_account",
+				"aws_secrets_manager.0.secret_arn", data.AwsSecretsManager.SecretArn,
+			),
 		)
 	} else if data.CyralStorage != nil {
-		testFunc = resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr("cyral_repository_local_account.tf_test_repository_account", "cyral_storage.0.database_name", data.CyralStorage.DatabaseName),
-			resource.TestCheckResourceAttr("cyral_repository_local_account.tf_test_repository_account", "cyral_storage.0.local_account", data.CyralStorage.RepoAccount),
-			resource.TestCheckResourceAttr("cyral_repository_local_account.tf_test_repository_account", "cyral_storage.0.password", data.CyralStorage.Password),
+		testCheckFunc = resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"cyral_repository_local_account.tf_test_repository_account",
+				"cyral_storage.0.database_name", data.CyralStorage.DatabaseName,
+			),
+			resource.TestCheckResourceAttr(
+				"cyral_repository_local_account.tf_test_repository_account",
+				"cyral_storage.0.local_account", data.CyralStorage.RepoAccount,
+			),
+			resource.TestCheckResourceAttr(
+				"cyral_repository_local_account.tf_test_repository_account",
+				"cyral_storage.0.password", data.CyralStorage.Password,
+			),
 		)
 	} else if data.HashicorpVault != nil {
-		testFunc = resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr("cyral_repository_local_account.tf_test_repository_account", "hashicorp_vault.0.database_name", data.HashicorpVault.DatabaseName),
-			resource.TestCheckResourceAttr("cyral_repository_local_account.tf_test_repository_account", "hashicorp_vault.0.local_account", data.HashicorpVault.RepoAccount),
-			resource.TestCheckResourceAttr("cyral_repository_local_account.tf_test_repository_account", "hashicorp_vault.0.path", data.HashicorpVault.Path),
+		testCheckFunc = resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"cyral_repository_local_account.tf_test_repository_account",
+				"hashicorp_vault.0.database_name", data.HashicorpVault.DatabaseName,
+			),
+			resource.TestCheckResourceAttr(
+				"cyral_repository_local_account.tf_test_repository_account",
+				"hashicorp_vault.0.local_account", data.HashicorpVault.RepoAccount,
+			),
+			resource.TestCheckResourceAttr(
+				"cyral_repository_local_account.tf_test_repository_account",
+				"hashicorp_vault.0.path", data.HashicorpVault.Path,
+			),
 		)
-	} else if data.EnviromentVariable != nil {
-		testFunc = resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr("cyral_repository_local_account.tf_test_repository_account", "enviroment_variable.0.database_name", data.EnviromentVariable.DatabaseName),
-			resource.TestCheckResourceAttr("cyral_repository_local_account.tf_test_repository_account", "enviroment_variable.0.local_account", data.EnviromentVariable.RepoAccount),
-			resource.TestCheckResourceAttr("cyral_repository_local_account.tf_test_repository_account", "enviroment_variable.0.variable_name", data.EnviromentVariable.VariableName),
+	} else if data.EnvironmentVariable != nil {
+		testCheckFunc = resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"cyral_repository_local_account.tf_test_repository_account",
+				"environment_variable.0.database_name", data.EnvironmentVariable.DatabaseName,
+			),
+			resource.TestCheckResourceAttr(
+				"cyral_repository_local_account.tf_test_repository_account",
+				"environment_variable.0.local_account", data.EnvironmentVariable.RepoAccount,
+			),
+			resource.TestCheckResourceAttr(
+				"cyral_repository_local_account.tf_test_repository_account",
+				"environment_variable.0.variable_name", data.EnvironmentVariable.VariableName,
+			),
+		)
+	} else if data.KubernetesSecret != nil {
+		testCheckFunc = resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"cyral_repository_local_account.tf_test_repository_account",
+				"kubernetes_secret.0.database_name", data.KubernetesSecret.DatabaseName,
+			),
+			resource.TestCheckResourceAttr(
+				"cyral_repository_local_account.tf_test_repository_account",
+				"kubernetes_secret.0.local_account", data.KubernetesSecret.RepoAccount,
+			),
+			resource.TestCheckResourceAttr(
+				"cyral_repository_local_account.tf_test_repository_account",
+				"kubernetes_secret.0.secret_name", data.KubernetesSecret.SecretName,
+			),
+			resource.TestCheckResourceAttr(
+				"cyral_repository_local_account.tf_test_repository_account",
+				"kubernetes_secret.0.secret_key", data.KubernetesSecret.SecretKey,
+			),
 		)
 	}
 
-	return testFunc
+	return testCheckFunc
 }

--- a/docs/resources/repository_local_account.md
+++ b/docs/resources/repository_local_account.md
@@ -1,6 +1,6 @@
 # Repository Local Account Resource
 
-Provides a resource to handle repository local accounts.
+Provides a resource to handle [repository local accounts](https://cyral.com/docs/using-cyral/sso-auth-users#give-your-sidecar-access-to-the-local-account).
 
 ## Example Usage
 
@@ -56,14 +56,29 @@ resource "cyral_repository_local_account" "some_resource_name" {
 }
 ```
 
-### Environment variable
+### Environment Variable
 
 ```hcl
 resource "cyral_repository_local_account" "some_resource_name" {
     repository_id = cyral_repository.SOME_REPOSITORY_RESOURCE_NAME.id
     environment_variable {
+        database_name = ""
         local_account = ""
         variable_name = ""
+    }
+}
+```
+
+### Kubernetes Secret
+
+```hcl
+resource "cyral_repository_local_account" "some_resource_name" {
+    repository_id = cyral_repository.SOME_REPOSITORY_RESOURCE_NAME.id
+    kubernetes_secret {
+        database_name = ""
+        local_account = ""
+        secret_name = ""
+        secret_key = ""
     }
 }
 ```
@@ -75,6 +90,8 @@ resource "cyral_repository_local_account" "some_resource_name" {
 - `aws_secrets_manager` - (Optional) Credential option to set the local account from AWS Secrets Manager. See [aws_secrets_manager](#aws_secrets_manager) below for more details.
 - `cyral_storage` - (Optional) Credential option to set the local account from Cyral Storage. See [cyral_storage](#cyral_storage) below for more details.
 - `hashicorp_vault` - (Optional) Credential option to set the local account from Hashicorp Vault. See [hashicorp_vault](#hashicorp_vault) below for more details.
+- `environment_variable` - (Optional) Credential option to set the local account from Environment Variable. See [environment_variable](#environment_variable) below for more details.
+- `kubernetes_secret` - (Optional) Credential option to set the local account from Kubernetes Secret. See [kubernetes_secret](#kubernetes_secret) below for more details.
 
 ### aws_iam
 
@@ -115,6 +132,15 @@ The `environment_variable` object supports the following arguments:
 - `database_name` - (Optional) Database name that the local account corresponds to.
 - `local_account` - (Required) Local account name.
 - `environment_name` - (Required) Name of the environment variable that will store credentials.
+
+### kubernetes_secret
+
+The `kubernetes_secret` object supports the following arguments:
+
+- `database_name` - (Optional) Database name that the local account corresponds to.
+- `local_account` - (Required) Local account name.
+- `secret_name` - (Required) Name of the secret in kubernetes.
+- `secret_key` - (Required) Name of the key that stores the credentials within the secret.
 
 ## Attribute Reference
 

--- a/docs/resources/repository_local_account.md
+++ b/docs/resources/repository_local_account.md
@@ -144,4 +144,4 @@ The `kubernetes_secret` object supports the following arguments:
 
 ## Attribute Reference
 
-- `id` - The ID of this resource.
+- `id` - ID of this resource in Cyral environment.


### PR DESCRIPTION
## Description of the change

ENG-8392: Terraform provider - add resource for k8s secrets local account

- Add support for Kubernetes Secret
- Deprecate `enviroment_variable` field since it contains a typo
- Fix issue with `repository_id` by adding ForceNew to this field
- Fix some details in docs.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Jira issue referenced in commit message and/or PR title

### Testing

Manual and automated tests
