### PR TITLE
ENG-8610: Fix memory referencing issue and refactor resources

### DIFF
--- a/cyral/data_source_cyral_saml_certificate.go
+++ b/cyral/data_source_cyral_saml_certificate.go
@@ -18,7 +18,7 @@ func dataSourceSAMLCertificate() *schema.Resource {
 			CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 				return fmt.Sprintf("https://%s/v1/integrations/saml/rsa/cert", c.ControlPlane)
 			},
-			ResponseData: &SAMLCertificateData{},
+			NewResponseData: func() ResponseData { return &SAMLCertificateData{} },
 		}),
 		Schema: map[string]*schema.Schema{
 			"id": {
@@ -42,9 +42,8 @@ type SAMLCertificateData struct {
 	Certificate string `json:"certificate,omitempty"`
 }
 
-func (data SAMLCertificateData) WriteToSchema(d *schema.ResourceData) {
+func (data SAMLCertificateData) WriteToSchema(d *schema.ResourceData) error {
 	d.SetId(uuid.New().String())
 	d.Set("certificate", data.Certificate)
+	return nil
 }
-
-func (data *SAMLCertificateData) ReadFromSchema(d *schema.ResourceData) {}

--- a/cyral/resource.go
+++ b/cyral/resource.go
@@ -20,9 +20,9 @@ const (
 
 type URLCreatorFunc = func(d *schema.ResourceData, c *client.Client) string
 
-type NewResourceData func(d *schema.ResourceData) (interface{}, error)
+type NewResourceDataFunc func(d *schema.ResourceData) (interface{}, error)
 
-type NewResponseData func() ResponseData
+type NewResponseDataFunc func() ResponseData
 
 type ResponseData interface {
 	WriteToSchema(d *schema.ResourceData) error
@@ -32,8 +32,8 @@ type ResourceOperationConfig struct {
 	Name            string
 	HttpMethod      string
 	CreateURL       URLCreatorFunc
-	NewResourceData NewResourceData
-	NewResponseData NewResponseData
+	NewResourceData NewResourceDataFunc
+	NewResponseData NewResponseDataFunc
 }
 
 func CreateResource(createConfig, readConfig ResourceOperationConfig) schema.CreateContextFunc {
@@ -110,6 +110,10 @@ func HandleRequest(
 
 type IDBasedResponse struct {
 	ID string `json:"id"`
+}
+
+func NewIDBasedResponse() ResponseData {
+	return new(IDBasedResponse)
 }
 
 func (response IDBasedResponse) WriteToSchema(d *schema.ResourceData) error {

--- a/cyral/resource.go
+++ b/cyral/resource.go
@@ -112,10 +112,6 @@ type IDBasedResponse struct {
 	ID string `json:"id"`
 }
 
-func NewIDBasedResponse() ResponseData {
-	return new(IDBasedResponse)
-}
-
 func (response IDBasedResponse) WriteToSchema(d *schema.ResourceData) error {
 	d.SetId(response.ID)
 	return nil

--- a/cyral/resource.go
+++ b/cyral/resource.go
@@ -11,122 +11,108 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+const (
+	create = "create"
+	read   = "read"
+	update = "update"
+	delete = "delete"
+)
+
 type URLCreatorFunc = func(d *schema.ResourceData, c *client.Client) string
 
-type SchemaDataHandler interface {
-	WriteToSchema(d *schema.ResourceData)
-	ReadFromSchema(d *schema.ResourceData)
+type ResourceData interface {
+	ReadFromSchema(d *schema.ResourceData) error
+}
+
+type ResponseData interface {
+	WriteToSchema(d *schema.ResourceData) error
 }
 
 type ResourceOperationConfig struct {
-	Name         string
-	HttpMethod   string
-	CreateURL    URLCreatorFunc
-	ResourceData SchemaDataHandler
-	ResponseData SchemaDataHandler
+	Name            string
+	HttpMethod      string
+	CreateURL       URLCreatorFunc
+	NewResourceData func() ResourceData
+	NewResponseData func() ResponseData
+}
+
+func CreateResource(createConfig, readConfig ResourceOperationConfig) schema.CreateContextFunc {
+	return HandleRequest(create, createConfig, &readConfig)
+}
+
+func ReadResource(readConfig ResourceOperationConfig) schema.ReadContextFunc {
+	return HandleRequest(read, readConfig, nil)
+}
+
+func UpdateResource(updateConfig, readConfig ResourceOperationConfig) schema.UpdateContextFunc {
+	return HandleRequest(update, updateConfig, &readConfig)
+}
+
+func DeleteResource(deleteConfig ResourceOperationConfig) schema.DeleteContextFunc {
+	return HandleRequest(delete, deleteConfig, nil)
+}
+
+func HandleRequest(
+	operationType string,
+	config ResourceOperationConfig,
+	consecutiveConfig *ResourceOperationConfig,
+) func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
+	return func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+		log.Printf("[DEBUG] Init %s", config.Name)
+		c := m.(*client.Client)
+
+		var resourceData ResourceData
+		if config.NewResourceData != nil {
+			if resourceData = config.NewResourceData(); resourceData != nil {
+				if err := resourceData.ReadFromSchema(d); err != nil {
+					return createError(
+						fmt.Sprintf("Unable to %s resource", operationType),
+						err.Error(),
+					)
+				}
+			}
+		}
+
+		url := config.CreateURL(d, c)
+
+		body, err := c.DoRequest(url, config.HttpMethod, resourceData)
+		if err != nil {
+			return createError(
+				fmt.Sprintf("Unable to %s resource", operationType),
+				err.Error(),
+			)
+		}
+
+		if config.NewResponseData != nil {
+			if responseData := config.NewResponseData(); responseData != nil {
+				if err := json.Unmarshal(body, responseData); err != nil {
+					return createError("Unable to unmarshall JSON", err.Error())
+				}
+				log.Printf("[DEBUG] Response body (unmarshalled): %#v", responseData)
+
+				if err := responseData.WriteToSchema(d); err != nil {
+					return createError(
+						fmt.Sprintf("Unable to %s resource", operationType),
+						err.Error(),
+					)
+				}
+			}
+		}
+
+		log.Printf("[DEBUG] End %s", config.Name)
+
+		if consecutiveConfig != nil {
+			return HandleRequest(read, *consecutiveConfig, nil)(ctx, d, m)
+		}
+		return diag.Diagnostics{}
+	}
 }
 
 type IDBasedResponse struct {
 	ID string `json:"id"`
 }
 
-func (response IDBasedResponse) WriteToSchema(d *schema.ResourceData) {
+func (response IDBasedResponse) WriteToSchema(d *schema.ResourceData) error {
 	d.SetId(response.ID)
-}
-
-func (response *IDBasedResponse) ReadFromSchema(d *schema.ResourceData) {
-	response.ID = d.Id()
-}
-
-func CreateResource(createConfig ResourceOperationConfig, readConfig ResourceOperationConfig) schema.CreateContextFunc {
-	return func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-		log.Printf("[DEBUG] Init %s", createConfig.Name)
-		c := m.(*client.Client)
-
-		createConfig.ResourceData.ReadFromSchema(d)
-
-		url := createConfig.CreateURL(d, c)
-
-		body, err := c.DoRequest(url, createConfig.HttpMethod, createConfig.ResourceData)
-		if err != nil {
-			return createError("Unable to create integration", fmt.Sprintf("%v", err))
-		}
-
-		if err := json.Unmarshal(body, &createConfig.ResponseData); err != nil {
-			return createError("Unable to unmarshall JSON", fmt.Sprintf("%v", err))
-		}
-		log.Printf("[DEBUG] Response body (unmarshalled): %#v", createConfig.ResponseData)
-
-		createConfig.ResponseData.WriteToSchema(d)
-
-		log.Printf("[DEBUG] End %s", createConfig.Name)
-
-		return ReadResource(readConfig)(ctx, d, m)
-	}
-}
-
-func ReadResource(config ResourceOperationConfig) schema.ReadContextFunc {
-	return func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-		log.Printf("[DEBUG] Init %s", config.Name)
-		c := m.(*client.Client)
-
-		url := config.CreateURL(d, c)
-
-		body, err := c.DoRequest(url, config.HttpMethod, nil)
-		if err != nil {
-			return createError(fmt.Sprintf("Unable to read integration. IntegrationID: %s",
-				d.Id()), fmt.Sprintf("%v", err))
-		}
-
-		if err := json.Unmarshal(body, &config.ResponseData); err != nil {
-			return createError("Unable to unmarshall JSON", fmt.Sprintf("%v", err))
-		}
-		log.Printf("[DEBUG] Response body (unmarshalled): %#v", config.ResponseData)
-
-		config.ResponseData.WriteToSchema(d)
-
-		log.Printf("[DEBUG] End %s", config.Name)
-
-		return diag.Diagnostics{}
-	}
-}
-
-func UpdateResource(updateConfig ResourceOperationConfig, readConfig ResourceOperationConfig) schema.UpdateContextFunc {
-	return func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-		log.Printf("[DEBUG] Init %s", updateConfig.Name)
-		c := m.(*client.Client)
-
-		updateConfig.ResourceData.ReadFromSchema(d)
-
-		url := updateConfig.CreateURL(d, c)
-
-		if _, err := c.DoRequest(url, updateConfig.HttpMethod, updateConfig.ResourceData); err != nil {
-			return createError("Unable to update integration", fmt.Sprintf("%v", err))
-		}
-
-		log.Printf("[DEBUG] End %s", updateConfig.Name)
-
-		return ReadResource(readConfig)(ctx, d, m)
-	}
-}
-
-func DeleteResource(config ResourceOperationConfig) schema.DeleteContextFunc {
-	return func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-		log.Printf("[DEBUG] Init %s", config.Name)
-		c := m.(*client.Client)
-
-		if config.ResourceData != nil {
-			config.ResourceData.ReadFromSchema(d)
-		}
-
-		url := config.CreateURL(d, c)
-
-		if _, err := c.DoRequest(url, config.HttpMethod, config.ResourceData); err != nil {
-			return createError("Unable to delete integration", fmt.Sprintf("%v", err))
-		}
-
-		log.Printf("[DEBUG] End %s", config.Name)
-
-		return diag.Diagnostics{}
-	}
+	return nil
 }

--- a/cyral/resource_cyral_integration_datadog.go
+++ b/cyral/resource_cyral_integration_datadog.go
@@ -14,15 +14,17 @@ type DatadogIntegration struct {
 	APIKey string `json:"apiKey"`
 }
 
-func (data DatadogIntegration) WriteToSchema(d *schema.ResourceData) {
+func (data DatadogIntegration) WriteToSchema(d *schema.ResourceData) error {
 	d.Set("name", data.Name)
 	d.Set("api_key", data.APIKey)
+	return nil
 }
 
-func (data *DatadogIntegration) ReadFromSchema(d *schema.ResourceData) {
+func (data *DatadogIntegration) ReadFromSchema(d *schema.ResourceData) error {
 	data.ID = d.Id()
 	data.Name = d.Get("name").(string)
 	data.APIKey = d.Get("api_key").(string)
+	return nil
 }
 
 var ReadDatadogConfig = ResourceOperationConfig{
@@ -31,7 +33,7 @@ var ReadDatadogConfig = ResourceOperationConfig{
 	CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 		return fmt.Sprintf("https://%s/v1/integrations/datadog/%s", c.ControlPlane, d.Id())
 	},
-	ResponseData: &DatadogIntegration{},
+	NewResponseData: func() ResponseData { return new(DatadogIntegration) },
 }
 
 func resourceIntegrationDatadog() *schema.Resource {
@@ -45,8 +47,8 @@ func resourceIntegrationDatadog() *schema.Resource {
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					return fmt.Sprintf("https://%s/v1/integrations/datadog", c.ControlPlane)
 				},
-				ResourceData: &DatadogIntegration{},
-				ResponseData: &IDBasedResponse{},
+				NewResourceData: func() ResourceData { return new(DatadogIntegration) },
+				NewResponseData: func() ResponseData { return new(IDBasedResponse) },
 			}, ReadDatadogConfig,
 		),
 		ReadContext: ReadResource(ReadDatadogConfig),
@@ -57,7 +59,7 @@ func resourceIntegrationDatadog() *schema.Resource {
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					return fmt.Sprintf("https://%s/v1/integrations/datadog/%s", c.ControlPlane, d.Id())
 				},
-				ResourceData: &DatadogIntegration{},
+				NewResourceData: func() ResourceData { return new(DatadogIntegration) },
 			}, ReadDatadogConfig,
 		),
 		DeleteContext: DeleteResource(

--- a/cyral/resource_cyral_integration_datadog.go
+++ b/cyral/resource_cyral_integration_datadog.go
@@ -14,17 +14,16 @@ type DatadogIntegration struct {
 	APIKey string `json:"apiKey"`
 }
 
-func NewDatadogIntegrationFromSchema(d *schema.ResourceData) (interface{}, error) {
-	return &DatadogIntegration{
-		ID:     d.Id(),
-		Name:   d.Get("name").(string),
-		APIKey: d.Get("api_key").(string),
-	}, nil
-}
-
 func (data DatadogIntegration) WriteToSchema(d *schema.ResourceData) error {
 	d.Set("name", data.Name)
 	d.Set("api_key", data.APIKey)
+	return nil
+}
+
+func (data *DatadogIntegration) ReadFromSchema(d *schema.ResourceData) error {
+	data.ID = d.Id()
+	data.Name = d.Get("name").(string)
+	data.APIKey = d.Get("api_key").(string)
 	return nil
 }
 
@@ -34,7 +33,7 @@ var ReadDatadogConfig = ResourceOperationConfig{
 	CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 		return fmt.Sprintf("https://%s/v1/integrations/datadog/%s", c.ControlPlane, d.Id())
 	},
-	NewResponseData: func() ResponseData { return new(DatadogIntegration) },
+	NewResponseData: func() ResponseData { return &DatadogIntegration{} },
 }
 
 func resourceIntegrationDatadog() *schema.Resource {
@@ -48,8 +47,8 @@ func resourceIntegrationDatadog() *schema.Resource {
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					return fmt.Sprintf("https://%s/v1/integrations/datadog", c.ControlPlane)
 				},
-				NewResourceData: NewDatadogIntegrationFromSchema,
-				NewResponseData: NewIDBasedResponse,
+				NewResourceData: func() ResourceData { return &DatadogIntegration{} },
+				NewResponseData: func() ResponseData { return &IDBasedResponse{} },
 			}, ReadDatadogConfig,
 		),
 		ReadContext: ReadResource(ReadDatadogConfig),
@@ -60,7 +59,7 @@ func resourceIntegrationDatadog() *schema.Resource {
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					return fmt.Sprintf("https://%s/v1/integrations/datadog/%s", c.ControlPlane, d.Id())
 				},
-				NewResourceData: NewDatadogIntegrationFromSchema,
+				NewResourceData: func() ResourceData { return &DatadogIntegration{} },
 			}, ReadDatadogConfig,
 		),
 		DeleteContext: DeleteResource(

--- a/cyral/resource_cyral_integration_datadog.go
+++ b/cyral/resource_cyral_integration_datadog.go
@@ -14,7 +14,7 @@ type DatadogIntegration struct {
 	APIKey string `json:"apiKey"`
 }
 
-func NewDatadogIntegration(d *schema.ResourceData) (interface{}, error) {
+func NewDatadogIntegrationFromSchema(d *schema.ResourceData) (interface{}, error) {
 	return &DatadogIntegration{
 		ID:     d.Id(),
 		Name:   d.Get("name").(string),
@@ -48,8 +48,8 @@ func resourceIntegrationDatadog() *schema.Resource {
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					return fmt.Sprintf("https://%s/v1/integrations/datadog", c.ControlPlane)
 				},
-				NewResourceData: NewDatadogIntegration,
-				NewResponseData: func() ResponseData { return new(IDBasedResponse) },
+				NewResourceData: NewDatadogIntegrationFromSchema,
+				NewResponseData: NewIDBasedResponse,
 			}, ReadDatadogConfig,
 		),
 		ReadContext: ReadResource(ReadDatadogConfig),
@@ -60,7 +60,7 @@ func resourceIntegrationDatadog() *schema.Resource {
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					return fmt.Sprintf("https://%s/v1/integrations/datadog/%s", c.ControlPlane, d.Id())
 				},
-				NewResourceData: NewDatadogIntegration,
+				NewResourceData: NewDatadogIntegrationFromSchema,
 			}, ReadDatadogConfig,
 		),
 		DeleteContext: DeleteResource(

--- a/cyral/resource_cyral_integration_datadog.go
+++ b/cyral/resource_cyral_integration_datadog.go
@@ -14,16 +14,17 @@ type DatadogIntegration struct {
 	APIKey string `json:"apiKey"`
 }
 
+func NewDatadogIntegration(d *schema.ResourceData) (interface{}, error) {
+	return &DatadogIntegration{
+		ID:     d.Id(),
+		Name:   d.Get("name").(string),
+		APIKey: d.Get("api_key").(string),
+	}, nil
+}
+
 func (data DatadogIntegration) WriteToSchema(d *schema.ResourceData) error {
 	d.Set("name", data.Name)
 	d.Set("api_key", data.APIKey)
-	return nil
-}
-
-func (data *DatadogIntegration) ReadFromSchema(d *schema.ResourceData) error {
-	data.ID = d.Id()
-	data.Name = d.Get("name").(string)
-	data.APIKey = d.Get("api_key").(string)
 	return nil
 }
 
@@ -47,7 +48,7 @@ func resourceIntegrationDatadog() *schema.Resource {
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					return fmt.Sprintf("https://%s/v1/integrations/datadog", c.ControlPlane)
 				},
-				NewResourceData: func() ResourceData { return new(DatadogIntegration) },
+				NewResourceData: NewDatadogIntegration,
 				NewResponseData: func() ResponseData { return new(IDBasedResponse) },
 			}, ReadDatadogConfig,
 		),
