### PR TITLE
ENG-10094: Deprecate 'View Sidecars and Repositories'

### DIFF
--- a/cyral/resource_cyral_role.go
+++ b/cyral/resource_cyral_role.go
@@ -13,6 +13,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+const (
+	permissionIsDeprecatedMessage = "This permission can only be set " +
+		"on control plane versions up to `%s`. This permission is " +
+		"automatically granted to all Cyral Roles for control " +
+		"plane versions greater or equal to `%s`."
+)
+
+
 // Roles correspond to Groups in API.
 type RoleDataRequest struct {
 	Name string `json:"name,omitempty"`
@@ -82,6 +90,7 @@ func resourceRole() *schema.Resource {
 							Description: "Allows viewing sidecars and repositories for this role. Defaults to `false`.",
 							Type:        schema.TypeBool,
 							Optional:    true,
+							Deprecated:  fmt.Sprintf(permissionIsDeprecatedMessage, "3.0.2", "3.0.3"),
 							Default:     false,
 						},
 						"view_audit_logs": {

--- a/cyral/resource_cyral_role.go
+++ b/cyral/resource_cyral_role.go
@@ -14,10 +14,9 @@ import (
 )
 
 const (
-	permissionIsDeprecatedMessage = "This permission can only be set " +
-		"on control plane versions up to `%s`. This permission is " +
-		"automatically granted to all Cyral Roles for control " +
-		"plane versions greater or equal to `%s`."
+	permissionIsDeprecatedMessage = "Setting this permission is " +
+	"deprecated. It will be automatically granted to all Cyral " +
+	"Roles for Control Planes `v3.x` and later."
 )
 
 
@@ -90,7 +89,7 @@ func resourceRole() *schema.Resource {
 							Description: "Allows viewing sidecars and repositories for this role. Defaults to `false`.",
 							Type:        schema.TypeBool,
 							Optional:    true,
-							Deprecated:  fmt.Sprintf(permissionIsDeprecatedMessage, "3.0.2", "3.0.3"),
+							Deprecated:  permissionIsDeprecatedMessage,
 							Default:     false,
 						},
 						"view_audit_logs": {

--- a/cyral/resource_cyral_role.go
+++ b/cyral/resource_cyral_role.go
@@ -15,10 +15,9 @@ import (
 
 const (
 	permissionIsDeprecatedMessage = "Setting this permission is " +
-	"deprecated. It will be automatically granted to all Cyral " +
-	"Roles for Control Planes `v3.x` and later."
+		"deprecated. It will be automatically granted to all Cyral " +
+		"Roles for Control Planes `v3.x` and later."
 )
-
 
 // Roles correspond to Groups in API.
 type RoleDataRequest struct {

--- a/cyral/resource_cyral_role_test.go
+++ b/cyral/resource_cyral_role_test.go
@@ -24,7 +24,6 @@ var onlyFalsePermissions = map[string]string{
 	"modify_sidecars_and_repositories": "false",
 	"modify_users":                     "false",
 	"modify_policies":                  "false",
-	"view_sidecars_and_repositories":   "false",
 	"view_audit_logs":                  "false",
 	"modify_integrations":              "false",
 	"modify_roles":                     "false",
@@ -35,7 +34,6 @@ var trueAndFalsePermissions = map[string]string{
 	"modify_sidecars_and_repositories": "true",
 	"modify_users":                     "true",
 	"modify_policies":                  "true",
-	"view_sidecars_and_repositories":   "true",
 	"view_audit_logs":                  "false",
 	"modify_integrations":              "false",
 	"modify_roles":                     "false",
@@ -46,7 +44,6 @@ var onlyTruePermissions = map[string]string{
 	"modify_sidecars_and_repositories": "true",
 	"modify_users":                     "true",
 	"modify_policies":                  "true",
-	"view_sidecars_and_repositories":   "true",
 	"view_audit_logs":                  "true",
 	"modify_integrations":              "true",
 	"modify_roles":                     "true",
@@ -155,7 +152,6 @@ func testAccRoleConfig_OnlyFalsePermissions() string {
 			modify_sidecars_and_repositories = false
 			modify_users = false
 			modify_policies = false
-			view_sidecars_and_repositories = false
 			view_audit_logs = false
 			modify_integrations = false
 			modify_roles = false
@@ -182,7 +178,6 @@ func testAccRoleConfig_TrueAndFalsePermissions() string {
 			modify_sidecars_and_repositories = true
 			modify_users = true
 			modify_policies = true
-			view_sidecars_and_repositories = true
 			view_audit_logs = false
 			modify_integrations = false
 			modify_roles = false
@@ -209,7 +204,6 @@ func testAccRoleConfig_OnlyTruePermissions() string {
 			modify_sidecars_and_repositories = true
 			modify_users = true
 			modify_policies = true
-			view_sidecars_and_repositories = true
 			view_audit_logs = true
 			modify_integrations = true
 			modify_roles = true

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -25,6 +25,7 @@ resource "cyral_role" "some_resource_name" {
     modify_sidecars_and_repositories = true
     modify_users = true
     modify_policies = true
+    view_sidecars_and_repositories = true
     view_audit_logs = false
     modify_integrations = false
     modify_roles = false

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -25,7 +25,6 @@ resource "cyral_role" "some_resource_name" {
     modify_sidecars_and_repositories = true
     modify_users = true
     modify_policies = true
-    view_sidecars_and_repositories = true
     view_audit_logs = false
     modify_integrations = false
     modify_roles = false
@@ -63,4 +62,4 @@ Optional:
 - `modify_users` (Boolean) Allows modifying users for this role. Defaults to `false`.
 - `view_audit_logs` (Boolean) Allows viewing audit logs for this role. Defaults to `false`.
 - `view_datamaps` (Boolean) Allows viewing datamaps for this role. Defaults to `false`.
-- `view_sidecars_and_repositories` (Boolean) Allows viewing sidecars and repositories for this role. Defaults to `false`.
+- `view_sidecars_and_repositories` (Boolean, Deprecated) Allows viewing sidecars and repositories for this role. Defaults to `false`.

--- a/examples/resources/cyral_role/resource.tf
+++ b/examples/resources/cyral_role/resource.tf
@@ -10,6 +10,7 @@ resource "cyral_role" "some_resource_name" {
     modify_sidecars_and_repositories = true
     modify_users = true
     modify_policies = true
+    view_sidecars_and_repositories = true
     view_audit_logs = false
     modify_integrations = false
     modify_roles = false

--- a/examples/resources/cyral_role/resource.tf
+++ b/examples/resources/cyral_role/resource.tf
@@ -10,7 +10,6 @@ resource "cyral_role" "some_resource_name" {
     modify_sidecars_and_repositories = true
     modify_users = true
     modify_policies = true
-    view_sidecars_and_repositories = true
     view_audit_logs = false
     modify_integrations = false
     modify_roles = false


### PR DESCRIPTION
## Description of the change

Jira: https://cyralinc.atlassian.net/browse/ENG-10094

After cleaning up some permissions that are no longer used, some Terraform tests broke. It turns out that the Cyral Role Terraform contains direct references to Cyral Permissions. This PR deprecates the 'View Sidecars and Repositories' permission that is now being granted to all API clients, users and groups. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Jira issue referenced in commit message and/or PR title

### Testing


