### PR TITLE
Fix typo in guide to setup CP and deploy sidecar to AWS

### DIFF
--- a/docs/guides/setup_cp_and_deploy_sidecar.md
+++ b/docs/guides/setup_cp_and_deploy_sidecar.md
@@ -31,7 +31,7 @@ locals {
         # resources in the target AWS account. For this reason, we use 'cyral-zzzzzz' where
         # zzzzzz are the last 6 digits of the sidecar id created in the control plane. This
         # explanation is purely informational and we advise you to keep this variable as is.
-        sidecar_name_prefix = "cyral-${substr(lower(cyral_sidecar.mysql_sidecar.id), -6, -1)}"
+        sidecar_name_prefix = "cyral-${substr(lower(cyral_sidecar.main_sidecar.id), -6, -1)}"
 
         # If you would like to use other log integration, download a new template from the UI
         # and copy the log integration configuration or follow this module documentation.
@@ -81,7 +81,7 @@ provider "cyral" {
 }
 
 resource "cyral_sidecar" "main_sidecar" {
-  name              = "main_sidecar"
+  name              = "MainSidecar"
   deployment_method = "terraform"
 }
 


### PR DESCRIPTION
## Description of the change

Fix an invalid variable name in the guide to setup CP and deploy sidecar to AWS.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

Deployed the actual example and it worked.