@@ -59,7 +60,7 @@ func resourceIntegrationDatadog() *schema.Resource {
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					return fmt.Sprintf("https://%s/v1/integrations/datadog/%s", c.ControlPlane, d.Id())
 				},
-				NewResourceData: func() ResourceData { return new(DatadogIntegration) },
+				NewResourceData: NewDatadogIntegration,
 			}, ReadDatadogConfig,
 		),
 		DeleteContext: DeleteResource(

--- a/cyral/resource_cyral_integration_elk.go
+++ b/cyral/resource_cyral_integration_elk.go
@@ -15,17 +15,19 @@ type ELKIntegration struct {
 	ESURL     string `json:"esUrl"`
 }
 
-func (data ELKIntegration) WriteToSchema(d *schema.ResourceData) {
+func (data ELKIntegration) WriteToSchema(d *schema.ResourceData) error {
 	d.Set("name", data.Name)
 	d.Set("kibana_url", data.KibanaURL)
 	d.Set("es_url", data.ESURL)
+	return nil
 }
 
-func (data *ELKIntegration) ReadFromSchema(d *schema.ResourceData) {
+func (data *ELKIntegration) ReadFromSchema(d *schema.ResourceData) error {
 	data.ID = d.Id()
 	data.Name = d.Get("name").(string)
 	data.KibanaURL = d.Get("kibana_url").(string)
 	data.ESURL = d.Get("es_url").(string)
+	return nil
 }
 
 var ReadELKConfig = ResourceOperationConfig{
@@ -34,7 +36,7 @@ var ReadELKConfig = ResourceOperationConfig{
 	CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 		return fmt.Sprintf("https://%s/v1/integrations/elk/%s", c.ControlPlane, d.Id())
 	},
-	ResponseData: &ELKIntegration{},
+	NewResponseData: func() ResponseData { return &ELKIntegration{} },
 }
 
 func resourceIntegrationELK() *schema.Resource {
@@ -47,8 +49,8 @@ func resourceIntegrationELK() *schema.Resource {
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					return fmt.Sprintf("https://%s/v1/integrations/elk", c.ControlPlane)
 				},
-				ResourceData: &ELKIntegration{},
-				ResponseData: &IDBasedResponse{},
+				NewResourceData: func() ResourceData { return &ELKIntegration{} },
+				NewResponseData: func() ResponseData { return &IDBasedResponse{} },
 			}, ReadELKConfig,
 		),
 		ReadContext: ReadResource(ReadELKConfig),
@@ -59,7 +61,7 @@ func resourceIntegrationELK() *schema.Resource {
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					return fmt.Sprintf("https://%s/v1/integrations/elk/%s", c.ControlPlane, d.Id())
 				},
-				ResourceData: &ELKIntegration{},
+				NewResourceData: func() ResourceData { return &ELKIntegration{} },
 			}, ReadELKConfig,
 		),
 		DeleteContext: DeleteResource(

--- a/cyral/resource_cyral_integration_hcvault.go
+++ b/cyral/resource_cyral_integration_hcvault.go
@@ -8,20 +8,22 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func (data HCVaultIntegration) WriteToSchema(d *schema.ResourceData) {
+func (data HCVaultIntegration) WriteToSchema(d *schema.ResourceData) error {
 	d.Set("auth_method", data.AuthMethod)
 	d.Set("id", data.ID)
 	d.Set("auth_type", data.AuthType)
 	d.Set("name", data.Name)
 	d.Set("server", data.Server)
+	return nil
 }
 
-func (data *HCVaultIntegration) ReadFromSchema(d *schema.ResourceData) {
+func (data *HCVaultIntegration) ReadFromSchema(d *schema.ResourceData) error {
 	data.AuthMethod = d.Get("auth_method").(string)
 	data.ID = d.Get("id").(string)
 	data.AuthType = d.Get("auth_type").(string)
 	data.Name = d.Get("name").(string)
 	data.Server = d.Get("server").(string)
+	return nil
 }
 
 var ReadHCVaultIntegrationConfig = ResourceOperationConfig{
@@ -30,7 +32,7 @@ var ReadHCVaultIntegrationConfig = ResourceOperationConfig{
 	CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 		return fmt.Sprintf("https://%s/v1/integrations/secretProviders/hcvault/%s", c.ControlPlane, d.Id())
 	},
-	ResponseData: &HCVaultIntegration{},
+	NewResponseData: func() ResponseData { return &HCVaultIntegration{} },
 }
 
 func resourceIntegrationHCVault() *schema.Resource {
@@ -43,8 +45,8 @@ func resourceIntegrationHCVault() *schema.Resource {
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					return fmt.Sprintf("https://%s/v1/integrations/secretProviders/hcvault", c.ControlPlane)
 				},
-				ResourceData: &HCVaultIntegration{},
-				ResponseData: &IDBasedResponse{},
+				NewResourceData: func() ResourceData { return &HCVaultIntegration{} },
+				NewResponseData: func() ResponseData { return &IDBasedResponse{} },
 			}, ReadHCVaultIntegrationConfig,
 		),
 		ReadContext: ReadResource(ReadHCVaultIntegrationConfig),
@@ -55,7 +57,7 @@ func resourceIntegrationHCVault() *schema.Resource {
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					return fmt.Sprintf("https://%s/v1/integrations/secretProviders/hcvault/%s", c.ControlPlane, d.Id())
 				},
-				ResourceData: &HCVaultIntegration{},
+				NewResourceData: func() ResourceData { return &HCVaultIntegration{} },
 			}, ReadHCVaultIntegrationConfig,
 		),
 		DeleteContext: DeleteResource(

--- a/cyral/resource_cyral_integration_logstash.go
+++ b/cyral/resource_cyral_integration_logstash.go
@@ -16,20 +16,22 @@ type LogstashIntegration struct {
 	UseTLS                     bool   `json:"useTLS"`
 }
 
-func (data LogstashIntegration) WriteToSchema(d *schema.ResourceData) {
+func (data LogstashIntegration) WriteToSchema(d *schema.ResourceData) error {
 	d.Set("name", data.Name)
 	d.Set("endpoint", data.Endpoint)
 	d.Set("use_mutual_authentication", data.UseMutualAuthentication)
 	d.Set("use_private_certificate_chain", data.UsePrivateCertificateChain)
 	d.Set("use_tls", data.UseTLS)
+	return nil
 }
 
-func (data *LogstashIntegration) ReadFromSchema(d *schema.ResourceData) {
+func (data *LogstashIntegration) ReadFromSchema(d *schema.ResourceData) error {
 	data.Name = d.Get("name").(string)
 	data.Endpoint = d.Get("endpoint").(string)
 	data.UseMutualAuthentication = d.Get("use_mutual_authentication").(bool)
 	data.UsePrivateCertificateChain = d.Get("use_private_certificate_chain").(bool)
 	data.UseTLS = d.Get("use_tls").(bool)
+	return nil
 }
 
 var ReadLogstashConfig = ResourceOperationConfig{
@@ -38,7 +40,7 @@ var ReadLogstashConfig = ResourceOperationConfig{
 	CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 		return fmt.Sprintf("https://%s/v1/integrations/logstash/%s", c.ControlPlane, d.Id())
 	},
-	ResponseData: &LogstashIntegration{},
+	NewResponseData: func() ResponseData { return &LogstashIntegration{} },
 }
 
 func resourceIntegrationLogstash() *schema.Resource {
@@ -51,8 +53,8 @@ func resourceIntegrationLogstash() *schema.Resource {
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					return fmt.Sprintf("https://%s/v1/integrations/logstash", c.ControlPlane)
 				},
-				ResourceData: &LogstashIntegration{},
-				ResponseData: &IDBasedResponse{},
+				NewResourceData: func() ResourceData { return &LogstashIntegration{} },
+				NewResponseData: func() ResponseData { return &IDBasedResponse{} },
 			}, ReadLogstashConfig,
 		),
 		ReadContext: ReadResource(ReadLogstashConfig),
@@ -63,7 +65,7 @@ func resourceIntegrationLogstash() *schema.Resource {
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					return fmt.Sprintf("https://%s/v1/integrations/logstash/%s", c.ControlPlane, d.Id())
 				},
-				ResourceData: &LogstashIntegration{},
+				NewResourceData: func() ResourceData { return &LogstashIntegration{} },
 			}, ReadLogstashConfig,
 		),
 		DeleteContext: DeleteResource(

--- a/cyral/resource_cyral_integration_looker.go
+++ b/cyral/resource_cyral_integration_looker.go
@@ -14,16 +14,18 @@ type LookerIntegration struct {
 	URL          string `json:"url"`
 }
 
-func (data LookerIntegration) WriteToSchema(d *schema.ResourceData) {
+func (data LookerIntegration) WriteToSchema(d *schema.ResourceData) error {
 	d.Set("client_secret", data.ClientSecret)
 	d.Set("client_id", data.ClientId)
 	d.Set("url", data.URL)
+	return nil
 }
 
-func (data *LookerIntegration) ReadFromSchema(d *schema.ResourceData) {
+func (data *LookerIntegration) ReadFromSchema(d *schema.ResourceData) error {
 	data.ClientSecret = d.Get("client_secret").(string)
 	data.ClientId = d.Get("client_id").(string)
 	data.URL = d.Get("url").(string)
+	return nil
 }
 
 var ReadLookerConfig = ResourceOperationConfig{
@@ -32,7 +34,7 @@ var ReadLookerConfig = ResourceOperationConfig{
 	CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 		return fmt.Sprintf("https://%s/v1/integrations/looker/%s", c.ControlPlane, d.Id())
 	},
-	ResponseData: &LookerIntegration{},
+	NewResponseData: func() ResponseData { return &LookerIntegration{} },
 }
 
 func resourceIntegrationLooker() *schema.Resource {
@@ -45,8 +47,8 @@ func resourceIntegrationLooker() *schema.Resource {
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					return fmt.Sprintf("https://%s/v1/integrations/looker", c.ControlPlane)
 				},
-				ResourceData: &LookerIntegration{},
-				ResponseData: &IDBasedResponse{},
+				NewResourceData: func() ResourceData { return &LookerIntegration{} },
+				NewResponseData: func() ResponseData { return &IDBasedResponse{} },
 			}, ReadLookerConfig,
 		),
 		ReadContext: ReadResource(ReadLookerConfig),
@@ -57,7 +59,7 @@ func resourceIntegrationLooker() *schema.Resource {
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					return fmt.Sprintf("https://%s/v1/integrations/looker/%s", c.ControlPlane, d.Id())
 				},
-				ResourceData: &LookerIntegration{},
+				NewResourceData: func() ResourceData { return &LookerIntegration{} },
 			}, ReadLookerConfig,
 		),
 		DeleteContext: DeleteResource(

--- a/cyral/resource_cyral_integration_okta.go
+++ b/cyral/resource_cyral_integration_okta.go
@@ -46,33 +46,41 @@ type ResourceIntegrationOktaPayload struct {
 	Samlp ResourceIntegrationOkta `json:"samlp"`
 }
 
-func (data ResourceIntegrationOktaPayload) WriteToSchema(d *schema.ResourceData) {
+func (data ResourceIntegrationOktaPayload) WriteToSchema(d *schema.ResourceData) error {
 	data.Samlp.WriteToSchema(d)
+	return nil
 }
 
-func (data *ResourceIntegrationOktaPayload) ReadFromSchema(d *schema.ResourceData) {
+func (data *ResourceIntegrationOktaPayload) ReadFromSchema(d *schema.ResourceData) error {
 	data.Samlp.ReadFromSchema(d)
+	return nil
 }
 
 type CreateResourceIntegrationOktaResponse struct {
 	ID string `json:"status"`
 }
 
-func (data CreateResourceIntegrationOktaResponse) WriteToSchema(d *schema.ResourceData) {
+func (data CreateResourceIntegrationOktaResponse) WriteToSchema(d *schema.ResourceData) error {
 	d.SetId("okta")
+	return nil
 }
 
-func (data *CreateResourceIntegrationOktaResponse) ReadFromSchema(d *schema.ResourceData) {
+func (data *CreateResourceIntegrationOktaResponse) ReadFromSchema(d *schema.ResourceData) error {
 	data.ID = "okta"
+	return nil
 }
 
 type ResourceIntegrationOktaIdentityProviderPayload struct {
 	Keycloak KeycloakProvider `json:"keyCloakProvider"`
 }
 
-func (data ResourceIntegrationOktaIdentityProviderPayload) WriteToSchema(d *schema.ResourceData) {}
+func (data ResourceIntegrationOktaIdentityProviderPayload) WriteToSchema(d *schema.ResourceData) error {
+	return nil
+}
 
-func (data *ResourceIntegrationOktaIdentityProviderPayload) ReadFromSchema(d *schema.ResourceData) {}
+func (data *ResourceIntegrationOktaIdentityProviderPayload) ReadFromSchema(d *schema.ResourceData) error {
+	return nil
+}
 
 var ReadResourceIntegrationOktaConfig = ResourceOperationConfig{
 	Name:       " OktaResourceRead - Integration ",
@@ -80,7 +88,7 @@ var ReadResourceIntegrationOktaConfig = ResourceOperationConfig{
 	CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 		return fmt.Sprintf("https://%s/v1/integrations/okta/%s", c.ControlPlane, d.Get("name").(string))
 	},
-	ResponseData: &ResourceIntegrationOktaPayload{},
+	NewResponseData: func() ResponseData { return &ResourceIntegrationOktaPayload{} },
 }
 
 var ReadResourceIntegrationOktaIdentityProviderConfig = ResourceOperationConfig{
@@ -89,7 +97,7 @@ var ReadResourceIntegrationOktaIdentityProviderConfig = ResourceOperationConfig{
 	CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 		return fmt.Sprintf("https://%s/v1/conf/identityProviders/%s", c.ControlPlane, d.Get("name").(string))
 	},
-	ResponseData: &ResourceIntegrationOktaIdentityProviderPayload{},
+	NewResponseData: func() ResponseData { return &ResourceIntegrationOktaIdentityProviderPayload{} },
 }
 
 var cleanUpOktaIntegration = ResourceOperationConfig{
@@ -152,8 +160,8 @@ func CreateOktaIntegration(ctx context.Context, d *schema.ResourceData, m interf
 			CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 				return fmt.Sprintf("https://%s/v1/integrations/okta", c.ControlPlane)
 			},
-			ResourceData: &ResourceIntegrationOktaPayload{},
-			ResponseData: &CreateResourceIntegrationOktaResponse{},
+			NewResourceData: func() ResourceData { return &ResourceIntegrationOktaPayload{} },
+			NewResponseData: func() ResponseData { return &CreateResourceIntegrationOktaResponse{} },
 		}, ReadResourceIntegrationOktaConfig,
 	)(ctx, d, m)
 
@@ -168,8 +176,8 @@ func CreateOktaIntegration(ctx context.Context, d *schema.ResourceData, m interf
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					return fmt.Sprintf("https://%s/v1/conf/identityProviders/%s", c.ControlPlane, d.Get("name").(string))
 				},
-				ResourceData: &ResourceIntegrationOktaIdentityProviderPayload{},
-				ResponseData: &CreateResourceIntegrationOktaResponse{},
+				NewResourceData: func() ResourceData { return &ResourceIntegrationOktaIdentityProviderPayload{} },
+				NewResponseData: func() ResponseData { return &CreateResourceIntegrationOktaResponse{} },
 			}, ReadResourceIntegrationOktaIdentityProviderConfig,
 		)(ctx, d, m)
 	}
@@ -198,7 +206,7 @@ func UpdateOktaIntegration(ctx context.Context, d *schema.ResourceData, m interf
 		CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 			return fmt.Sprintf("https://%s/v1/integrations/okta", c.ControlPlane)
 		},
-		ResourceData: &ResourceIntegrationOktaPayload{},
+		NewResourceData: func() ResourceData { return &ResourceIntegrationOktaPayload{} },
 	}, ReadResourceIntegrationOktaConfig,
 	)(ctx, d, m)
 
