### PR TITLE
ENG-8591: Change repo account resource to support GCP Secret Manager

### DIFF
--- a/cyral/resource_cyral_repository_local_account.go
+++ b/cyral/resource_cyral_repository_local_account.go
@@ -195,6 +195,34 @@ func (resource *KubernetesSecretResource) ReadFromSchema(d *schema.ResourceData)
 	}
 }
 
+type GcpSecretManagerResource struct {
+	DatabaseName string `json:"databaseName"`
+	RepoAccount  string `json:"repoAccount"`
+	SecretName   string `json:"secretName"`
+}
+
+func (resource GcpSecretManagerResource) WriteToSchema(d *schema.ResourceData) {
+	d.Set("gcp_secret_manager", []interface{}{
+		map[string]interface{}{
+			"database_name": resource.DatabaseName,
+			"local_account": resource.RepoAccount,
+			"secret_name":   resource.SecretName,
+		},
+	})
+}
+
+func (resource *GcpSecretManagerResource) ReadFromSchema(d *schema.ResourceData) {
+	data := d.Get("gcp_secret_manager").(*schema.Set)
+
+	for _, id := range data.List() {
+		idMap := id.(map[string]interface{})
+
+		resource.DatabaseName = idMap["database_name"].(string)
+		resource.RepoAccount = idMap["local_account"].(string)
+		resource.SecretName = idMap["secret_name"].(string)
+	}
+}
+
 type CreateRepoAccountResponse struct {
 	UUID string `json:"uuid"`
 }
@@ -214,6 +242,7 @@ type RepositoryLocalAccountResource struct {
 	HashicorpVault      *HashicorpVaultResource      `json:"hashicorpVault,omitempty"`
 	EnvironmentVariable *EnvironmentVariableResource `json:"environmentVariable,omitempty"`
 	KubernetesSecret    *KubernetesSecretResource    `json:"kubernetesSecret,omitempty"`
+	GcpSecretManager    *GcpSecretManagerResource    `json:"gcpSecretManager,omitempty"`
 }
 
 func (repoAccount RepositoryLocalAccountResource) WriteToSchema(d *schema.ResourceData) {
@@ -231,6 +260,8 @@ func (repoAccount RepositoryLocalAccountResource) WriteToSchema(d *schema.Resour
 		repoAccount.EnvironmentVariable.WriteToSchema(d)
 	} else if repoAccount.KubernetesSecret != nil {
 		repoAccount.KubernetesSecret.WriteToSchema(d)
+	} else if repoAccount.GcpSecretManager != nil {
+		repoAccount.GcpSecretManager.WriteToSchema(d)
 	}
 
 	log.Printf("[DEBUG] RepositoryLocalAccountResource - WriteToSchema END")
@@ -261,6 +292,9 @@ func (repoAccount *RepositoryLocalAccountResource) ReadFromSchema(d *schema.Reso
 	} else if _, hasKubernetesSecret := d.GetOk("kubernetes_secret"); hasKubernetesSecret {
 		repoAccount.KubernetesSecret = &KubernetesSecretResource{}
 		repoAccount.KubernetesSecret.ReadFromSchema(d)
+	} else if _, hasGcpSecretManager := d.GetOk("gcp_secret_manager"); hasGcpSecretManager {
+		repoAccount.GcpSecretManager = &GcpSecretManagerResource{}
+		repoAccount.GcpSecretManager.ReadFromSchema(d)
 	}
 
 	log.Printf("[DEBUG] RepositoryLocalAccountResource - ReadFromSchema END")
@@ -288,6 +322,7 @@ func resourceRepositoryLocalAccount() *schema.Resource {
 		"enviroment_variable", // Deprecated: should be removed in the next MAJOR release
 		"environment_variable",
 		"kubernetes_secret",
+		"gcp_secret_manager",
 	}
 
 	databaseNameDescription := "Database name that the local account corresponds to."
@@ -466,6 +501,33 @@ func resourceRepositoryLocalAccount() *schema.Resource {
 		},
 	}
 
