### PR TITLE
Modified the script to call terraform show less

### DIFF
--- a/scripts/3.0-migration.sh
+++ b/scripts/3.0-migration.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Set the color variable
+red='\033[0;31m'
+# Clear the color after that
+clear='\033[0m'
+
 if ! command -v terraform &> /dev/null
 then
     echo "The Terraform CLI must be installed for this script to run."
@@ -137,11 +142,11 @@ echo "Before we proceed, you will need to do the following:
 
             Access Rules
             resource \"cyral_repository_access_rules\" \"<resource_name>\" {}
-    ***********************************
-    *                                 *
-    * IMPORTANT STEP PLEASE DONT SKIP *
-    *                                 *
-    ***********************************
+    ************************************************
+    *                                              *
+    *        ${red}IMPORTANT STEP PLEASE DONT SKIP${clear}       *
+    *                                              *
+    ************************************************
     4.  Find all references to cyral_repository_identity_map and
         cyral_repository_local_account in your .tf file and remove the
         entire resource definition for each one."

--- a/scripts/3.0-migration.sh
+++ b/scripts/3.0-migration.sh
@@ -104,9 +104,6 @@ for resource in ${tf_state[@]}; do
   fi
 done
 
-echo ${user_account_resource_defs[1]}
-echo ${access_rule_resource_defs[1]}
-
 echo "Found ${#local_accounts_to_delete[@]} cyral_repository_local_accounts to migrate to cyral_repository_user_accounts."
 echo "Found ${#identity_maps_to_delete[@]} cyral_repository_identity_maps to migrate to cyral_repository_access_rules."
 echo
@@ -140,6 +137,11 @@ echo "Before we proceed, you will need to do the following:
 
             Access Rules
             resource \"cyral_repository_access_rules\" \"<resource_name>\" {}
+    ***********************************
+    *                                 *
+    * IMPORTANT STEP PLEASE DONT SKIP *
+    *                                 *
+    ***********************************
     4.  Find all references to cyral_repository_identity_map and
         cyral_repository_local_account in your .tf file and remove the
         entire resource definition for each one."


### PR DESCRIPTION
## Description of the change

Improved the script to make less calls to terraform show -json. Also I modified the way we create the tf_state array to only list cyral_repository_identity_map and cyral_repository_local_account. From a performance standpoint I tested locally migrating only 1 repo with 1 account and 1 identity map:

OLD bash ./3.0-migration.sh  5.87s user 1.28s system 114% cpu 6.235 
NEW bash ./3.0-migration.sh  1.05s user 0.25s system 97% cpu 1.332 total

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Optimization

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

Test is still running locally, but with my 6000 resource terraform script each resource takes 2-4 seconds vs 10+ on the previous script