@@ -210,7 +218,7 @@ func UpdateOktaIntegration(ctx context.Context, d *schema.ResourceData, m interf
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					return fmt.Sprintf("https://%s/v1/conf/identityProviders/%s", c.ControlPlane, d.Get("name").(string))
 				},
-				ResourceData: &ResourceIntegrationOktaIdentityProviderPayload{},
+				NewResourceData: func() ResourceData { return &ResourceIntegrationOktaIdentityProviderPayload{} },
 			}, ReadResourceIntegrationOktaIdentityProviderConfig,
 		)(ctx, d, m)
 	}

--- a/cyral/resource_cyral_integration_pager_duty.go
+++ b/cyral/resource_cyral_integration_pager_duty.go
@@ -10,7 +10,7 @@ import (
 )
 
 // WriteToSchema writes the pager duty information contained in a PagerDutyIntegration to the TF schema
-func (data PagerDutyIntegration) WriteToSchema(d *schema.ResourceData) {
+func (data PagerDutyIntegration) WriteToSchema(d *schema.ResourceData) error {
 	d.Set("id", data.ID)
 	d.Set("name", data.Name)
 
@@ -25,10 +25,12 @@ func (data PagerDutyIntegration) WriteToSchema(d *schema.ResourceData) {
 	}
 
 	d.Set("api_token", token.APIToken)
+
+	return nil
 }
 
 // ReadFromSchema reads the pager duty information from a given schema
-func (data *PagerDutyIntegration) ReadFromSchema(d *schema.ResourceData) {
+func (data *PagerDutyIntegration) ReadFromSchema(d *schema.ResourceData) error {
 	data.ID = d.Get("id").(string)
 	data.Name = d.Get("name").(string)
 
@@ -44,6 +46,8 @@ func (data *PagerDutyIntegration) ReadFromSchema(d *schema.ResourceData) {
 	// API information for typing
 	data.TemplateType = "pagerduty"
 	data.Category = "builtin"
+
+	return nil
 }
 
 // ReadPagerDutyIntegrationConfig is the configuration to read from a pager duty resource contained in a Control Plane
@@ -56,7 +60,7 @@ var ReadPagerDutyIntegrationConfig = ResourceOperationConfig{
 			c.ControlPlane, d.Id(),
 		)
 	},
-	ResponseData: &PagerDutyIntegration{},
+	NewResponseData: func() ResponseData { return &PagerDutyIntegration{} },
 }
 
 func resourceIntegrationPagerDuty() *schema.Resource {
@@ -71,8 +75,8 @@ func resourceIntegrationPagerDuty() *schema.Resource {
 						"https://%s/v1/integrations/confExtensions/instances", c.ControlPlane,
 					)
 				},
-				ResourceData: &PagerDutyIntegration{},
-				ResponseData: &IDBasedResponse{},
+				NewResourceData: func() ResourceData { return &PagerDutyIntegration{} },
+				NewResponseData: func() ResponseData { return &IDBasedResponse{} },
 			}, ReadPagerDutyIntegrationConfig,
 		),
 		ReadContext: ReadResource(ReadPagerDutyIntegrationConfig),
