### PR TITLE
ENG-8345: Support different TLS options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ docker/clean:
 	rm -rf ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}
 
 local/test:
-	$(GOTEST) github.com/cyralinc/terraform-provider-cyral/... -v -race -timeout 20m
+	GOOS=darwin GOARCH=arm64 $(GOTEST) github.com/cyralinc/terraform-provider-cyral/... -v -race -timeout 20m
 
 docker-compose/build: docker-compose/lint
 	docker-compose build --build-arg VERSION="$(VERSION+sha)" build

--- a/Makefile
+++ b/Makefile
@@ -26,14 +26,17 @@ local/build:
 	mkdir -p out/
 	# Build for both MacOS and Linux
 	GOOS=darwin GOARCH=amd64 $(GOBUILD) -o out/darwin_amd64/$(BINARY) .
+	GOOS=darwin GOARCH=arm64 $(GOBUILD) -o out/darwin_arm64/$(BINARY) .
 	GOOS=linux GOARCH=amd64 $(GOBUILD) -o out/linux_amd64/$(BINARY) .
 
 local/install: local/build
 # Store in local registry to be used by Terraform 13 and 14
+	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/darwin_arm64
 	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/darwin_amd64
 	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/linux_amd64
-	cp out/darwin_amd64/$(BINARY) ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/darwin_amd64
+	cp out/darwin_arm64/$(BINARY) ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/darwin_arm64
 	cp out/linux_amd64/$(BINARY) ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/linux_amd64
+	cp out/darwin_amd64/$(BINARY) ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/darwin_amd64
 
 docker/test:
 	docker-compose run -e CYRAL_TF_CONTROL_PLANE=$(CYRAL_TF_CONTROL_PLANE) -e CYRAL_TF_CLIENT_ID=$(CYRAL_TF_CLIENT_ID) \

