### PR TITLE
ENG-9128: Fix ACC tests

### DIFF
--- a/cyral/resource_cyral_datalabel_test.go
+++ b/cyral/resource_cyral_datalabel_test.go
@@ -43,7 +43,7 @@ func TestAccDatalabelResource(t *testing.T) {
 			{
 				ImportState:       true,
 				ImportStateVerify: true,
-				ResourceName:      "cyral_datalabel.test_datalabel",
+				ResourceName:      "cyral_datalabel.main_test",
 			},
 		},
 	})

--- a/cyral/resource_cyral_sidecar_test.go
+++ b/cyral/resource_cyral_sidecar_test.go
@@ -58,19 +58,19 @@ var singleContainerSidecarConfig *SidecarData = &SidecarData{
 	CertificateBundleSecrets: getTestCBS(),
 }
 
-var failoverSidecarConfig *SidecarData = &SidecarData{
-	Name:            "tf-provider-TestAccSidecarResource-failoverSidecar",
+var bypassNeverSidecarConfig *SidecarData = &SidecarData{
+	Name:            "tf-provider-TestAccSidecarResource-bypassNeverSidecar",
 	SidecarProperty: NewSidecarProperty("terraform"),
 	ServicesConfig: SidecarServicesConfig{
 		"dispatcher": map[string]string{
-			"bypass": "always",
+			"bypass": "never",
 		},
 	},
 	UserEndpoint: "some.user.endpoint",
 }
 
-var passthroughSidecarConfig *SidecarData = &SidecarData{
-	Name:            "tf-provider-TestAccSidecarResource-passthroughSidecar",
+var bypassAlwaysSidecarConfig *SidecarData = &SidecarData{
+	Name:            "tf-provider-TestAccSidecarResource-bypassAlwaysSidecar",
 	SidecarProperty: NewSidecarProperty("terraform"),
 	ServicesConfig: SidecarServicesConfig{
 		"dispatcher": map[string]string{
@@ -88,8 +88,8 @@ func TestAccSidecarResource(t *testing.T) {
 	testUpdateConfigSingleContainer, testUpdateFuncSingleContainer := setupSidecarTest(
 		singleContainerSidecarConfig,
 	)
-	testUpdateConfigPassthrough, testUpdateFuncPassthrough := setupSidecarTest(passthroughSidecarConfig)
-	testUpdateConfigFailover, testUpdateFuncFailover := setupSidecarTest(failoverSidecarConfig)
+	testUpdateConfigBypassAlways, testUpdateFuncBypassAlways := setupSidecarTest(bypassAlwaysSidecarConfig)
+	testUpdateConfigBypassNever, testUpdateFuncBypassNever := setupSidecarTest(bypassNeverSidecarConfig)
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
@@ -115,12 +115,12 @@ func TestAccSidecarResource(t *testing.T) {
 				Check:  testUpdateFuncSingleContainer,
 			},
 			{
-				Config: testUpdateConfigPassthrough,
-				Check:  testUpdateFuncPassthrough,
+				Config: testUpdateConfigBypassAlways,
+				Check:  testUpdateFuncBypassAlways,
 			},
 			{
-				Config: testUpdateConfigFailover,
-				Check:  testUpdateFuncFailover,
+				Config: testUpdateConfigBypassNever,
+				Check:  testUpdateFuncBypassNever,
 			},
 			{
 				ImportState:       true,


### PR DESCRIPTION
## Description of the change

The ACC tests were failing due to the Import test in the Data Label resource -- file `cyral/resource_cyral_datalabel_test.go`. After merging multiple PRs, specifically #260 and #261, unfortunately we missed this detail when solving the conflicts between the PRs.

I took the opportunity to correct a redundant ACC test we had added for the `cyral_sidecar` resource. The changes in `cyral_resource_sidecar_test.go` are not necessary for the fix, it is just to improve test quality there.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Jira issue referenced in commit message and/or PR title

### Testing

Ran all ACC tests against a clean Control Plane with version `v2.34.1`. All ACC tests are passing.