@@ -85,7 +89,7 @@ func resourceIntegrationPagerDuty() *schema.Resource {
 						"https://%s/v1/integrations/confExtensions/instances/%s", c.ControlPlane, d.Id(),
 					)
 				},
-				ResourceData: &PagerDutyIntegration{},
+				NewResourceData: func() ResourceData { return &PagerDutyIntegration{} },
 			}, ReadPagerDutyIntegrationConfig,
 		),
 		DeleteContext: DeleteResource(

--- a/cyral/resource_cyral_integration_slack_alerts.go
+++ b/cyral/resource_cyral_integration_slack_alerts.go
@@ -13,14 +13,16 @@ type SlackAlertsIntegration struct {
 	URL  string `json:"url"`
 }
 
-func (data SlackAlertsIntegration) WriteToSchema(d *schema.ResourceData) {
+func (data SlackAlertsIntegration) WriteToSchema(d *schema.ResourceData) error {
 	d.Set("name", data.Name)
 	d.Set("url", data.URL)
+	return nil
 }
 
-func (data *SlackAlertsIntegration) ReadFromSchema(d *schema.ResourceData) {
+func (data *SlackAlertsIntegration) ReadFromSchema(d *schema.ResourceData) error {
 	data.Name = d.Get("name").(string)
 	data.URL = d.Get("url").(string)
+	return nil
 }
 
 var ReadSlackAlertsConfig = ResourceOperationConfig{
@@ -29,7 +31,7 @@ var ReadSlackAlertsConfig = ResourceOperationConfig{
 	CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 		return fmt.Sprintf("https://%s/v1/integrations/notifications/slack/%s", c.ControlPlane, d.Id())
 	},
-	ResponseData: &SlackAlertsIntegration{},
+	NewResponseData: func() ResponseData { return &SlackAlertsIntegration{} },
 }
 
 func resourceIntegrationSlackAlerts() *schema.Resource {
@@ -42,8 +44,8 @@ func resourceIntegrationSlackAlerts() *schema.Resource {
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					return fmt.Sprintf("https://%s/v1/integrations/notifications/slack", c.ControlPlane)
 				},
-				ResourceData: &SlackAlertsIntegration{},
-				ResponseData: &IDBasedResponse{},
+				NewResourceData: func() ResourceData { return &SlackAlertsIntegration{} },
+				NewResponseData: func() ResponseData { return &IDBasedResponse{} },
 			}, ReadSlackAlertsConfig,
 		),
 		ReadContext: ReadResource(ReadSlackAlertsConfig),
@@ -54,7 +56,7 @@ func resourceIntegrationSlackAlerts() *schema.Resource {
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					return fmt.Sprintf("https://%s/v1/integrations/notifications/slack/%s", c.ControlPlane, d.Id())
 				},
-				ResourceData: &SlackAlertsIntegration{},
+				NewResourceData: func() ResourceData { return &SlackAlertsIntegration{} },
 			}, ReadSlackAlertsConfig,
 		),
 		DeleteContext: DeleteResource(

--- a/cyral/resource_cyral_integration_splunk.go
+++ b/cyral/resource_cyral_integration_splunk.go
@@ -18,22 +18,24 @@ type SplunkIntegration struct {
 	CyralActivityLogsEnabled bool   `json:"cyralActivityLogsEnabled"`
 }
 
-func (data SplunkIntegration) WriteToSchema(d *schema.ResourceData) {
+func (data SplunkIntegration) WriteToSchema(d *schema.ResourceData) error {
 	d.Set("name", data.Name)
 	d.Set("access_token", data.AccessToken)
 	d.Set("port", data.Port)
 	d.Set("host", data.Host)
 	d.Set("index", data.Index)
 	d.Set("use_tls", data.UseTLS)
+	return nil
 }
 
-func (data *SplunkIntegration) ReadFromSchema(d *schema.ResourceData) {
+func (data *SplunkIntegration) ReadFromSchema(d *schema.ResourceData) error {
 	data.Name = d.Get("name").(string)
 	data.AccessToken = d.Get("access_token").(string)
 	data.Port = d.Get("port").(int)
 	data.Host = d.Get("host").(string)
 	data.Index = d.Get("index").(string)
 	data.UseTLS = d.Get("use_tls").(bool)
+	return nil
 }
 
 var ReadSplunkConfig = ResourceOperationConfig{
@@ -42,7 +44,7 @@ var ReadSplunkConfig = ResourceOperationConfig{
 	CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 		return fmt.Sprintf("https://%s/v1/integrations/splunk/%s", c.ControlPlane, d.Id())
 	},
-	ResponseData: &SplunkIntegration{},
+	NewResponseData: func() ResponseData { return &SplunkIntegration{} },
 }
 
 func resourceIntegrationSplunk() *schema.Resource {
@@ -55,8 +57,8 @@ func resourceIntegrationSplunk() *schema.Resource {
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					return fmt.Sprintf("https://%s/v1/integrations/splunk", c.ControlPlane)
 				},
-				ResourceData: &SplunkIntegration{},
-				ResponseData: &IDBasedResponse{},
+				NewResourceData: func() ResourceData { return &SplunkIntegration{} },
+				NewResponseData: func() ResponseData { return &IDBasedResponse{} },
 			}, ReadSplunkConfig,
 		),
 		ReadContext: ReadResource(ReadSplunkConfig),
@@ -67,7 +69,7 @@ func resourceIntegrationSplunk() *schema.Resource {
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					return fmt.Sprintf("https://%s/v1/integrations/splunk/%s", c.ControlPlane, d.Id())
 				},
-				ResourceData: &SplunkIntegration{},
+				NewResourceData: func() ResourceData { return &SplunkIntegration{} },
 			}, ReadSplunkConfig,
 		),
 		DeleteContext: DeleteResource(

--- a/cyral/resource_cyral_integration_sumo_logic.go
+++ b/cyral/resource_cyral_integration_sumo_logic.go
@@ -13,14 +13,16 @@ type SumoLogicIntegration struct {
 	Address string `json:"address"`
 }
 
-func (data SumoLogicIntegration) WriteToSchema(d *schema.ResourceData) {
+func (data SumoLogicIntegration) WriteToSchema(d *schema.ResourceData) error {
 	d.Set("name", data.Name)
 	d.Set("address", data.Address)
+	return nil
 }
 
-func (data *SumoLogicIntegration) ReadFromSchema(d *schema.ResourceData) {
+func (data *SumoLogicIntegration) ReadFromSchema(d *schema.ResourceData) error {
 	data.Name = d.Get("name").(string)
 	data.Address = d.Get("address").(string)
+	return nil
 }
 
 var ReadSumoLogicConfig = ResourceOperationConfig{
@@ -29,7 +31,7 @@ var ReadSumoLogicConfig = ResourceOperationConfig{
 	CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 		return fmt.Sprintf("https://%s/v1/integrations/sumologic/%s", c.ControlPlane, d.Id())
 	},
-	ResponseData: &SumoLogicIntegration{},
+	NewResponseData: func() ResponseData { return &SumoLogicIntegration{} },
 }
 
 func resourceIntegrationSumoLogic() *schema.Resource {
@@ -42,8 +44,8 @@ func resourceIntegrationSumoLogic() *schema.Resource {
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					return fmt.Sprintf("https://%s/v1/integrations/sumologic", c.ControlPlane)
 				},
-				ResourceData: &SumoLogicIntegration{},
-				ResponseData: &IDBasedResponse{},
+				NewResourceData: func() ResourceData { return &SumoLogicIntegration{} },
+				NewResponseData: func() ResponseData { return &IDBasedResponse{} },
 			}, ReadSumoLogicConfig,
 		),
 		ReadContext: ReadResource(ReadSumoLogicConfig),
@@ -54,7 +56,7 @@ func resourceIntegrationSumoLogic() *schema.Resource {
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					return fmt.Sprintf("https://%s/v1/integrations/sumologic/%s", c.ControlPlane, d.Id())
 				},
-				ResourceData: &SumoLogicIntegration{},
+				NewResourceData: func() ResourceData { return &SumoLogicIntegration{} },
 			}, ReadSumoLogicConfig,
 		),
 		DeleteContext: DeleteResource(

--- a/cyral/resource_cyral_integration_teams.go
+++ b/cyral/resource_cyral_integration_teams.go
@@ -13,14 +13,16 @@ type MsTeamsIntegration struct {
 	URL  string `json:"url"`
 }
 
-func (data MsTeamsIntegration) WriteToSchema(d *schema.ResourceData) {
+func (data MsTeamsIntegration) WriteToSchema(d *schema.ResourceData) error {
 	d.Set("name", data.Name)
 	d.Set("url", data.URL)
+	return nil
 }
 
-func (data *MsTeamsIntegration) ReadFromSchema(d *schema.ResourceData) {
+func (data *MsTeamsIntegration) ReadFromSchema(d *schema.ResourceData) error {
 	data.Name = d.Get("name").(string)
 	data.URL = d.Get("url").(string)
+	return nil
 }
 
 var ReadMsTeamsConfig = ResourceOperationConfig{
@@ -29,7 +31,7 @@ var ReadMsTeamsConfig = ResourceOperationConfig{
 	CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 		return fmt.Sprintf("https://%s/v1/integrations/notifications/teams/%s", c.ControlPlane, d.Id())
 	},
-	ResponseData: &MsTeamsIntegration{},
+	NewResponseData: func() ResponseData { return &MsTeamsIntegration{} },
 }
 
 func resourceIntegrationMsTeams() *schema.Resource {
@@ -42,8 +44,8 @@ func resourceIntegrationMsTeams() *schema.Resource {
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					return fmt.Sprintf("https://%s/v1/integrations/notifications/teams", c.ControlPlane)
 				},
-				ResourceData: &MsTeamsIntegration{},
-				ResponseData: &IDBasedResponse{},
+				NewResourceData: func() ResourceData { return &MsTeamsIntegration{} },
+				NewResponseData: func() ResponseData { return &IDBasedResponse{} },
 			}, ReadMsTeamsConfig,
 		),
 		ReadContext: ReadResource(ReadMsTeamsConfig),
@@ -54,7 +56,7 @@ func resourceIntegrationMsTeams() *schema.Resource {
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					return fmt.Sprintf("https://%s/v1/integrations/notifications/teams/%s", c.ControlPlane, d.Id())
 				},
-				ResourceData: &MsTeamsIntegration{},
+				NewResourceData: func() ResourceData { return &MsTeamsIntegration{} },
 			}, ReadMsTeamsConfig,
 		),
 		DeleteContext: DeleteResource(

--- a/cyral/resource_cyral_repository_identity_map.go
+++ b/cyral/resource_cyral_repository_identity_map.go
@@ -55,7 +55,7 @@ type RepositoryIdentityMapResource struct {
 	AccessDuration        *AccessDuration `json:"accessDuration,omitempty"`
 }
 
-func (data RepositoryIdentityMapResource) WriteToSchema(d *schema.ResourceData) {
+func (data RepositoryIdentityMapResource) WriteToSchema(d *schema.ResourceData) error {
 	d.Set("repository_id", data.RepositoryId)
 
 	if err := data.isIdentityTypeValid(); err != nil {
@@ -74,9 +74,10 @@ func (data RepositoryIdentityMapResource) WriteToSchema(d *schema.ResourceData) 
 			},
 		})
 	}
