### PR TITLE
ENG-9835: Policy rule identities field should be omitted by default

### DIFF
--- a/cyral/resource_cyral_policy_rule.go
+++ b/cyral/resource_cyral_policy_rule.go
@@ -409,7 +409,7 @@ func resourcePolicyRuleUpdate(ctx context.Context, d *schema.ResourceData, m int
 
 func deletePolicyRule() ResourceOperationConfig {
 	return ResourceOperationConfig{
-		Name:       "RepositoryNetworkAccessPolicyDelete",
+		Name:       "PolicyRuleDelete",
 		HttpMethod: http.MethodDelete,
 		CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 			policyID, policyRuleID := unmarshalPolicyRuleID(d)

--- a/cyral/resource_cyral_policy_rule.go
+++ b/cyral/resource_cyral_policy_rule.go
@@ -267,7 +267,7 @@ func resourcePolicyRule() *schema.Resource {
 		CreateContext: resourcePolicyRuleCreate,
 		ReadContext:   resourcePolicyRuleRead,
 		UpdateContext: resourcePolicyRuleUpdate,
-		DeleteContext: DeleteResource(deletePolicyRule()),
+		DeleteContext: DeleteResource(policyRuleDeleteConfig()),
 
 		SchemaVersion: 1,
 		StateUpgraders: []schema.StateUpgrader{
@@ -407,7 +407,7 @@ func resourcePolicyRuleUpdate(ctx context.Context, d *schema.ResourceData, m int
 	return resourcePolicyRuleRead(ctx, d, m)
 }
 
-func deletePolicyRule() ResourceOperationConfig {
+func policyRuleDeleteConfig() ResourceOperationConfig {
 	return ResourceOperationConfig{
 		Name:       "PolicyRuleDelete",
 		HttpMethod: http.MethodDelete,

--- a/cyral/resource_cyral_policy_rule_test.go
+++ b/cyral/resource_cyral_policy_rule_test.go
@@ -20,6 +20,7 @@ type PolicyRuleConfig struct {
 	DeletedRateLimit int
 	UpdatedRateLimit int
 	ReadRateLimit    int
+	Identities       *Identity
 }
 
 var initialPolicyRuleConfig PolicyRuleConfig = PolicyRuleConfig{
@@ -29,30 +30,60 @@ var initialPolicyRuleConfig PolicyRuleConfig = PolicyRuleConfig{
 	DeletedRateLimit: 1,
 	UpdatedRateLimit: 2,
 	ReadRateLimit:    3,
+	Identities: &Identity{
+		DBRoles: []string{
+			"db-role-1",
+		},
+	},
 }
 
-var updated1PolicyRuleConfig PolicyRuleConfig = PolicyRuleConfig{
+var updatedGroupsPolicyRuleConfig PolicyRuleConfig = PolicyRuleConfig{
 	DeletedSeverity:  "low",
 	UpdatedSeverity:  "medium",
 	ReadSeverity:     "high",
 	DeletedRateLimit: 2,
 	UpdatedRateLimit: 3,
 	ReadRateLimit:    4,
+	Identities: &Identity{
+		Groups: []string{
+			"groups-1",
+		},
+	},
 }
 
-var updated2PolicyRuleConfig PolicyRuleConfig = PolicyRuleConfig{
+var updatedServicesPolicyRuleConfig PolicyRuleConfig = PolicyRuleConfig{
 	DeletedSeverity:  "high",
 	UpdatedSeverity:  "low",
 	ReadSeverity:     "medium",
 	DeletedRateLimit: 5,
 	UpdatedRateLimit: 6,
 	ReadRateLimit:    7,
+	Identities: &Identity{
+		Services: []string{
+			"services-1",
+		},
+	},
+}
+
+var updatedUsersPolicyRuleConfig PolicyRuleConfig = PolicyRuleConfig{
+	DeletedSeverity:  "high",
+	UpdatedSeverity:  "low",
+	ReadSeverity:     "medium",
+	DeletedRateLimit: 5,
+	UpdatedRateLimit: 6,
+	ReadRateLimit:    7,
+	Identities: &Identity{
+		Users: []string{
+			"users-1",
+		},
+	},
 }
 
 func TestAccPolicyRuleResource(t *testing.T) {
 	testConfig, testFunc := setupPolicyRuleTest(initialPolicyRuleConfig)
-	testUpdate1Config, testUpdate1Func := setupPolicyRuleTest(updated1PolicyRuleConfig)
-	testUpdate2Config, testUpdate2Func := setupPolicyRuleTest(updated2PolicyRuleConfig)
+	testGroupsConfig, testGroupsFunc := setupPolicyRuleTest(updatedGroupsPolicyRuleConfig)
+	testServicesConfig, testServicesFunc := setupPolicyRuleTest(updatedServicesPolicyRuleConfig)
+	testUsersConfig, testUsersFunc := setupPolicyRuleTest(updatedServicesPolicyRuleConfig)
 
 	importStateResName := "cyral_policy_rule.policy_rule_test"
 
@@ -64,12 +95,16 @@ func TestAccPolicyRuleResource(t *testing.T) {
 				Check:  testFunc,
 			},
 			{
-				Config: testUpdate1Config,
-				Check:  testUpdate1Func,
+				Config: testGroupsConfig,
+				Check:  testGroupsFunc,
 			},
 			{
-				Config: testUpdate2Config,
-				Check:  testUpdate2Func,
+				Config: testServicesConfig,
+				Check:  testServicesFunc,
+			},
+			{
+				Config: testUsersConfig,
+				Check:  testUsersFunc,
 			},
 			{
 				ImportState:       true,
@@ -107,26 +142,84 @@ func setupPolicyRuleTest(policyRule PolicyRuleConfig) (string, resource.TestChec
 		testLabelName,
 	)
 
-	testFunction := resource.ComposeTestCheckFunc(
-		resource.TestCheckResourceAttr("cyral_policy_rule.policy_rule_test", "deletes.0.severity", policyRule.DeletedSeverity),
-		resource.TestCheckResourceAttr("cyral_policy_rule.policy_rule_test", "reads.0.severity", policyRule.ReadSeverity),
-		resource.TestCheckResourceAttr("cyral_policy_rule.policy_rule_test", "updates.0.severity", policyRule.UpdatedSeverity),
-	)
+	resFullName := "cyral_policy_rule.policy_rule_test"
+	testFunctions := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(resFullName,
+			"deletes.0.severity", policyRule.DeletedSeverity),
+		resource.TestCheckResourceAttr(resFullName,
+			"reads.0.severity", policyRule.ReadSeverity),
+		resource.TestCheckResourceAttr(resFullName,
+			"updates.0.severity", policyRule.UpdatedSeverity),
+	}
 
-	return config, testFunction
+	if policyRule.Identities != nil {
+		identities := policyRule.Identities
+
+		for i, dbRole := range identities.DBRoles {
+			testFunctions = append(testFunctions,
+				resource.TestCheckResourceAttr(resFullName,
+					fmt.Sprintf("identities.0.db_roles.%d", i), dbRole),
+			)
+		}
+		for i, group := range identities.Groups {
+			testFunctions = append(testFunctions,
+				resource.TestCheckResourceAttr(resFullName,
+					fmt.Sprintf("identities.0.groups.%d", i), group),
+			)
+		}
+		for i, service := range identities.Services {
+			testFunctions = append(testFunctions,
+				resource.TestCheckResourceAttr(resFullName,
+					fmt.Sprintf("identities.0.services.%d", i), service),
+			)
+		}
+		for i, user := range identities.Users {
+			testFunctions = append(testFunctions,
+				resource.TestCheckResourceAttr(resFullName,
+					fmt.Sprintf("identities.0.users.%d", i), user),
+			)
+		}
+	}
+
+	return config, resource.ComposeTestCheckFunc(testFunctions...)
 }
 
 func formatPolicyRuleConfigIntoConfig(
 	policyRule PolicyRuleConfig,
 	dataLabelName string,
 ) string {
+	var identitiesStr string
+	if policyRule.Identities != nil {
+		identities := policyRule.Identities
+		identitiesStr += `
+		identities {`
+
+		if identities.DBRoles != nil {
+			identitiesStr += fmt.Sprintf(`
+			db_roles = %s`, listToStr(identities.DBRoles))
+		}
+		if identities.Groups != nil {
+			identitiesStr += fmt.Sprintf(`
+			groups = %s`, listToStr(identities.Groups))
+		}
+		if identities.Services != nil {
+			identitiesStr += fmt.Sprintf(`
+			services = %s`, listToStr(identities.Services))
+		}
+		if identities.Users != nil {
+			identitiesStr += fmt.Sprintf(`
+			users = %s`, listToStr(identities.Users))
+		}
+
+		identitiesStr += `
+		}`
+	}
+
 	return fmt.Sprintf(`
 	resource "cyral_policy_rule" "policy_rule_test" {
 		policy_id = cyral_policy.test_policy.id
 		hosts = ["192.0.2.22", "203.0.113.16/28"]
-		identities {
-			groups = ["analyst"]
-		}
+		%s
 		deletes {
 			data = ["%s"]
 			rows = 1
@@ -145,7 +238,8 @@ func formatPolicyRuleConfigIntoConfig(
 			severity = "%s"
 			rate_limit = %d
 		}
-	}`, dataLabelName, policyRule.DeletedSeverity, policyRule.DeletedRateLimit,
+	}`, identitiesStr,
+		dataLabelName, policyRule.DeletedSeverity, policyRule.DeletedRateLimit,
 		dataLabelName, policyRule.ReadSeverity, policyRule.ReadRateLimit,
 		dataLabelName, policyRule.UpdatedSeverity, policyRule.UpdatedRateLimit)
 }

--- a/cyral/resource_cyral_policy_rule_test.go
+++ b/cyral/resource_cyral_policy_rule_test.go
@@ -92,7 +92,7 @@ func TestAccPolicyRuleResource(t *testing.T) {
 	testConfig, testFunc := setupPolicyRuleTest(initialPolicyRuleConfig)
 	testGroupsConfig, testGroupsFunc := setupPolicyRuleTest(updatedGroupsPolicyRuleConfig)
 	testServicesConfig, testServicesFunc := setupPolicyRuleTest(updatedServicesPolicyRuleConfig)
-	testUsersConfig, testUsersFunc := setupPolicyRuleTest(updatedServicesPolicyRuleConfig)
+	testUsersConfig, testUsersFunc := setupPolicyRuleTest(updatedUsersPolicyRuleConfig)
 	testNoIdentityConfig, testNoIdentityFunc := setupPolicyRuleTest(updatedNoIdentityPolicyRuleConfig)
 
 	importStateResName := "cyral_policy_rule.policy_rule_test"

--- a/cyral/resource_cyral_policy_rule_test.go
+++ b/cyral/resource_cyral_policy_rule_test.go
@@ -79,11 +79,21 @@ var updatedUsersPolicyRuleConfig PolicyRuleConfig = PolicyRuleConfig{
 	},
 }
 
+var updatedNoIdentityPolicyRuleConfig PolicyRuleConfig = PolicyRuleConfig{
+	DeletedSeverity:  "low",
+	UpdatedSeverity:  "medium",
+	ReadSeverity:     "high",
+	DeletedRateLimit: 1,
+	UpdatedRateLimit: 2,
+	ReadRateLimit:    3,
+}
+
 func TestAccPolicyRuleResource(t *testing.T) {
 	testConfig, testFunc := setupPolicyRuleTest(initialPolicyRuleConfig)
 	testGroupsConfig, testGroupsFunc := setupPolicyRuleTest(updatedGroupsPolicyRuleConfig)
 	testServicesConfig, testServicesFunc := setupPolicyRuleTest(updatedServicesPolicyRuleConfig)
 	testUsersConfig, testUsersFunc := setupPolicyRuleTest(updatedServicesPolicyRuleConfig)
+	testNoIdentityConfig, testNoIdentityFunc := setupPolicyRuleTest(updatedNoIdentityPolicyRuleConfig)
 
 	importStateResName := "cyral_policy_rule.policy_rule_test"
 
@@ -105,6 +115,10 @@ func TestAccPolicyRuleResource(t *testing.T) {
 			{
 				Config: testUsersConfig,
 				Check:  testUsersFunc,
+			},
+			{
+				Config: testNoIdentityConfig,
+				Check:  testNoIdentityFunc,
 			},
 			{
 				ImportState:       true,


### PR DESCRIPTION
## Description of the change

This PR solves issue #300 

Also, this PR adds the capability of the policy rule to ignore a non-existent policy rule on deletion (when received a 404). I have encountered this problem in the past, so decided to include this fix in the PR.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Jira issue referenced in commit message and/or PR title

### Testing

Manually checked that the issue is not happening anymore.

Also added acceptance tests. All acceptance tests are passing after the changes.
