### PR TITLE
ENG-10094: Deprecate & Update Cyral Permissions in for Cyral Roles

### DIFF
--- a/cyral/resource_cyral_role.go
+++ b/cyral/resource_cyral_role.go
@@ -89,7 +89,7 @@ func resourceRole() *schema.Resource {
 							Description: "Allows viewing sidecars and repositories for this role. Defaults to `false`.",
 							Type:        schema.TypeBool,
 							Optional:    true,
-							Deprecated:  fmt.Sprintf(permissionIsDeprecatedMessage, "2.34.x", "2.35.x"),
+							Deprecated:  fmt.Sprintf(permissionIsDeprecatedMessage, "3.0.2", "3.0.3"),
 							Default:     false,
 						},
 						"view_audit_logs": {

--- a/cyral/resource_cyral_role.go
+++ b/cyral/resource_cyral_role.go
@@ -13,6 +13,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+const (
+	permissionIsDeprecatedMessage = "This permission can only be set " +
+		"on control plane versions up to `%s`. This permission is " +
+		"automatically granted to all Cyral Roles for control " +
+		"plane versions greater or equal to `%s`."
+)
+
 // Roles correspond to Groups in API.
 type RoleDataRequest struct {
 	Name string `json:"name,omitempty"`
@@ -82,6 +89,7 @@ func resourceRole() *schema.Resource {
 							Description: "Allows viewing sidecars and repositories for this role. Defaults to `false`.",
 							Type:        schema.TypeBool,
 							Optional:    true,
+							Deprecated:  fmt.Sprintf(permissionIsDeprecatedMessage, "2.34.x", "2.35.x"),
 							Default:     false,
 						},
 						"view_audit_logs": {
@@ -104,6 +112,18 @@ func resourceRole() *schema.Resource {
 						},
 						"view_datamaps": {
 							Description: "Allows viewing datamaps for this role. Defaults to `false`.",
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+						},
+						"approval_management": {
+							Description: "Allows approving or denying approval requests. Defaults to `false`.",
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+						},
+						"repo_crawler": {
+							Description: "Allows discovery of cyral_repository_user_accounts. Defaults to `false`.",
 							Type:        schema.TypeBool,
 							Optional:    true,
 							Default:     false,

--- a/cyral/resource_cyral_role.go
+++ b/cyral/resource_cyral_role.go
@@ -109,7 +109,7 @@ func resourceRole() *schema.Resource {
 							Default:     false,
 						},
 						"repo_crawler": {
-							Description: "Allows discovery of cyral_repository_user_accounts. Defaults to `false`.",
+							Description: "Allows reporting of cyral_repository_user_accounts. Defaults to `false`.",
 							Type:        schema.TypeBool,
 							Optional:    true,
 							Default:     false,

--- a/cyral/resource_cyral_role.go
+++ b/cyral/resource_cyral_role.go
@@ -13,13 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-const (
-	permissionIsDeprecatedMessage = "This permission can only be set " +
-		"on control plane versions up to `%s`. This permission is " +
-		"automatically granted to all Cyral Roles for control " +
-		"plane versions greater or equal to `%s`."
-)
-
 // Roles correspond to Groups in API.
 type RoleDataRequest struct {
 	Name string `json:"name,omitempty"`
@@ -83,13 +76,6 @@ func resourceRole() *schema.Resource {
 							Description: "Allows modifying policies for this role. Defaults to `false`.",
 							Type:        schema.TypeBool,
 							Optional:    true,
-							Default:     false,
-						},
-						"view_sidecars_and_repositories": {
-							Description: "Allows viewing sidecars and repositories for this role. Defaults to `false`.",
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Deprecated:  fmt.Sprintf(permissionIsDeprecatedMessage, "3.0.2", "3.0.3"),
 							Default:     false,
 						},
 						"view_audit_logs": {

--- a/cyral/resource_cyral_role_test.go
+++ b/cyral/resource_cyral_role_test.go
@@ -24,33 +24,36 @@ var onlyFalsePermissions = map[string]string{
 	"modify_sidecars_and_repositories": "false",
 	"modify_users":                     "false",
 	"modify_policies":                  "false",
-	"view_sidecars_and_repositories":   "false",
 	"view_audit_logs":                  "false",
 	"modify_integrations":              "false",
 	"modify_roles":                     "false",
 	"view_datamaps":                    "false",
+	"repo_crawler":                     "false",
+	"approval_management":              "false",
 }
 
 var trueAndFalsePermissions = map[string]string{
 	"modify_sidecars_and_repositories": "true",
 	"modify_users":                     "true",
 	"modify_policies":                  "true",
-	"view_sidecars_and_repositories":   "true",
 	"view_audit_logs":                  "false",
 	"modify_integrations":              "false",
 	"modify_roles":                     "false",
 	"view_datamaps":                    "false",
+	"repo_crawler":                     "true",
+	"approval_management":              "true",
 }
 
 var onlyTruePermissions = map[string]string{
 	"modify_sidecars_and_repositories": "true",
 	"modify_users":                     "true",
 	"modify_policies":                  "true",
-	"view_sidecars_and_repositories":   "true",
 	"view_audit_logs":                  "true",
 	"modify_integrations":              "true",
 	"modify_roles":                     "true",
 	"view_datamaps":                    "true",
+	"repo_crawler":                     "true",
+	"approval_management":              "true",
 }
 
 func TestAccRoleResource(t *testing.T) {
@@ -164,11 +167,12 @@ func testAccRoleConfig_OnlyFalsePermissions(resName string) string {
 			modify_sidecars_and_repositories = false
 			modify_users = false
 			modify_policies = false
-			view_sidecars_and_repositories = false
 			view_audit_logs = false
 			modify_integrations = false
 			modify_roles = false
 			view_datamaps = false
+			repo_crawler = false
+			approval_management = false
 		}
 	}
 	`, resName, updatedRoleName())
@@ -191,11 +195,12 @@ func testAccRoleConfig_TrueAndFalsePermissions(resName string) string {
 			modify_sidecars_and_repositories = true
 			modify_users = true
 			modify_policies = true
-			view_sidecars_and_repositories = true
 			view_audit_logs = false
 			modify_integrations = false
 			modify_roles = false
 			view_datamaps = false
+			repo_crawler = true
+			approval_management = true
 		}
 	}
 	`, resName, updatedRoleName())
@@ -218,11 +223,12 @@ func testAccRoleConfig_OnlyTruePermissions(resName string) string {
 			modify_sidecars_and_repositories = true
 			modify_users = true
 			modify_policies = true
-			view_sidecars_and_repositories = true
 			view_audit_logs = true
 			modify_integrations = true
 			modify_roles = true
 			view_datamaps = true
+			repo_crawler = true
+			approval_management = true
 		}
 	}
 	`, resName, updatedRoleName())

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -25,11 +25,12 @@ resource "cyral_role" "some_resource_name" {
     modify_sidecars_and_repositories = true
     modify_users = true
     modify_policies = true
-    view_sidecars_and_repositories = true
     view_audit_logs = false
     modify_integrations = false
     modify_roles = false
     view_datamaps = false
+    repo_crawler = false
+    approval_management = false
   }
 }
 ```
@@ -56,11 +57,12 @@ resource "cyral_role" "some_resource_name" {
 
 Optional:
 
+- `approval_management` (Boolean) Allows approving or denying approval requests. Defaults to `false`.
 - `modify_integrations` (Boolean) Allows modifying integrations for this role. Defaults to `false`.
 - `modify_policies` (Boolean) Allows modifying policies for this role. Defaults to `false`.
 - `modify_roles` (Boolean) Allows modifying roles for this role. Defaults to `false`.
 - `modify_sidecars_and_repositories` (Boolean) Allows modifying sidecars and repositories for this role. Defaults to `false`.
 - `modify_users` (Boolean) Allows modifying users for this role. Defaults to `false`.
+- `repo_crawler` (Boolean) Allows reporting of cyral_repository_user_accounts. Defaults to `false`.
 - `view_audit_logs` (Boolean) Allows viewing audit logs for this role. Defaults to `false`.
 - `view_datamaps` (Boolean) Allows viewing datamaps for this role. Defaults to `false`.
-- `view_sidecars_and_repositories` (Boolean) Allows viewing sidecars and repositories for this role. Defaults to `false`.

--- a/examples/resources/cyral_role/resource.tf
+++ b/examples/resources/cyral_role/resource.tf
@@ -10,10 +10,11 @@ resource "cyral_role" "some_resource_name" {
     modify_sidecars_and_repositories = true
     modify_users = true
     modify_policies = true
-    view_sidecars_and_repositories = true
     view_audit_logs = false
     modify_integrations = false
     modify_roles = false
     view_datamaps = false
+    repo_crawler = false
+    approval_management = false
   }
 }


### PR DESCRIPTION
## Description of the change

Jira: https://cyralinc.atlassian.net/browse/ENG-10094

After cleaning up some permissions that are no longer used, some Terraform tests broke. It turns out that the Cyral Role Terraform contains direct references to Cyral Permissions. This PR removes the 'View Sidecars and Repositories' permission that is now being granted to all API clients, users and groups. It also adds some new permissions that had not yet been added. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

> Description of testing