+	return nil
 }
 
-func (data *RepositoryIdentityMapResource) ReadFromSchema(d *schema.ResourceData) {
+func (data *RepositoryIdentityMapResource) ReadFromSchema(d *schema.ResourceData) error {
 	data.RepositoryId = d.Get("repository_id").(string)
 	data.IdentityType = d.Get("identity_type").(string)
 	if err := data.isIdentityTypeValid(); err != nil {
@@ -98,6 +99,7 @@ func (data *RepositoryIdentityMapResource) ReadFromSchema(d *schema.ResourceData
 			data.AccessDuration.Seconds = idMap["seconds"].(int)
 		}
 	}
+	return nil
 }
 
 func (resource *RepositoryIdentityMapResource) UnmarshalJSON(data []byte) error {
@@ -135,7 +137,7 @@ type RepositoryIdentityMapAPIResponse struct {
 	AccessDuration *AccessDuration `json:"accessDuration,omitempty"`
 }
 
-func (data RepositoryIdentityMapAPIResponse) WriteToSchema(d *schema.ResourceData) {
+func (data RepositoryIdentityMapAPIResponse) WriteToSchema(d *schema.ResourceData) error {
 	d.SetId(fmt.Sprintf("%s-%s", d.Get("repository_id").(string),
 		d.Get("repository_local_account_id").(string)))
 	if data.AccessDuration != nil {
@@ -148,9 +150,10 @@ func (data RepositoryIdentityMapAPIResponse) WriteToSchema(d *schema.ResourceDat
 			},
 		})
 	}
+	return nil
 }
 
-func (data *RepositoryIdentityMapAPIResponse) ReadFromSchema(d *schema.ResourceData) {
+func (data *RepositoryIdentityMapAPIResponse) ReadFromSchema(d *schema.ResourceData) error {
 	if _, hasAcessDuration := d.GetOk("access_duration"); hasAcessDuration {
 		data.AccessDuration = &AccessDuration{}
 		acess := d.Get("access_duration").(*schema.Set)
@@ -164,6 +167,7 @@ func (data *RepositoryIdentityMapAPIResponse) ReadFromSchema(d *schema.ResourceD
 			data.AccessDuration.Seconds = idMap["seconds"].(int)
 		}
 	}
+	return nil
 }
 
 func (resource *RepositoryIdentityMapAPIResponse) UnmarshalJSON(data []byte) error {
@@ -194,7 +198,7 @@ var ReadRepositoryIdentityMapConfig = ResourceOperationConfig{
 			d.Get("identity_name").(string),
 			d.Get("repository_local_account_id").(string))
 	},
-	ResponseData: &RepositoryIdentityMapAPIResponse{},
+	NewResponseData: func() ResponseData { return &RepositoryIdentityMapAPIResponse{} },
 }
 
 func resourceRepositoryIdentityMap(deprecationMessage string) *schema.Resource {
@@ -213,8 +217,8 @@ func resourceRepositoryIdentityMap(deprecationMessage string) *schema.Resource {
 						d.Get("identity_name").(string),
 						d.Get("repository_local_account_id").(string))
 				},
-				ResourceData: &RepositoryIdentityMapResource{},
-				ResponseData: &RepositoryIdentityMapAPIResponse{},
+				NewResourceData: func() ResourceData { return &RepositoryIdentityMapResource{} },
+				NewResponseData: func() ResponseData { return &RepositoryIdentityMapAPIResponse{} },
 			}, ReadRepositoryIdentityMapConfig,
 		),
 		ReadContext: ReadResource(ReadRepositoryIdentityMapConfig),