+	gcpSecretManagerSchema := &schema.Schema{
+		Description:  "Credential option to set the local account from GCP Secret Manager.",
+		Type:         schema.TypeSet,
+		Optional:     true,
+		ExactlyOneOf: secretManagersTypes,
+		MaxItems:     1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"database_name": {
+					Description: databaseNameDescription,
+					Type:        schema.TypeString,
+					Optional:    true,
+				},
+				"local_account": {
+					Description: localAccountDescription,
+					Type:        schema.TypeString,
+					Required:    true,
+				},
+				"secret_name": {
+					Description: "The unique identifier of the secret in GCP Secret Manager. Should obey one of the following formats: `projects/<project-name>/secrets/<secret-name>` or `projects/<project-name>/secrets/<secret-name>/versions/<version>`.",
+					Type:        schema.TypeString,
+					Required:    true,
+				},
+			},
+		},
+	}
+
 	return &schema.Resource{
 		Description: "Provides a resource to handle [repository local accounts](https://cyral.com/docs/using-cyral/sso-auth-users#give-your-sidecar-access-to-the-local-account).",
 		CreateContext: CreateResource(
@@ -530,6 +592,7 @@ func resourceRepositoryLocalAccount() *schema.Resource {
 			"enviroment_variable":  &environmentVariableSchemaDeprecated,
 			"environment_variable": environmentVariableSchema,
 			"kubernetes_secret":    kubernetesSecretSchema,
+			"gcp_secret_manager":   gcpSecretManagerSchema,
 		},
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,

--- a/docs/resources/repository_local_account.md
+++ b/docs/resources/repository_local_account.md
@@ -83,6 +83,19 @@ resource "cyral_repository_local_account" "some_resource_name" {
 }
 ```
 
+### GCP Secret Manager
+
+```hcl
+resource "cyral_repository_local_account" "some_resource_name" {
+    repository_id = cyral_repository.SOME_REPOSITORY_RESOURCE_NAME.id
+    gcp_secret_manager {
+        database_name = ""
+        local_account = ""
+        secret_name = ""
+    }
+}
+```
+
 ## Argument Reference
 
 - `repository_id` - (Required) ID of the repository that will be used by the local account.
@@ -92,6 +105,7 @@ resource "cyral_repository_local_account" "some_resource_name" {
 - `hashicorp_vault` - (Optional) Credential option to set the local account from Hashicorp Vault. See [hashicorp_vault](#hashicorp_vault) below for more details.
 - `environment_variable` - (Optional) Credential option to set the local account from Environment Variable. See [environment_variable](#environment_variable) below for more details.
 - `kubernetes_secret` - (Optional) Credential option to set the local account from Kubernetes Secret. See [kubernetes_secret](#kubernetes_secret) below for more details.
+- `gcp_secret_manager` - (Optional) Credential option to set the local account from GCP Secret Manager. See [gcp_secret_manager](#gcp_secret_manager) below for more details.
 
 ### aws_iam
 
@@ -141,6 +155,14 @@ The `kubernetes_secret` object supports the following arguments:
 - `local_account` - (Required) Local account name.
 - `secret_name` - (Required) Name of the secret in kubernetes.
 - `secret_key` - (Required) Name of the key that stores the credentials within the secret.
+
+### gcp_secret_manager
+
+The `gcp_secret_manager` object supports the following arguments:
+
+- `database_name` - (Optional) Database name that the local account corresponds to.
+- `local_account` - (Required) Local account name.
+- `secret_name` - (Required) The unique identifier of the secret in GCP Secret Manager. Should obey one of the following formats: `projects/<project-name>/secrets/<secret-name>` or `projects/<project-name>/secrets/<secret-name>/versions/<version>`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
## Description of the change

ENG-8591: Terraform provider - Update repo account resource to support GCP Secret Manager

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Jira issue referenced in commit message and/or PR title

### Testing

Manual and automated tests