### PR TITLE
ENG-9385: Fix race condition in user accounts test

### DIFF
--- a/cyral/resource_cyral_repository_user_account.go
+++ b/cyral/resource_cyral_repository_user_account.go
@@ -321,12 +321,11 @@ var ReadRepositoryUserAccountConfig = ResourceOperationConfig{
 }
 
 func resourceRepositoryUserAccount() *schema.Resource {
-	var authSchemeTypesFullScope []string
+	authSchemeTypesFullScopes := make([]string, 0, len(allAuthSchemes))
 	for _, authType := range allAuthSchemes {
-		authSchemeTypesFullScope = append(authSchemeTypesFullScope,
+		authSchemeTypesFullScopes = append(authSchemeTypesFullScopes,
 			fmt.Sprintf("auth_scheme.0.%s", authType))
 	}
-
 	return &schema.Resource{
 		CreateContext: CreateResource(
 			ResourceOperationConfig{
@@ -487,7 +486,7 @@ func resourceRepositoryUserAccount() *schema.Resource {
 								"Environment Variable.",
 							Optional:     true,
 							Type:         schema.TypeSet,
-							ExactlyOneOf: authSchemeTypesFullScope,
+							ExactlyOneOf: authSchemeTypesFullScopes,
 							MaxItems:     1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -505,7 +504,7 @@ func resourceRepositoryUserAccount() *schema.Resource {
 								"AWS IAM.",
 							Optional:     true,
 							Type:         schema.TypeSet,
-							ExactlyOneOf: authSchemeTypesFullScope,
+							ExactlyOneOf: authSchemeTypesFullScopes,
 							MaxItems:     1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -523,7 +522,7 @@ func resourceRepositoryUserAccount() *schema.Resource {
 								"AWS Secrets Manager.",
 							Optional:     true,
 							Type:         schema.TypeSet,
-							ExactlyOneOf: authSchemeTypesFullScope,
+							ExactlyOneOf: authSchemeTypesFullScopes,
 							MaxItems:     1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -541,7 +540,7 @@ func resourceRepositoryUserAccount() *schema.Resource {
 								"Cyral Storage.",
 							Optional:     true,
 							Type:         schema.TypeSet,
-							ExactlyOneOf: authSchemeTypesFullScope,
+							ExactlyOneOf: authSchemeTypesFullScopes,
 							MaxItems:     1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -560,7 +559,7 @@ func resourceRepositoryUserAccount() *schema.Resource {
 								"Hashicorp Vault.",
 							Optional:     true,
 							Type:         schema.TypeSet,
-							ExactlyOneOf: authSchemeTypesFullScope,
+							ExactlyOneOf: authSchemeTypesFullScopes,
 							MaxItems:     1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -585,7 +584,7 @@ func resourceRepositoryUserAccount() *schema.Resource {
 								"a Kubernetes secret.",
 							Optional:     true,
 							Type:         schema.TypeSet,
-							ExactlyOneOf: authSchemeTypesFullScope,
+							ExactlyOneOf: authSchemeTypesFullScopes,
 							MaxItems:     1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -608,7 +607,7 @@ func resourceRepositoryUserAccount() *schema.Resource {
 								"GCP Secrets Manager.",
 							Optional:     true,
 							Type:         schema.TypeSet,
-							ExactlyOneOf: authSchemeTypesFullScope,
+							ExactlyOneOf: authSchemeTypesFullScopes,
 							MaxItems:     1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{


### PR DESCRIPTION
## Description of the change

A race condition was caused during exactltyOneOf validation by [this line](https://github.com/cyralinc/terraform-provider-cyral/blob/30c18a231452631a0166e63fbb162bb3094ed9dd/cyral/resource_cyral_repository_user_account.go#L324), due to the fact that the slice was nor allocated. Allocating the slice, such that underlying array remains constant, removed the race condition. 

Please see [this slack thread](https://cyralinc.slack.com/archives/C01NQPCDRTQ/p1664820750286589) for more info. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Jira issue referenced in commit message and/or PR title

### Testing

> This was tested against a CFT based CP. 