@@ -230,7 +234,7 @@ func resourceRepositoryIdentityMap(deprecationMessage string) *schema.Resource {
 						d.Get("identity_name").(string),
 						d.Get("repository_local_account_id").(string))
 				},
-				ResourceData: &RepositoryIdentityMapResource{},
+				NewResourceData: func() ResourceData { return &RepositoryIdentityMapResource{} },
 			}, ReadRepositoryIdentityMapConfig,
 		),
 		DeleteContext: DeleteResource(

--- a/cyral/resource_cyral_repository_local_account.go
+++ b/cyral/resource_cyral_repository_local_account.go
@@ -227,12 +227,14 @@ type CreateRepoAccountResponse struct {
 	UUID string `json:"uuid"`
 }
 
-func (resource CreateRepoAccountResponse) WriteToSchema(d *schema.ResourceData) {
+func (resource CreateRepoAccountResponse) WriteToSchema(d *schema.ResourceData) error {
 	d.SetId(resource.UUID)
+	return nil
 }
 
-func (resource *CreateRepoAccountResponse) ReadFromSchema(d *schema.ResourceData) {
+func (resource *CreateRepoAccountResponse) ReadFromSchema(d *schema.ResourceData) error {
 	resource.UUID = d.Id()
+	return nil
 }
 
 type RepositoryLocalAccountResource struct {
@@ -245,7 +247,7 @@ type RepositoryLocalAccountResource struct {
 	GcpSecretManager    *GcpSecretManagerResource    `json:"gcpSecretManager,omitempty"`
 }
 
-func (repoAccount RepositoryLocalAccountResource) WriteToSchema(d *schema.ResourceData) {
+func (repoAccount RepositoryLocalAccountResource) WriteToSchema(d *schema.ResourceData) error {
 	log.Printf("[DEBUG] RepositoryLocalAccountResource - WriteToSchema START")
 
 	if repoAccount.AwsIAM != nil {
@@ -265,9 +267,11 @@ func (repoAccount RepositoryLocalAccountResource) WriteToSchema(d *schema.Resour
 	}
 
 	log.Printf("[DEBUG] RepositoryLocalAccountResource - WriteToSchema END")
+
+	return nil
 }
 
-func (repoAccount *RepositoryLocalAccountResource) ReadFromSchema(d *schema.ResourceData) {
+func (repoAccount *RepositoryLocalAccountResource) ReadFromSchema(d *schema.ResourceData) error {
 	log.Printf("[DEBUG] RepositoryLocalAccountResource - ReadFromSchema START")
 
 	if _, hasAwsIam := d.GetOk("aws_iam"); hasAwsIam {
@@ -298,6 +302,8 @@ func (repoAccount *RepositoryLocalAccountResource) ReadFromSchema(d *schema.Reso
 	}
 
 	log.Printf("[DEBUG] RepositoryLocalAccountResource - ReadFromSchema END")
+
+	return nil
 }
 
 func resourceRepositoryLocalAccount() *schema.Resource {
@@ -311,7 +317,7 @@ func resourceRepositoryLocalAccount() *schema.Resource {
 				c.ControlPlane, repository_id, d.Id(),
 			)
 		},
-		ResponseData: &RepositoryLocalAccountResource{},
+		NewResponseData: func() ResponseData { return &RepositoryLocalAccountResource{} },
 	}
 
 	secretManagersTypes := []string{
@@ -541,8 +547,8 @@ func resourceRepositoryLocalAccount() *schema.Resource {
 						c.ControlPlane, repository_id,
 					)
 				},
-				ResourceData: &RepositoryLocalAccountResource{},
-				ResponseData: &CreateRepoAccountResponse{},
+				NewResourceData: func() ResourceData { return &RepositoryLocalAccountResource{} },
+				NewResponseData: func() ResponseData { return &CreateRepoAccountResponse{} },
 			}, ReadRepositoryLocalAccountConfig,
 		),
 		ReadContext: ReadResource(ReadRepositoryLocalAccountConfig),
@@ -557,7 +563,7 @@ func resourceRepositoryLocalAccount() *schema.Resource {
 						c.ControlPlane, repository_id, d.Id(),
 					)
 				},
-				ResourceData: &RepositoryLocalAccountResource{},
+				NewResourceData: func() ResourceData { return &RepositoryLocalAccountResource{} },
 			}, ReadRepositoryLocalAccountConfig,
 		),
 		DeleteContext: DeleteResource(

--- a/cyral/resource_cyral_role_sso_groups.go
+++ b/cyral/resource_cyral_role_sso_groups.go
@@ -90,8 +90,8 @@ var createRoleSSOGroupsConfig = ResourceOperationConfig{
 		return fmt.Sprintf("https://%s/v1/users/groups/%s/mappings", c.ControlPlane,
 			d.Get("role_id").(string))
 	},
-	ResourceData: &RoleSSOGroupsCreateRequest{},
-	ResponseData: &RoleSSOGroupsCreateRequest{},
+	NewResourceData: func() ResourceData { return &RoleSSOGroupsCreateRequest{} },
+	NewResponseData: func() ResponseData { return &RoleSSOGroupsCreateRequest{} },
 }
 
 var readRoleSSOGroupsConfig = ResourceOperationConfig{
@@ -101,7 +101,7 @@ var readRoleSSOGroupsConfig = ResourceOperationConfig{
 		return fmt.Sprintf("https://%s/v1/users/groups/%s/mappings", c.ControlPlane,
 			d.Get("role_id").(string))
 	},
-	ResponseData: &RoleSSOGroupsReadResponse{},
+	NewResponseData: func() ResponseData { return &RoleSSOGroupsReadResponse{} },
 }
 
 var deleteRoleSSOGroupsConfig = ResourceOperationConfig{
@@ -111,14 +111,15 @@ var deleteRoleSSOGroupsConfig = ResourceOperationConfig{
 		return fmt.Sprintf("https://%s/v1/users/groups/%s/mappings", c.ControlPlane,
 			d.Get("role_id").(string))
 	},
-	ResourceData: &RoleSSOGroupsDeleteRequest{},
+	NewResourceData: func() ResourceData { return &RoleSSOGroupsDeleteRequest{} },
 }
 
-func (data RoleSSOGroupsCreateRequest) WriteToSchema(d *schema.ResourceData) {
+func (data RoleSSOGroupsCreateRequest) WriteToSchema(d *schema.ResourceData) error {
 	d.SetId(fmt.Sprintf("%s/SSOGroups", d.Get("role_id")))
+	return nil
 }
 
-func (data *RoleSSOGroupsCreateRequest) ReadFromSchema(d *schema.ResourceData) {
+func (data *RoleSSOGroupsCreateRequest) ReadFromSchema(d *schema.ResourceData) error {
 	var SSOGroupsMappings []*SSOGroup
 
 	if ssoGroups, ok := d.GetOk("sso_group"); ok {
@@ -135,13 +136,15 @@ func (data *RoleSSOGroupsCreateRequest) ReadFromSchema(d *schema.ResourceData) {
 	}
 
 	data.SSOGroupsMappings = SSOGroupsMappings
+
+	return nil
 }
 
 func (data RoleSSOGroupsCreateRequest) MarshalJSON() ([]byte, error) {
 	return json.Marshal(data.SSOGroupsMappings)
 }
 
-func (data RoleSSOGroupsReadResponse) WriteToSchema(d *schema.ResourceData) {
+func (data RoleSSOGroupsReadResponse) WriteToSchema(d *schema.ResourceData) error {
 	var flatSSOGroupsMappings []interface{}
 
 	for _, ssoGroup := range data.SSOGroupsMappings {
@@ -155,13 +158,11 @@ func (data RoleSSOGroupsReadResponse) WriteToSchema(d *schema.ResourceData) {
 	}
 
 	d.Set("sso_group", flatSSOGroupsMappings)
+
+	return nil
 }
 
-func (data *RoleSSOGroupsReadResponse) ReadFromSchema(d *schema.ResourceData) {}
-
-func (data RoleSSOGroupsDeleteRequest) WriteToSchema(d *schema.ResourceData) {}
-
-func (data *RoleSSOGroupsDeleteRequest) ReadFromSchema(d *schema.ResourceData) {
+func (data *RoleSSOGroupsDeleteRequest) ReadFromSchema(d *schema.ResourceData) error {
 	var SSOGroupsMappingsIds []string
 
 	if ssoGroups, ok := d.GetOk("sso_group"); ok {
@@ -175,6 +176,8 @@ func (data *RoleSSOGroupsDeleteRequest) ReadFromSchema(d *schema.ResourceData) {
 	}
 
 	data.SSOGroupsMappingsIds = SSOGroupsMappingsIds
+
+	return nil
 }
 
 func (data RoleSSOGroupsDeleteRequest) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
## Description of the change

ENG-8610: Terraform provider: Creating 30+ repos will fail when creating identity map with okta as idp

This PR fixes an issue where resource instances of the same type were sharing the same memory address for the request/response payloads, this was causing data inconsistency between the resource instances. This fix also includes some code refactoring in the provider's internal structure (addressing issue #196). All of these changes are backward compatible.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Jira issue referenced in commit message and/or PR title

### Testing

Manual and automated tests. All tests are passing as expected, since these changes are supposed to be backward compatible.
