### PR TITLE
ENG-6069: Support MongoDB repository replica sets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM hashicorp/terraform:1.2.3 as terraform
 
 FROM golang:1.17.3-alpine3.13 AS build
 WORKDIR /go/src/cyral
-RUN apk add --no-cache build-base=0.5-r2
+RUN apk add --no-cache build-base=0.5-r3
 COPY main.go go.mod go.sum ./
 COPY client/ client/
 COPY cyral/ cyral/

--- a/cyral/resource_cyral_datamap.go
+++ b/cyral/resource_cyral_datamap.go
@@ -26,7 +26,7 @@ type RepoAttrs struct {
 
 func resourceDatamap() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Manages [Data map](https://cyral.com/docs/policy#data-map).",
+		Description:   "Manages [Data map](https://cyral.com/docs/policy/datamap).",
 		CreateContext: resourceDatamapCreate,
 		ReadContext:   resourceDatamapRead,
 		UpdateContext: resourceDatamapUpdate,

--- a/cyral/resource_cyral_datamap.go
+++ b/cyral/resource_cyral_datamap.go
@@ -26,7 +26,7 @@ type RepoAttrs struct {
 
 func resourceDatamap() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Manages [Data map](https://cyral.com/docs/policy#data-map).",
+		Description:   "Manages [Data map](https://cyral.com/docs/policy#data-map)",
 		CreateContext: resourceDatamapCreate,
 		ReadContext:   resourceDatamapRead,
 		UpdateContext: resourceDatamapUpdate,

--- a/cyral/resource_cyral_datamap.go
+++ b/cyral/resource_cyral_datamap.go
@@ -26,7 +26,7 @@ type RepoAttrs struct {
 
 func resourceDatamap() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Manages [Data map](https://cyral.com/docs/policy#data-map)",
+		Description:   "Manages [Data map](https://cyral.com/docs/policy#data-map).",
 		CreateContext: resourceDatamapCreate,
 		ReadContext:   resourceDatamapRead,
 		UpdateContext: resourceDatamapUpdate,

--- a/cyral/resource_cyral_repository.go
+++ b/cyral/resource_cyral_repository.go
@@ -39,7 +39,7 @@ func resourceRepository() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"id": {
-				Description: "ID of this resource in Cyral environment",
+				Description: "ID of this resource in Cyral environment.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
@@ -89,16 +89,35 @@ func resourceRepository() *schema.Resource {
 				Required:    true,
 			},
 			"name": {
-				Description: "Repository name that will be used internally in the control plane (ex: `your_repo_name`)",
+				Description: "Repository name that will be used internally in the control plane (ex: `your_repo_name`).",
 				Type:        schema.TypeString,
 				Required:    true,
 			},
 			"labels": {
-				Description: "labels enable you to categorize your repository",
+				Description: "Labels enable you to categorize your repository.",
 				Type:        schema.TypeList,
 				Optional:    true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
+				},
+			},
+			"replica_set": {
+				Description: "Used to configure a distributed database, such as a MongoDB cluster.",
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"max_nodes": {
+							Description: "Maximum number of nodes of the replica set cluster.",
+							Type:        schema.TypeInt,
+							Required:    true,
+						},
+						"replica_set_id": {
+							Description: "Identifier of the replica set cluster. Used to construct the URI command (available in Cyral's Access Token page) that your users will need for connecting to the repository via Cyral.",
+							Type:        schema.TypeString,
+							Required:    true,
+						},
+					},
 				},
 			},
 		},

--- a/cyral/resource_cyral_repository.go
+++ b/cyral/resource_cyral_repository.go
@@ -117,7 +117,7 @@ func resourceRepository() *schema.Resource {
 				Optional:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"replica_set": {
+						"mongodb_replica_set": {
 							Description: "Used to configure a distributed database, such as a MongoDB cluster.",
 							Type:        schema.TypeSet,
 							Optional:    true,
@@ -254,7 +254,7 @@ func getRepoDataFromResource(c *client.Client, d *schema.ResourceData) (RepoData
 		for _, propertiesMap := range propertiesIface.List() {
 			propertiesMap := propertiesMap.(map[string]interface{})
 			// Replica set properties
-			if rsetIface, ok := propertiesMap["replica_set"]; ok {
+			if rsetIface, ok := propertiesMap["mongodb_replica_set"]; ok {
 				for _, rsetMap := range rsetIface.(*schema.Set).List() {
 					rsetMap := rsetMap.(map[string]interface{})
 					maxAllowedListeners = rsetMap["max_nodes"].(uint32)

--- a/cyral/resource_cyral_repository.go
+++ b/cyral/resource_cyral_repository.go
@@ -257,7 +257,7 @@ func getRepoDataFromResource(c *client.Client, d *schema.ResourceData) (RepoData
 			if rsetIface, ok := propertiesMap["mongodb_replica_set"]; ok {
 				for _, rsetMap := range rsetIface.(*schema.Set).List() {
 					rsetMap := rsetMap.(map[string]interface{})
-					maxAllowedListeners = rsetMap["max_nodes"].(uint32)
+					maxAllowedListeners = uint32(rsetMap["max_nodes"].(int))
 					properties.MongoDBReplicaSetName = rsetMap["replica_set_id"].(string)
 				}
 				properties.MongoDBServerType = "replicaset"

--- a/cyral/resource_cyral_repository.go
+++ b/cyral/resource_cyral_repository.go
@@ -153,7 +153,7 @@ func resourceRepository() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"mongodb_replica_set": {
-							Description: "Used to configure a distributed database, such as a MongoDB cluster.",
+							Description: "Used to configure a MongoDB cluster.",
 							Type:        schema.TypeSet,
 							Optional:    true,
 							Elem: &schema.Resource{

--- a/cyral/resource_cyral_repository.go
+++ b/cyral/resource_cyral_repository.go
@@ -112,9 +112,7 @@ func resourceRepository() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			// 'advanced' is equivalent to 'properties' in the Cyral
-			// v1/repos API, but with a user-friendly name.
-			"advanced": {
+			"properties": {
 				Description: "Contains advanced repository configuration.",
 				Type:        schema.TypeSet,
 				Optional:    true,
@@ -252,7 +250,7 @@ func getRepoDataFromResource(c *client.Client, d *schema.ResourceData) (RepoData
 
 	var properties *RepositoryProperties
 	var maxAllowedListeners uint32
-	if propertiesIface, ok := d.Get("advanced").(*schema.Set); ok {
+	if propertiesIface, ok := d.Get("properties").(*schema.Set); ok {
 		properties = new(RepositoryProperties)
 		for _, setMap := range propertiesIface.List() {
 			setMap := setMap.(map[string]interface{})

--- a/cyral/resource_cyral_repository.go
+++ b/cyral/resource_cyral_repository.go
@@ -33,7 +33,6 @@ type RepoData struct {
 // API.
 type RepositoryProperties struct {
 	// Replica set
-	MaxNodes              string `json:"max-nodes,omitempty"`
 	MongoDBReplicaSetName string `json:"mongodb-replicaset-name,omitempty"`
 	MongoDBServerType     string `json:"mongodb-server-type,omitempty"`
 }
@@ -252,20 +251,16 @@ func getRepoDataFromResource(c *client.Client, d *schema.ResourceData) (RepoData
 	var maxAllowedListeners uint32
 	if propertiesIface, ok := d.Get("properties").(*schema.Set); ok {
 		properties = new(RepositoryProperties)
-		for _, setMap := range propertiesIface.List() {
-			setMap := setMap.(map[string]interface{})
-			if rsetIface, ok := setMap["replica_set"]; ok {
-				var maxNodes int
+		for _, propertiesMap := range propertiesIface.List() {
+			propertiesMap := propertiesMap.(map[string]interface{})
+			// Replica set properties
+			if rsetIface, ok := propertiesMap["replica_set"]; ok {
 				for _, rsetMap := range rsetIface.(*schema.Set).List() {
 					rsetMap := rsetMap.(map[string]interface{})
-					// The API requires that
-					// properties.MaxNodes be a string.
-					maxNodes = rsetMap["max_nodes"].(int)
-					properties.MaxNodes = fmt.Sprintf("%d", maxNodes)
+					maxAllowedListeners = rsetMap["max_nodes"].(uint32)
 					properties.MongoDBReplicaSetName = rsetMap["replica_set_id"].(string)
 				}
 				properties.MongoDBServerType = "replicaset"
-				maxAllowedListeners = uint32(maxNodes)
 			}
 		}
 	}

--- a/cyral/resource_cyral_repository_test.go
+++ b/cyral/resource_cyral_repository_test.go
@@ -23,6 +23,32 @@ var updatedRepoConfig RepoData = RepoData{
 	Labels:   []string{"rds", "us-east-1"},
 }
 
+var initialRepoConfigReplicaSet RepoData = RepoData{
+	Name:     "repo-test-replica-set",
+	Host:     "host-1",
+	Port:     27017,
+	RepoType: "mongodb",
+	Labels:   []string{"rds", "us-east-1"},
+	Properties: &RepositoryProperties{
+		MaxNodes:              "2",
+		MongoDBReplicaSetName: "replica-set-1",
+		MongoDBServerType:     "replicaset",
+	},
+}
+
+var updatedRepoConfigReplicaSet RepoData = RepoData{
+	Name:     "repo-test-replica-set",
+	Host:     "host-1",
+	Port:     27017,
+	RepoType: "mongodb",
+	Labels:   []string{"rds", "us-east-1"},
+	Properties: &RepositoryProperties{
+		MaxNodes:              "2",
+		MongoDBReplicaSetName: "replica-set-2",
+		MongoDBServerType:     "replicaset",
+	},
+}
+
 func TestAccRepositoryResource(t *testing.T) {
 	testConfig, testFunc := setupRepositoryTest(initialRepoConfig)
 	testUpdateConfig, testUpdateFunc := setupRepositoryTest(updatedRepoConfig)
@@ -42,27 +68,86 @@ func TestAccRepositoryResource(t *testing.T) {
 	})
 }
 
-func setupRepositoryTest(integrationData RepoData) (string, resource.TestCheckFunc) {
-	configuration := formatRepoDataIntoConfig(integrationData)
+func TestAccRepositoryResource_MongoDBReplicaSet(t *testing.T) {
+	testConfig, testFunc := setupRepositoryTest(initialRepoConfigReplicaSet)
+	testUpdateConfig, testUpdateFunc := setupRepositoryTest(updatedRepoConfigReplicaSet)
 
-	testFunction := resource.ComposeTestCheckFunc(
-		resource.TestCheckResourceAttr("cyral_repository.test_repo_repository", "type", integrationData.RepoType),
-		resource.TestCheckResourceAttr("cyral_repository.test_repo_repository", "host", integrationData.Host),
-		resource.TestCheckResourceAttr("cyral_repository.test_repo_repository", "port", fmt.Sprintf("%d", integrationData.Port)),
-		resource.TestCheckResourceAttr("cyral_repository.test_repo_repository", "name", integrationData.Name),
-		resource.TestCheckResourceAttr("cyral_repository.test_repo_repository", "labels.#", "2"),
-	)
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testConfig,
+				Check:  testFunc,
+			},
+			{
+				Config: testUpdateConfig,
+				Check:  testUpdateFunc,
+			},
+		},
+	})
+}
+
+func setupRepositoryTest(repoData RepoData) (string, resource.TestCheckFunc) {
+	configuration := formatRepoDataIntoConfig(repoData)
+
+	checkFuncs := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr("cyral_repository.test_repo_repository",
+			"type", repoData.RepoType),
+		resource.TestCheckResourceAttr("cyral_repository.test_repo_repository",
+			"host", repoData.Host),
+		resource.TestCheckResourceAttr("cyral_repository.test_repo_repository",
+			"port", fmt.Sprintf("%d", repoData.Port)),
+		resource.TestCheckResourceAttr("cyral_repository.test_repo_repository",
+			"name", repoData.Name),
+		resource.TestCheckResourceAttr("cyral_repository.test_repo_repository",
+			"labels.#", "2"),
+	}
+
+	if repoReplicaSetEnabled(repoData) {
+		checkFuncs = append(checkFuncs, []resource.TestCheckFunc{
+			resource.TestCheckResourceAttr("cyral_repository.test_repo_repository",
+				"properties.0.replica_set.0.max_nodes", repoData.Properties.MaxNodes),
+			resource.TestCheckResourceAttr("cyral_repository.test_repo_repository",
+				"properties.0.replica_set.0.MongoDBReplicaSetName",
+				repoData.Properties.MongoDBReplicaSetName),
+		}...)
+	}
+
+	testFunction := resource.ComposeTestCheckFunc(checkFuncs...)
 
 	return configuration, testFunction
 }
 
 func formatRepoDataIntoConfig(data RepoData) string {
-	return fmt.Sprintf(`
+	base := fmt.Sprintf(`
 	resource "cyral_repository" "test_repo_repository" {
 		type  = "%s"
 		host  = "%s"
 		port  = %d
 		name  = "%s"
-		labels = [%s]
-	}`, data.RepoType, data.Host, data.Port, data.Name, formatAttibutes(data.Labels))
+		labels = [%s]`, data.RepoType, data.Host, data.Port, data.Name, formatAttibutes(data.Labels))
+	propertiesStr := ""
+	if data.Properties != nil {
+		propertiesStr += `
+		properties {`
+		properties := data.Properties
+		if repoReplicaSetEnabled(data) {
+			propertiesStr += fmt.Sprintf(`
+			replica_set {
+				max_nodes = %s
+				replica_set_id = %s
+			}`, properties.MaxNodes, properties.MongoDBReplicaSetName)
+		}
+		propertiesStr += `
+		}
+`
+	}
+	completeConfig := base + propertiesStr + `
+	}`
+	return completeConfig
+}
+
+func repoReplicaSetEnabled(repoData RepoData) bool {
+	properties := repoData.Properties
+	return properties != nil && properties.MaxNodes != "" && properties.MongoDBReplicaSetName != ""
 }

--- a/cyral/resource_cyral_repository_test.go
+++ b/cyral/resource_cyral_repository_test.go
@@ -31,7 +31,7 @@ var replicaSetRepoConfig RepoData = RepoData{
 	Labels:   []string{"rds", "us-east-1"},
 	Properties: &RepositoryProperties{
 		MongoDBReplicaSetName: "replica-set-1",
-		MongoDBServerType:     "replicaset",
+		MongoDBServerType:     mongodbReplicaSetServerType,
 	},
 }
 
@@ -75,7 +75,7 @@ func setupRepositoryTest(repoData RepoData) (string, resource.TestCheckFunc) {
 			"labels.#", "2"),
 	}
 
-	if repoReplicaSetEnabled(repoData) {
+	if repoData.IsReplicaSet() {
 		checkFuncs = append(checkFuncs, []resource.TestCheckFunc{
 			resource.TestCheckResourceAttr("cyral_repository.test_repo_repository",
 				"properties.0.mongodb_replica_set.0.max_nodes", fmt.Sprintf("%d",
@@ -105,7 +105,7 @@ func formatRepoDataIntoConfig(data RepoData) string {
 		propertiesStr += `
 		properties {`
 		properties := data.Properties
-		if repoReplicaSetEnabled(data) {
+		if data.IsReplicaSet() {
 			propertiesStr += fmt.Sprintf(`
 			mongodb_replica_set {
 				max_nodes = %d
@@ -119,9 +119,4 @@ func formatRepoDataIntoConfig(data RepoData) string {
 	completeConfig := base + propertiesStr + `
 	}`
 	return completeConfig
-}
-
-func repoReplicaSetEnabled(repoData RepoData) bool {
-	properties := repoData.Properties
-	return properties != nil && properties.MongoDBServerType == "replicaset" && properties.MongoDBReplicaSetName != ""
 }

--- a/cyral/resource_cyral_repository_test.go
+++ b/cyral/resource_cyral_repository_test.go
@@ -78,11 +78,11 @@ func setupRepositoryTest(repoData RepoData) (string, resource.TestCheckFunc) {
 	if repoReplicaSetEnabled(repoData) {
 		checkFuncs = append(checkFuncs, []resource.TestCheckFunc{
 			resource.TestCheckResourceAttr("cyral_repository.test_repo_repository",
-				"properties.0.replica_set.0.max_nodes", fmt.Sprintf("%d",
+				"properties.0.mongodb_replica_set.0.max_nodes", fmt.Sprintf("%d",
 					repoData.MaxAllowedListeners)),
 
 			resource.TestCheckResourceAttr("cyral_repository.test_repo_repository",
-				"properties.0.replica_set.0.replica_set_id",
+				"properties.0.mongodb_replica_set.0.replica_set_id",
 				repoData.Properties.MongoDBReplicaSetName),
 		}...)
 	}
@@ -107,7 +107,7 @@ func formatRepoDataIntoConfig(data RepoData) string {
 		properties := data.Properties
 		if repoReplicaSetEnabled(data) {
 			propertiesStr += fmt.Sprintf(`
-			replica_set {
+			mongodb_replica_set {
 				max_nodes = %d
 				replica_set_id = "%s"
 			}`, data.MaxAllowedListeners, properties.MongoDBReplicaSetName)

--- a/docs/resources/datamap.md
+++ b/docs/resources/datamap.md
@@ -3,12 +3,12 @@
 page_title: "cyral_datamap Resource - cyral"
 subcategory: ""
 description: |-
-  Manages Data map https://cyral.com/docs/policy/datamap.
+  Manages Data map https://cyral.com/docs/policy#data-map
 ---
 
 # cyral_datamap (Resource)
 
-Manages [Data map](https://cyral.com/docs/policy/datamap).
+Manages [Data map](https://cyral.com/docs/policy#data-map)
 
 ## Example Usage
 

--- a/docs/resources/datamap.md
+++ b/docs/resources/datamap.md
@@ -3,12 +3,12 @@
 page_title: "cyral_datamap Resource - cyral"
 subcategory: ""
 description: |-
-  Manages Data map https://cyral.com/docs/policy#data-map.
+  Manages Data map https://cyral.com/docs/policy/datamap.
 ---
 
 # cyral_datamap (Resource)
 
-Manages [Data map](https://cyral.com/docs/policy#data-map).
+Manages [Data map](https://cyral.com/docs/policy/datamap).
 
 ## Example Usage
 

--- a/docs/resources/datamap.md
+++ b/docs/resources/datamap.md
@@ -3,12 +3,12 @@
 page_title: "cyral_datamap Resource - cyral"
 subcategory: ""
 description: |-
-  Manages Data map https://cyral.com/docs/policy#data-map
+  Manages Data map https://cyral.com/docs/policy#data-map.
 ---
 
 # cyral_datamap (Resource)
 
-Manages [Data map](https://cyral.com/docs/policy#data-map)
+Manages [Data map](https://cyral.com/docs/policy#data-map).
 
 ## Example Usage
 

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -96,7 +96,7 @@ resource "cyral_repository" "repositories" {
 
 Optional:
 
-- `mongodb_replica_set` (Block Set) Used to configure a distributed database, such as a MongoDB cluster. (see [below for nested schema](#nestedblock--properties--mongodb_replica_set))
+- `mongodb_replica_set` (Block Set) Used to configure a MongoDB cluster. (see [below for nested schema](#nestedblock--properties--mongodb_replica_set))
 
 <a id="nestedblock--properties--mongodb_replica_set"></a>
 

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -63,7 +63,7 @@ resource "cyral_repository" "repositories" {
 ### Required
 
 - `host` (String) Repository host name (ex: `somerepo.cyral.com`).
-- `name` (String) Repository name that will be used internally in the control plane (ex: `your_repo_name`)
+- `name` (String) Repository name that will be used internally in the control plane (ex: `your_repo_name`).
 - `port` (Number) Repository access port (ex: `3306`).
 - `type` (String) Repository type. List of supported types:
   - `bigquery`
@@ -83,8 +83,26 @@ resource "cyral_repository" "repositories" {
 
 ### Optional
 
-- `labels` (List of String) labels enable you to categorize your repository
+- `advanced` (Block Set) Contains advanced repository configuration. (see [below for nested schema](#nestedblock--advanced))
+- `labels` (List of String) Labels enable you to categorize your repository.
 
 ### Read-Only
 
-- `id` (String) ID of this resource in Cyral environment
+- `id` (String) ID of this resource in Cyral environment.
+
+<a id="nestedblock--advanced"></a>
+
+### Nested Schema for `advanced`
+
+Optional:
+
+- `replica_set` (Block Set) Used to configure a distributed database, such as a MongoDB cluster. (see [below for nested schema](#nestedblock--advanced--replica_set))
+
+<a id="nestedblock--advanced--replica_set"></a>
+
+### Nested Schema for `advanced.replica_set`
+
+Required:
+
+- `max_nodes` (Number) Maximum number of nodes of the replica set cluster.
+- `replica_set_id` (String) Identifier of the replica set cluster. Used to construct the URI command (available in Cyral's Access Token page) that your users will need for connecting to the repository via Cyral.

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -83,24 +83,24 @@ resource "cyral_repository" "repositories" {
 
 ### Optional
 
-- `advanced` (Block Set) Contains advanced repository configuration. (see [below for nested schema](#nestedblock--advanced))
 - `labels` (List of String) Labels enable you to categorize your repository.
+- `properties` (Block Set) Contains advanced repository configuration. (see [below for nested schema](#nestedblock--properties))
 
 ### Read-Only
 
 - `id` (String) ID of this resource in Cyral environment.
 
-<a id="nestedblock--advanced"></a>
+<a id="nestedblock--properties"></a>
 
-### Nested Schema for `advanced`
+### Nested Schema for `properties`
 
 Optional:
 
-- `replica_set` (Block Set) Used to configure a distributed database, such as a MongoDB cluster. (see [below for nested schema](#nestedblock--advanced--replica_set))
+- `replica_set` (Block Set) Used to configure a distributed database, such as a MongoDB cluster. (see [below for nested schema](#nestedblock--properties--replica_set))
 
-<a id="nestedblock--advanced--replica_set"></a>
+<a id="nestedblock--properties--replica_set"></a>
 
-### Nested Schema for `advanced.replica_set`
+### Nested Schema for `properties.replica_set`
 
 Required:
 

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -96,11 +96,11 @@ resource "cyral_repository" "repositories" {
 
 Optional:
 
-- `replica_set` (Block Set) Used to configure a distributed database, such as a MongoDB cluster. (see [below for nested schema](#nestedblock--properties--replica_set))
+- `mongodb_replica_set` (Block Set) Used to configure a distributed database, such as a MongoDB cluster. (see [below for nested schema](#nestedblock--properties--mongodb_replica_set))
 
-<a id="nestedblock--properties--replica_set"></a>
+<a id="nestedblock--properties--mongodb_replica_set"></a>
 
-### Nested Schema for `properties.replica_set`
+### Nested Schema for `properties.mongodb_replica_set`
 
 Required:
 

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -84,7 +84,7 @@ resource "cyral_repository" "repositories" {
 ### Optional
 
 - `labels` (List of String) Labels enable you to categorize your repository.
-- `properties` (Block Set) Contains advanced repository configuration. (see [below for nested schema](#nestedblock--properties))
+- `properties` (Block Set, Max: 1) Contains advanced repository configuration. (see [below for nested schema](#nestedblock--properties))
 
 ### Read-Only
 
@@ -96,7 +96,7 @@ resource "cyral_repository" "repositories" {
 
 Optional:
 
-- `mongodb_replica_set` (Block Set) Used to configure a MongoDB cluster. (see [below for nested schema](#nestedblock--properties--mongodb_replica_set))
+- `mongodb_replica_set` (Block Set, Max: 1) Used to configure a MongoDB cluster. (see [below for nested schema](#nestedblock--properties--mongodb_replica_set))
 
 <a id="nestedblock--properties--mongodb_replica_set"></a>
 
@@ -105,4 +105,4 @@ Optional:
 Required:
 
 - `max_nodes` (Number) Maximum number of nodes of the replica set cluster.
-- `replica_set_id` (String) Identifier of the replica set cluster. Used to construct the URI command (available in Cyral's Access Token page) that your users will need for connecting to the repository via Cyral.
+- `replica_set_id` (String) Identifier of the replica set cluster. Used to construct the URI command (available in Cyral's Access Portal page) that your users will need for connecting to the repository via Cyral.


### PR DESCRIPTION
## Description of the change

Adds parameters necessary to support MongoDB replica sets to the cyral_repository resource.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Jira issue referenced in commit message and/or PR title

### Testing

Added ACC test that covers added parameters.

- Deploy a Terraform config with this version of the provider containing a cyral_repository resource like the following
```hcl
resource "cyral_repository" "repo1" {
    host = "mongo-host-1"
    port = 27017
    type = "mongodb"
    name = "mongo-repo-1"
    properties {
        mongodb_replica_set {
            max_nodes = 2
            replica_set_id = "replica-set-id-1"
        }
    }
}
```
- Doing GET v1/repos returns the same results as if the replica set had been created from the UI.
