### PR TITLE
ENG-9629: Use version constraint ~> for guides (v2)

### DIFF
--- a/docs/guides/mongodb_cluster_okta_idp.md
+++ b/docs/guides/mongodb_cluster_okta_idp.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     cyral = {
       source  = "cyralinc/cyral"
-      version = ">= 2.7.0"
+      version = "~> 2.7"
     }
     okta = {
       source = "okta/okta"
@@ -300,7 +300,7 @@ locals {
 
 module "cyral_idp_okta" {
   source = "cyralinc/idp/okta"
-  version = ">= 3.0.2"
+  version = "~> 3.0"
 
   tenant = "default"
 

--- a/docs/guides/native_credentials_aws_sm.md
+++ b/docs/guides/native_credentials_aws_sm.md
@@ -25,10 +25,14 @@ terraform {
   }
 }
 
-# See the Cyral provider documentation for more
-# information on how to initialize it correctly.
+# Follow the instructions in the Cyral Terraform Provider page to set
+# up the credentials:
+#
+# * https://registry.terraform.io/providers/cyralinc/cyral/latest/docs
 provider "cyral" {
     control_plane = "mycontrolplane.cyral.com:8000"
+    client_id     = ""
+    client_secret = ""
 }
 
 resource "cyral_repository" "mongodb_repo" {

--- a/docs/guides/native_credentials_aws_sm.md
+++ b/docs/guides/native_credentials_aws_sm.md
@@ -16,6 +16,15 @@ locals {
     }
 }
 
+terraform {
+  required_providers {
+    cyral = {
+      source  = "cyralinc/cyral"
+      version = "~> 2.10"
+    }
+  }
+}
+
 # See the Cyral provider documentation for more
 # information on how to initialize it correctly.
 provider "cyral" {

--- a/docs/guides/setup_cp_and_deploy_sidecar.md
+++ b/docs/guides/setup_cp_and_deploy_sidecar.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     cyral = {
       source  = "cyralinc/cyral"
-      version = ">= 2.7.0"
+      version = "~> 2.7.0"
     }
   }
 }

--- a/docs/guides/setup_cp_and_deploy_sidecar.md
+++ b/docs/guides/setup_cp_and_deploy_sidecar.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     cyral = {
       source  = "cyralinc/cyral"
-      version = "~> 2.7.0"
+      version = "~> 2.7"
     }
   }
 }

--- a/examples/guides/mongodb_cluster_okta_idp_okta.tf
+++ b/examples/guides/mongodb_cluster_okta_idp_okta.tf
@@ -5,7 +5,7 @@ locals {
 
 module "cyral_idp_okta" {
   source = "cyralinc/idp/okta"
-  version = ">= 3.0.2"
+  version = "~> 3.0"
 
   tenant = "default"
 

--- a/examples/guides/mongodb_cluster_okta_idp_versions.tf
+++ b/examples/guides/mongodb_cluster_okta_idp_versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cyral = {
       source  = "cyralinc/cyral"
-      version = ">= 2.7.0"
+      version = "~> 2.7"
     }
     okta = {
       source = "okta/okta"

--- a/examples/guides/native_credentials_aws_sm.tf
+++ b/examples/guides/native_credentials_aws_sm.tf
@@ -9,6 +9,15 @@ locals {
     }
 }
 
+terraform {
+  required_providers {
+    cyral = {
+      source  = "cyralinc/cyral"
+      version = "~> 2.10"
+    }
+  }
+}
+
 # See the Cyral provider documentation for more
 # information on how to initialize it correctly.
 provider "cyral" {

--- a/examples/guides/native_credentials_aws_sm.tf
+++ b/examples/guides/native_credentials_aws_sm.tf
@@ -18,10 +18,14 @@ terraform {
   }
 }
 
-# See the Cyral provider documentation for more
-# information on how to initialize it correctly.
+# Follow the instructions in the Cyral Terraform Provider page to set
+# up the credentials:
+#
+# * https://registry.terraform.io/providers/cyralinc/cyral/latest/docs
 provider "cyral" {
     control_plane = "mycontrolplane.cyral.com:8000"
+    client_id     = ""
+    client_secret = ""
 }
 
 resource "cyral_repository" "mongodb_repo" {

--- a/examples/guides/setup_cp_and_deploy_sidecar.tf
+++ b/examples/guides/setup_cp_and_deploy_sidecar.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cyral = {
       source  = "cyralinc/cyral"
-      version = ">= 2.7.0"
+      version = "~> 2.7.0"
     }
   }
 }

--- a/examples/guides/setup_cp_and_deploy_sidecar.tf
+++ b/examples/guides/setup_cp_and_deploy_sidecar.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cyral = {
       source  = "cyralinc/cyral"
-      version = "~> 2.7.0"
+      version = "~> 2.7"
     }
   }
 }


### PR DESCRIPTION
## Description of the change

This PR adds standardization to use the `~>` version constraint in the guides, to avoid having user deployments breaking due to v3 changes.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

I only tested the AWS SM guide, in which I added a `terraform` block and completed the `provider` block which were missing. I did not test the other guides because the changes made are not supposed to break anything, so I only did `terraform init` to make sure there are no typos.
