### PR TITLE
ENG-9704: Add support for local account automatic approvals

### DIFF
--- a/cyral/resource_cyral_repository_local_account.go
+++ b/cyral/resource_cyral_repository_local_account.go
@@ -268,15 +268,6 @@ func (repoAccount RepositoryLocalAccountResource) WriteToSchema(d *schema.Resour
 		d.Set("config", []interface{}{configMap})
 	}
 
-	configList := d.Get("config").(*schema.Set).List()
-	if len(configList) > 0 {
-		configMap := configList[0].(map[string]interface{})
-		repoAccount.Config = &RepoAccountConfig{
-			AutoApproveAccess:      configMap["auto_approve_access"].(bool),
-			MaxAutoApproveDuration: configMap["max_auto_approve_duration"].(string),
-		}
-	}
-
 	if repoAccount.AwsIAM != nil {
 		repoAccount.AwsIAM.WriteToSchema(d)
 	} else if repoAccount.AwsSecretsManager != nil {

--- a/cyral/resource_cyral_repository_local_account.go
+++ b/cyral/resource_cyral_repository_local_account.go
@@ -301,11 +301,10 @@ func (repoAccount RepositoryLocalAccountResource) WriteToSchema(d *schema.Resour
 func (repoAccount *RepositoryLocalAccountResource) ReadFromSchema(d *schema.ResourceData) error {
 	log.Printf("[DEBUG] RepositoryLocalAccountResource - ReadFromSchema START")
 
+	// `config` optional field
 	configList := d.Get("config").(*schema.Set).List()
-	log.Printf("[DEBUG] Config list: %#v", configList)
 	if len(configList) > 0 {
 		configMap := configList[0].(map[string]interface{})
-		log.Printf("[DEBUG] Config map: %#v", configMap)
 		repoAccount.Config = &RepoAccountConfig{
 			AutoApproveAccess:      configMap["auto_approve_access"].(bool),
 			MaxAutoApproveDuration: configMap["max_auto_approve_duration"].(string),

--- a/docs/resources/repository_local_account.md
+++ b/docs/resources/repository_local_account.md
@@ -6,6 +6,27 @@ Manages [repository local accounts](https://cyral.com/docs/using-cyral/sso-auth-
 
 ## Example Usage
 
+### Automatic Approval
+
+```terraform
+### AWS Secrets Manager with automatic approval
+resource "cyral_repository_local_account" "some_resource_name" {
+    repository_id = cyral_repository.SOME_REPOSITORY_RESOURCE_NAME.id
+    config {
+        auto_approve_access = true
+        # Automatically approve 5 minutes access requests
+        max_auto_approve_duration = "PT5M"
+    }
+    aws_secrets_manager {
+        database_name = ""
+        local_account = ""
+        secret_arn = ""
+    }
+}
+```
+
+### Different auth schemes
+
 ```terraform
 ### AWS IAM
 resource "cyral_repository_local_account" "some_resource_name" {
@@ -89,6 +110,7 @@ resource "cyral_repository_local_account" "some_resource_name" {
 
 - `aws_iam` (Block Set, Max: 1) Credential option to set the local account from AWS IAM. (see [below for nested schema](#nestedblock--aws_iam))
 - `aws_secrets_manager` (Block Set, Max: 1) Credential option to set the local account from AWS Secrets Manager. (see [below for nested schema](#nestedblock--aws_secrets_manager))
+- `config` (Block Set, Max: 1) Optional configuration for automatic approvals. (see [below for nested schema](#nestedblock--config))
 - `cyral_storage` (Block Set, Max: 1) Credential option to set the local account from Cyral Storage. (see [below for nested schema](#nestedblock--cyral_storage))
 - `enviroment_variable` (Block Set, Max: 1, Deprecated) Credential option to set the local account from Environment Variable. (see [below for nested schema](#nestedblock--enviroment_variable))
 - `environment_variable` (Block Set, Max: 1) Credential option to set the local account from Environment Variable. (see [below for nested schema](#nestedblock--environment_variable))
@@ -125,6 +147,18 @@ Required:
 Optional:
 
 - `database_name` (String) Database name that the local account corresponds to.
+
+<a id="nestedblock--config"></a>
+
+### Nested Schema for `config`
+
+Required:
+
+- `auto_approve_access` (Boolean) If true, enables automatic approvals for this local account.
+
+Optional:
+
+- `max_auto_approve_duration` (String) Maximum duration (in seconds) for which approvals can be automatically granted, following ISO 8601 time format. For example, "PT1H2M3S" indicates 1 hour, 2 minutes and 3 seconds. "PT4S" denotes 4 seconds.
 
 <a id="nestedblock--cyral_storage"></a>
 

--- a/examples/resources/cyral_repository_local_account/resource_automatic_approval.tf
+++ b/examples/resources/cyral_repository_local_account/resource_automatic_approval.tf
@@ -1,0 +1,14 @@
+### AWS Secrets Manager with automatic approval
+resource "cyral_repository_local_account" "some_resource_name" {
+    repository_id = cyral_repository.SOME_REPOSITORY_RESOURCE_NAME.id
+    config {
+        auto_approve_access = true
+        # Automatically approve 5 minutes access requests
+        max_auto_approve_duration = "PT5M"
+    }
+    aws_secrets_manager {
+        database_name = ""
+        local_account = ""
+        secret_arn = ""
+    }
+}

--- a/templates/resources/repository_local_account.md.tmpl
+++ b/templates/resources/repository_local_account.md.tmpl
@@ -6,6 +6,12 @@
 
 ## Example Usage
 
+### Automatic Approval
+
+{{ tffile "examples/resources/cyral_repository_local_account/resource_automatic_approval.tf" }}
+
+### Different auth schemes
+
 {{ tffile "examples/resources/cyral_repository_local_account/resource.tf" }}
 
 {{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
## Description of the change

This PR adds the argument `config` in the resource `cyral_repository_local_account`. `config` has a nested schema with arguments `auto_approve_access` and `max_auto_approve_duration`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Jira issue referenced in commit message and/or PR title

### Testing

#### Acceptance tests
Acceptance tests were added and are passing.

#### Manual tests

- Create local account without `config`
- Create local account with `config` but no `auto_approve_access` -- errs, as expected
- Create local account with `config` and `auto_approve_access` set to false 
  - Try `terraform apply` again and make sure plan is empty
- Create local account with `auto_approve_access = true` and `max_auto_approve_duration = "PT4S"`, update to `PT5M`
  - In every step, make sure terraform plan is empty
  - Check if UI matches config
- Also tried updating `auto_approve_access` from `true` to `false`
- Destroy worked for all cases above