--- a/client/client.go
+++ b/client/client.go
@@ -106,7 +106,7 @@ func getAuth0Token(domain, clientID, clientSecret, audience string, client *http
 	if err != nil {
 		return TokenResponse{}, fmt.Errorf("unable execute auth0 request; err: %v", err)
 	}
-	// defer res.Body.Close()
+	defer res.Body.Close()
 	log.Printf("[DEBUG] body: %v", res.Body)
 	if res.StatusCode != http.StatusOK {
 		msg := fmt.Sprintf("Auth0 requisition fail. Response status code %d. Response body: %v",
@@ -150,7 +150,7 @@ func getKeycloakToken(controlPlane, clientID, clientSecret string, client *http.
 	if err != nil {
 		return TokenResponse{}, fmt.Errorf("unable execute keycloak request; err: %v", err)
 	}
-	// defer res.Body.Close()
+	defer res.Body.Close()
 	log.Printf("[DEBUG] body: %v", res.Body)
 	if res.StatusCode != http.StatusOK {
 		msg := fmt.Sprintf("keycloak requisition fail. Response status code %d. Response body: %v",
@@ -209,7 +209,7 @@ func (c *Client) DoRequest(url, httpMethod string, resourceData interface{}) ([]
 		return nil, fmt.Errorf("unable to execute request. Check the control plane address; err: %v", err)
 	}
 
-	// defer res.Body.Close()
+	defer res.Body.Close()
 	if res.StatusCode == http.StatusConflict ||
 		(httpMethod == http.MethodPost && strings.Contains(strings.ToLower(res.Status), "already exists")) {
 		return nil, fmt.Errorf("resource possibly exists in the control plane. Response status: %s", res.Status)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -18,7 +18,8 @@ func TestInvalidAuth0DomainFormat(t *testing.T) {
 			"^^^exampleInvalidDomain",
 			"ExampleAuth0Audience",
 			"SomeControlPlane",
-			keycloakProvider)
+			keycloakProvider,
+			true)
 
 		if err == nil {
 			t.Error(fmt.Errorf(
@@ -39,7 +40,8 @@ func TestInvalidAuth0DomainValue(t *testing.T) {
 			"invalidDomain",
 			"ExampleAuth0Audience",
 			"SomeControlPlane",
-			keycloakProvider)
+			keycloakProvider,
+			true)
 
 		if err == nil {
 			t.Error(fmt.Errorf(
@@ -55,7 +57,7 @@ func TestInvalidAuth0DomainValue(t *testing.T) {
 
 func TestServerDown(t *testing.T) {
 	test := func(keycloakProvider bool) {
-		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		// http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
 		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		}))
@@ -66,7 +68,8 @@ func TestServerDown(t *testing.T) {
 			ts.URL[8:len(ts.URL)],
 			"exampleAud",
 			"SomeControlPlane",
-			keycloakProvider)
+			keycloakProvider,
+			true)
 
 		ts.URL = ts.URL + "/oauth/token"
 
@@ -88,7 +91,7 @@ func TestTimeoutResponse(t *testing.T) {
 	test := func(keycloakProvider bool) {
 		// Disables client's certificate authority validation, in order to
 		// successfully mock https requests
-		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		// http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
 		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		}))
@@ -100,7 +103,7 @@ func TestTimeoutResponse(t *testing.T) {
 			ts.URL[8:len(ts.URL)],
 			"exampleAud",
 			"SomeControlPlane",
-			keycloakProvider)
+			keycloakProvider, true)
 
 		ts.URL = ts.URL + "/oauth/token"
 
@@ -139,7 +142,8 @@ func TestReqOK(t *testing.T) {
 			ts.URL[8:len(ts.URL)],
 			"exampleAud",
 			ts.URL[8:len(ts.URL)],
-			keycloakProvider)
+			keycloakProvider,
+			true)
 		ts.URL = ts.URL + "/oauth/token"
 
 		if err != nil {
@@ -156,7 +160,7 @@ func TestReqFail(t *testing.T) {
 	test := func(keycloakProvider bool) {
 		// Disables client's certificate authority validation, in order to
 		// successfully mock https requests
-		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		// http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
 		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Any response different than 200 (http.StatusOK) is an error.
@@ -169,7 +173,8 @@ func TestReqFail(t *testing.T) {
 			ts.URL[8:len(ts.URL)],
 			"exampleAud",
 			ts.URL[8:len(ts.URL)],
-			keycloakProvider)
+			keycloakProvider,
+			true)
 		ts.URL = ts.URL + "/oauth/token"
 
 		if err != nil {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -57,8 +57,6 @@ func TestInvalidAuth0DomainValue(t *testing.T) {
 
 func TestServerDown(t *testing.T) {
 	test := func(keycloakProvider bool) {
-		// http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-
 		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		}))
 
@@ -91,7 +89,6 @@ func TestTimeoutResponse(t *testing.T) {
 	test := func(keycloakProvider bool) {
 		// Disables client's certificate authority validation, in order to
 		// successfully mock https requests
-		// http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
 		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		}))
@@ -160,7 +157,6 @@ func TestReqFail(t *testing.T) {
 	test := func(keycloakProvider bool) {
 		// Disables client's certificate authority validation, in order to
 		// successfully mock https requests
-		// http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
 		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Any response different than 200 (http.StatusOK) is an error.

--- a/cyral/provider.go
+++ b/cyral/provider.go
@@ -11,12 +11,12 @@ import (
 )
 
 const (
-	keycloak                  = "keycloak"
-	auth0                     = "auth0"
-	EnvVarClientID            = "CYRAL_TF_CLIENT_ID"
-	EnvVarClientSecret        = "CYRAL_TF_CLIENT_SECRET"
-	EnvVarCPURL               = "CYRAL_TF_CONTROL_PLANE"
-	EnvVarTLSSkipVerifyEnable = "CYRAL_TF_TLS_SKIP_VERIFY_ENABLE"
+	keycloak            = "keycloak"
+	auth0               = "auth0"
+	EnvVarClientID      = "CYRAL_TF_CLIENT_ID"
+	EnvVarClientSecret  = "CYRAL_TF_CLIENT_SECRET"
+	EnvVarCPURL         = "CYRAL_TF_CONTROL_PLANE"
+	EnvVarTLSSkipVerify = "CYRAL_TF_TLS_SKIP_VERIFY"
 )
 
 // Provider defines and initializes the Cyral provider
@@ -79,11 +79,11 @@ func Provider() *schema.Provider {
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc(EnvVarCPURL, nil),
 			},
-			"tls_skip_verify_enable": {
+			"tls_skip_verify": {
 				Type:        schema.TypeBool,
 				Description: "Define the TLS verification or not to make request in control_plane",
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc(EnvVarTLSSkipVerifyEnable, nil),
+				DefaultFunc: schema.EnvDefaultFunc(EnvVarTLSSkipVerify, nil),
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
@@ -150,13 +150,13 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	auth0Domain := d.Get("auth0_domain").(string)
 	auth0Audience := d.Get("auth0_audience").(string)
 	controlPlane := d.Get("control_plane").(string)
-	tlsSkipVerifyEnable := d.Get("tls_skip_verify_enable").(bool)
+	tlsSkipVerify := d.Get("tls_skip_verify").(bool)
 
-	log.Printf("[DEBUG] auth0Domain: %s ; auth0Audience: %s ; controlPlane: %s ; tlsSkipVerifyEnable: %t",
-		auth0Domain, clientSecret, controlPlane, tlsSkipVerifyEnable)
+	log.Printf("[DEBUG] auth0Domain: %s ; auth0Audience: %s ; controlPlane: %s ; tlsSkipVerify: %t",
+		auth0Domain, clientSecret, controlPlane, tlsSkipVerify)
 
 	c, err := client.NewClient(clientID, clientSecret, auth0Domain, auth0Audience,
-		controlPlane, keycloakProvider, tlsSkipVerifyEnable)
+		controlPlane, keycloakProvider, tlsSkipVerify)
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,

--- a/cyral/provider.go
+++ b/cyral/provider.go
@@ -81,6 +81,7 @@ func Provider() *schema.Provider {
 			},
 			"tls_skip_verify_enable": {
 				Type:        schema.TypeBool,
+				Description: "Define the TLS verification or not to make request in control_plane",
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc(EnvVarTLSSkipVerifyEnable, nil),
 			},

--- a/cyral/provider.go
+++ b/cyral/provider.go
@@ -11,11 +11,12 @@ import (
 )
 
 const (
-	keycloak           = "keycloak"
-	auth0              = "auth0"
-	EnvVarClientID     = "CYRAL_TF_CLIENT_ID"
-	EnvVarClientSecret = "CYRAL_TF_CLIENT_SECRET"
-	EnvVarCPURL        = "CYRAL_TF_CONTROL_PLANE"
+	keycloak                  = "keycloak"
+	auth0                     = "auth0"
+	EnvVarClientID            = "CYRAL_TF_CLIENT_ID"
+	EnvVarClientSecret        = "CYRAL_TF_CLIENT_SECRET"
+	EnvVarCPURL               = "CYRAL_TF_CONTROL_PLANE"
+	EnvVarTLSSkipVerifyEnable = "CYRAL_TF_TLS_SKIP_VERIFY_ENABLE"
 )
 
 // Provider defines and initializes the Cyral provider
@@ -77,6 +78,11 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc(EnvVarCPURL, nil),
+			},
+			"tls_skip_verify_enable": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc(EnvVarTLSSkipVerifyEnable, nil),
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
@@ -143,12 +149,13 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	auth0Domain := d.Get("auth0_domain").(string)
 	auth0Audience := d.Get("auth0_audience").(string)
 	controlPlane := d.Get("control_plane").(string)
+	tlsSkipVerifyEnable := d.Get("tls_skip_verify_enable").(bool)
 
-	log.Printf("[DEBUG] auth0Domain: %s ; auth0Audience: %s ; controlPlane: %s",
-		auth0Domain, clientSecret, controlPlane)
+	log.Printf("[DEBUG] auth0Domain: %s ; auth0Audience: %s ; controlPlane: %s ; tlsSkipVerifyEnable: %t",
+		auth0Domain, clientSecret, controlPlane, tlsSkipVerifyEnable)
 
 	c, err := client.NewClient(clientID, clientSecret, auth0Domain, auth0Audience,
-		controlPlane, keycloakProvider)
+		controlPlane, keycloakProvider, tlsSkipVerifyEnable)
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,6 @@ provider "cyral" {
     client_id = ""     # optional
     client_secret = "" # optional
     control_plane = "some-cp.cyral.com:8000"
-    tls_skip_verify_enable = true
 }
 ```
 
@@ -38,7 +37,6 @@ provider "cyral" {
     client_id = ""     # optional
     client_secret = "" # optional
     control_plane = "some-cp.cyral.com:8000"
-    tls_skip_verify_enable = true
 }
 ```
 
@@ -54,14 +52,14 @@ provider "cyral" {
 
 ---
 
-Authentication parameters `client_id`, `client_secret` and `tls_skip_verify_enable` are defined as optional in the provider body once they can be set through environment variables in order to avoid storing secrets in source code repositories. The environment variables corresponds to `CYRAL_TF_CLIENT_ID`, `CYRAL_TF_CLIENT_SECRET` and `CYRAL_TF_TLS_SKIP_VERIFY_ENABLE` respectivelly and can be defined as follows:
+Authentication parameters `client_id`, `client_secret` and `tls_skip_verify` are defined as optional in the provider body once they can be set through environment variables in order to avoid storing secrets in source code repositories. The environment variables corresponds to `CYRAL_TF_CLIENT_ID`, `CYRAL_TF_CLIENT_SECRET` and `CYRAL_TF_TLS_SKIP_VERIFY` respectivelly and can be defined as follows:
 
 - Linux/Mac
 
 ```bash
 export CYRAL_TF_CLIENT_ID=""
 export CYRAL_TF_CLIENT_SECRET=""
-export CYRAL_TF_TLS_SKIP_VERIFY_ENABLE=true
+export CYRAL_TF_TLS_SKIP_VERIFY=true
 ```
 
 - Windows
@@ -69,7 +67,7 @@ export CYRAL_TF_TLS_SKIP_VERIFY_ENABLE=true
 ```
 set CYRAL_TF_CLIENT_ID=""
 set CYRAL_TF_CLIENT_SECRET=""
-set CYRAL_TF_TLS_SKIP_VERIFY_ENABLE=true
+set CYRAL_TF_TLS_SKIP_VERIFY=true
 ```
 
 ### Provider Credentials - UI

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ provider "cyral" {
 - `client_id` - (Optional) Client id used to authenticate against the Control Plane.
 - `client_secret` - (Optional) Client secret used to authenticate against the Control Plane.
 - `control_plane` - (Required) Control plane host and API port (ex: `some-cp.cyral.com:8000`)
-- `tls_skip_verify_enable` - (Optional) Define the TLS verification or not to make request in control_plane
+- `tls_skip_verify` - (Optional) Specifies if the client will verify the TLS server certificate used by the control plane. If set to `true`, the client will not verify the server certificate, hence, it will allow insecure connections to be established. This should be set only for testing and is not recommended to be used in production environments. Can be set through the `CYRAL_TF_TLS_SKIP_VERIFY` environment variable. Defaults to `false`.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ provider "cyral" {
     client_id = ""     # optional
     client_secret = "" # optional
     control_plane = "some-cp.cyral.com:8000"
+    tls_skip_verify_enable = true
 }
 ```
 
@@ -37,6 +38,7 @@ provider "cyral" {
     client_id = ""     # optional
     client_secret = "" # optional
     control_plane = "some-cp.cyral.com:8000"
+    tls_skip_verify_enable = true
 }
 ```
 
@@ -48,16 +50,18 @@ provider "cyral" {
 - `client_id` - (Optional) Client id used to authenticate against the Control Plane.
 - `client_secret` - (Optional) Client secret used to authenticate against the Control Plane.
 - `control_plane` - (Required) Control plane host and API port (ex: `some-cp.cyral.com:8000`)
+- `tls_skip_verify_enable` - (Optional) Define the TLS verification or not to make request in control_plane
 
 ---
 
-Authentication parameters `client_id` and `client_secret` are defined as optional in the provider body once they can be set through environment variables in order to avoid storing secrets in source code repositories. The environment variables corresponds to `CYRAL_TF_CLIENT_ID` and `CYRAL_TF_CLIENT_SECRET` respectivelly and can be defined as follows:
+Authentication parameters `client_id`, `client_secret` and `tls_skip_verify_enable` are defined as optional in the provider body once they can be set through environment variables in order to avoid storing secrets in source code repositories. The environment variables corresponds to `CYRAL_TF_CLIENT_ID`, `CYRAL_TF_CLIENT_SECRET` and `CYRAL_TF_TLS_SKIP_VERIFY_ENABLE` respectivelly and can be defined as follows:
 
 - Linux/Mac
 
 ```bash
 export CYRAL_TF_CLIENT_ID=""
 export CYRAL_TF_CLIENT_SECRET=""
+export CYRAL_TF_TLS_SKIP_VERIFY_ENABLE=true
 ```
 
 - Windows
@@ -65,6 +69,7 @@ export CYRAL_TF_CLIENT_SECRET=""
 ```
 set CYRAL_TF_CLIENT_ID=""
 set CYRAL_TF_CLIENT_SECRET=""
+set CYRAL_TF_TLS_SKIP_VERIFY_ENABLE=true
 ```
 
 ### Provider Credentials - UI


### PR DESCRIPTION
## Description of the change

> Create field in our provider that support TLS option and Add support to M1 architecture in macOs

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

> Create an resource in a CP that don't have a valid cerificate, and create an repository and policies.
Runned all the tests
