### PR TITLE
ENG-9399: Repo Resource Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,52 @@ Renamed resource arguments:
 - **Fix acceptance tests for network access policy**: [#289](https://github.com/cyralinc/terraform-provider-cyral/pull/289).
 - **Fix race condition in user accounts test**: [#295](https://github.com/cyralinc/terraform-provider-cyral/pull/295).
 
+## 2.11.1 (November 14, 2022)
+
+Minimum required Control Plane version: `v2.35.0`.
+Resource incompatible with Control Planes between previous to `v2.35`: parameter `enable_dataset_rewrites` from resource `cyral_repository_conf_analysis`.
+
+### Bug fixes:
+
+- **Deprecate 'View Sidecars and Repositories'**: [#315](https://github.com/cyralinc/terraform-provider-cyral/pull/315).
+
+## 2.11.0 (November 7, 2022)
+
+Minimum required Control Plane version: `v2.35.0`.
+Resource incompatible with Control Planes between previous to `v2.35`: parameter `enable_dataset_rewrites` from resource `cyral_repository_conf_analysis`.
+
+### Features:
+
+- **Deprecate rewrite_on_violation, add enable_dataset_rewrites**: [#310](https://github.com/cyralinc/terraform-provider-cyral/pull/310).
+- **Add support for linux sidecar deployment**: [#311](https://github.com/cyralinc/terraform-provider-cyral/pull/311).
+
+## 2.10.2 (October 18, 2022)
+
+Minimum required Control Plane version: `v2.34.0`.
+Resource incompatible with Control Planes between `v2.32` and `v2.34`: parameter `bypass_mode` from resource `cyral_sidecar`.
+
+### Bug fixes:
+
+- **Policy rule identities field should be omitted by default**: [#302](https://github.com/cyralinc/terraform-provider-cyral/pull/302).
+
+## 2.10.1 (October 6, 2022)
+
+Minimum required Control Plane version: `v2.34.0`.
+Resource incompatible with Control Planes between `v2.32` and `v2.34`: parameter `bypass_mode` from resource `cyral_sidecar`.
+
+### Documentation:
+
+- **Use version constraint ~> for guides (v2)**: [#298](https://github.com/cyralinc/terraform-provider-cyral/pull/298).
+
+## 2.10.0 (October 5, 2022)
+
+Minimum required Control Plane version: `v2.34.0`.
+Resource incompatible with Control Planes between `v2.32` and `v2.34`: parameter `bypass_mode` from resource `cyral_sidecar`.
+
+### Features:
+
+- **Add support for local account automatic approvals**: [#296](https://github.com/cyralinc/terraform-provider-cyral/pull/296).
+
 ## 2.9.0 (September 16, 2022)
 
 Minimum required Control Plane version: `v2.34.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 3.0.3 (November 14, 2022)
+
+Minimum required Control Plane version: `v3.0.0`.
+
+See the list of incompatible resources with Control Planes `v2.x` and Terraform `v2.x` in the [`3.0.0`](#300-october-5-2022) release documentation.
+
+### Bug fixes:
+
+- **Deprecate & Update Cyral Permissions in for Cyral Roles**: [#313](https://github.com/cyralinc/terraform-provider-cyral/pull/#313).
+- **Fix sidecar resource nil properties issue**: [#317](https://github.com/cyralinc/terraform-provider-cyral/pull/#317).
+
 ## 3.0.2 (November 7, 2022)
 
 Minimum required Control Plane version: `v3.0.0`.
@@ -6,16 +17,16 @@ See the list of incompatible resources with Control Planes `v2.x` and Terraform 
 
 ### Bug fixes:
 
-- **Remove rewrite_on_violation, add enable_dataset_rewrites**: [##308](https://github.com/cyralinc/terraform-provider-cyral/pull/#308).
-- **Add support for linux sidecar deployment**: [##311](https://github.com/cyralinc/terraform-provider-cyral/pull/#311).
+- **Remove rewrite_on_violation, add enable_dataset_rewrites**: [#308](https://github.com/cyralinc/terraform-provider-cyral/pull/#308).
+- **Add support for linux sidecar deployment**: [#311](https://github.com/cyralinc/terraform-provider-cyral/pull/#311).
 
 ### Documentation fixes:
 
-- **Fix typo edit in migration script**: [##307](https://github.com/cyralinc/terraform-provider-cyral/pull/#307).
+- **Fix typo edit in migration script**: [#307](https://github.com/cyralinc/terraform-provider-cyral/pull/#307).
 
 ### Security fixes:
 
-- **Bump github.com/stretchr/testify from 1.8.0 to 1.8.1**: [##306](https://github.com/cyralinc/terraform-provider-cyral/pull/#306).
+- **Bump github.com/stretchr/testify from 1.8.0 to 1.8.1**: [#306](https://github.com/cyralinc/terraform-provider-cyral/pull/#306).
 
 ## 3.0.1 (October 18, 2022)
 
@@ -98,7 +109,7 @@ Resource incompatible with Control Planes between `v2.32` and `v2.34`: parameter
 ### Improvements:
 
 - **Refactor acceptance tests**: [#267](https://github.com/cyralinc/terraform-provider-cyral/pull/267).
-- **Explain setting max value of port range**: [##277](https://github.com/cyralinc/terraform-provider-cyral/pull/#277).
+- **Explain setting max value of port range**: [#277](https://github.com/cyralinc/terraform-provider-cyral/pull/#277).
 
 ## 2.8.0 (August 5, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 3.0.4 (November 18, 2022)
+
+Minimum required Control Plane version: `v3.0.0`.
+
+See the list of incompatible resources with Control Planes `v2.x` and Terraform `v2.x` in the [`3.0.0`](#300-october-5-2022) release documentation.
+
+### Bug fixes:
+
+- **Modified the script to call terraform show less**: [#320](https://github.com/cyralinc/terraform-provider-cyral/pull/#320).
+
 ## 3.0.3 (November 14, 2022)
 
 Minimum required Control Plane version: `v3.0.0`.

--- a/cyral/data_source_cyral_repository.go
+++ b/cyral/data_source_cyral_repository.go
@@ -12,11 +12,11 @@ import (
 )
 
 // GetReposSubResponse is different from GetRepoByIDResponse. For the by-id
-// reponse, we expect the ids to be embedded in the RepoData struct. For
-// GetReposSubResponse, the ids come outside of RepoData.
+// reponse, we expect the ids to be embedded in the RepoInfo struct. For
+// GetReposSubResponse, the ids come outside of RepoInfo.
 type GetReposSubResponse struct {
 	ID   string   `json:"id"`
-	Repo RepoData `json:"repo"`
+	Repo RepoInfo `json:"repo"`
 }
 
 type GetReposResponse struct {
@@ -31,7 +31,7 @@ func (resp *GetReposResponse) WriteToSchema(d *schema.ResourceData) error {
 		argumentVals := map[string]interface{}{
 			"id":         repoID,
 			"name":       repoData.Name,
-			"type":       repoData.RepoType,
+			"type":       repoData.Type,
 			"host":       repoData.Host,
 			"port":       repoData.Port,
 			"labels":     repoData.Labels,

--- a/cyral/data_source_cyral_repository_test.go
+++ b/cyral/data_source_cyral_repository_test.go
@@ -11,20 +11,20 @@ const (
 	repositoryDataSourceName = "data-repository"
 )
 
-func repositoryDataSourceTestRepos() []RepoData {
-	return []RepoData{
+func repositoryDataSourceTestRepos() []RepoInfo {
+	return []RepoInfo{
 		{
-			Name:     accTestName(repositoryDataSourceName, "sqlserver-1"),
-			Host:     "localhost",
-			Port:     1433,
-			RepoType: "sqlserver",
-			Labels:   []string{"rds", "us-east-2"},
+			Name:   accTestName(repositoryDataSourceName, "sqlserver-1"),
+			Host:   "localhost",
+			Port:   1433,
+			Type:   "sqlserver",
+			Labels: []string{"rds", "us-east-2"},
 		},
 		{
 			Name:                accTestName(repositoryDataSourceName, "mongodb-1"),
 			Host:                "localhost",
 			Port:                27017,
-			RepoType:            "mongodb",
+			Type:                "mongodb",
 			Labels:              []string{"rds", "us-east-1"},
 			MaxAllowedListeners: 2,
 			Properties: &RepositoryProperties{
@@ -63,14 +63,14 @@ func TestAccRepositoryDataSource(t *testing.T) {
 	})
 }
 
-func testRepositoryDataSource(repoDatas []RepoData, nameFilter, typeFilter string) (
+func testRepositoryDataSource(repoDatas []RepoInfo, nameFilter, typeFilter string) (
 	string, resource.TestCheckFunc,
 ) {
 	return testRepositoryDataSourceConfig(repoDatas, nameFilter, typeFilter),
 		testRepositoryDataSourceChecks(repoDatas, nameFilter, typeFilter)
 }
 
-func testRepositoryDataSourceConfig(repoDatas []RepoData, nameFilter, typeFilter string) string {
+func testRepositoryDataSourceConfig(repoDatas []RepoInfo, nameFilter, typeFilter string) string {
 	var config string
 	var dependsOn []string
 	for _, repoData := range repoDatas {
@@ -82,7 +82,7 @@ func testRepositoryDataSourceConfig(repoDatas []RepoData, nameFilter, typeFilter
 	return config
 }
 
-func testRepositoryDataSourceChecks(repoDatas []RepoData, nameFilter, typeFilter string) resource.TestCheckFunc {
+func testRepositoryDataSourceChecks(repoDatas []RepoInfo, nameFilter, typeFilter string) resource.TestCheckFunc {
 	dataSourceFullName := "data.cyral_repository.test_repository"
 
 	if nameFilter == "" {
@@ -107,7 +107,7 @@ func testRepositoryDataSourceChecks(repoDatas []RepoData, nameFilter, typeFilter
 			resource.TestCheckResourceAttr(dataSourceFullName,
 				"repository_list.0.name", repoData.Name),
 			resource.TestCheckResourceAttr(dataSourceFullName,
-				"repository_list.0.type", repoData.RepoType),
+				"repository_list.0.type", repoData.Type),
 			resource.TestCheckResourceAttr(dataSourceFullName,
 				"repository_list.0.host", repoData.Host),
 			resource.TestCheckResourceAttr(dataSourceFullName,
@@ -134,11 +134,11 @@ func testRepositoryDataSourceChecks(repoDatas []RepoData, nameFilter, typeFilter
 	return testFunction
 }
 
-func filterRepoDatas(repoDatas []RepoData, nameFilter, typeFilter string) []RepoData {
-	var filteredRepoDatas []RepoData
+func filterRepoDatas(repoDatas []RepoInfo, nameFilter, typeFilter string) []RepoInfo {
+	var filteredRepoDatas []RepoInfo
 	for _, repoData := range repoDatas {
 		if (nameFilter == "" || repoData.Name == nameFilter) &&
-			(typeFilter == "" || repoData.RepoType == typeFilter) {
+			(typeFilter == "" || repoData.Type == typeFilter) {
 			filteredRepoDatas = append(filteredRepoDatas, repoData)
 		}
 	}

--- a/cyral/data_source_cyral_sidecar_bound_ports.go
+++ b/cyral/data_source_cyral_sidecar_bound_ports.go
@@ -182,13 +182,6 @@ func getBindingPorts(
 		bindingPorts = append(bindingPorts, primaryPort)
 	}
 
-	// MaxAllowedListeners is currently used to generate a repo binding port range
-	// between primaryPort and (primaryPort+MaxAllowedListeners-1). Thats why we
-	// add (MaxAllowedListeners-1) more ports to the repo binding ports.
-	for i := uint32(1); i < repoInfo.MaxAllowedListeners; i++ {
-		bindingPorts = append(bindingPorts, primaryPort+i)
-	}
-
 	// TcpListeners, also referred as seedListeners, are used as extra data
 	// repo out routes, and can be used, for instance, for mongoDB replicasets
 	// and sharded clusters.

--- a/cyral/data_source_cyral_sidecar_bound_ports.go
+++ b/cyral/data_source_cyral_sidecar_bound_ports.go
@@ -147,17 +147,17 @@ func getRepoBinding(
 	return bindingConfig, nil
 }
 
-func getRepoInfo(c *client.Client, repoID string) (RepoData, error) {
+func getRepoInfo(c *client.Client, repoID string) (RepoInfo, error) {
 	log.Printf("[DEBUG] Init getRepoInfo")
 	url := fmt.Sprintf("https://%s/v1/repos/%s", c.ControlPlane, repoID)
 	body, err := c.DoRequest(url, http.MethodGet, nil)
 	if err != nil {
-		return RepoData{}, err
+		return RepoInfo{}, err
 	}
 
 	var repoResponse GetRepoByIDResponse
 	if err := json.Unmarshal(body, &repoResponse); err != nil {
-		return RepoData{}, err
+		return RepoInfo{}, err
 	}
 	log.Printf("[DEBUG] Response body (unmarshalled): %#v", repoResponse)
 	log.Printf("[DEBUG] End getRepoInfo")
@@ -171,7 +171,7 @@ func getRepoInfo(c *client.Client, repoID string) (RepoData, error) {
 // than one node, or S3 repos that support S3 Browser, etc.
 func getBindingPorts(
 	bindingConfig BindingConfig,
-	repoInfo RepoData,
+	repoInfo RepoInfo,
 ) []uint32 {
 	var bindingPorts []uint32
 

--- a/cyral/data_source_cyral_sidecar_bound_ports_test.go
+++ b/cyral/data_source_cyral_sidecar_bound_ports_test.go
@@ -172,12 +172,10 @@ func TestGetBindingPorts_MultiplePorts(t *testing.T) {
 			},
 		},
 	}
-	repo := RepoInfo{
-		MaxAllowedListeners: 3,
-	}
+	repo := RepoInfo{}
 	ports := getBindingPorts(binding, repo)
 
-	expectedPorts := []uint32{443, 457, 1234, 1235, 1236, 37017, 47017}
+	expectedPorts := []uint32{443, 457, 1234, 37017, 47017}
 
 	assert.ElementsMatch(t, expectedPorts, ports)
 }

--- a/cyral/data_source_cyral_sidecar_bound_ports_test.go
+++ b/cyral/data_source_cyral_sidecar_bound_ports_test.go
@@ -130,7 +130,7 @@ func testAccSidecarBoundPortsCheck_MultipleBindings() resource.TestCheckFunc {
 }
 
 func TestGetBindingPorts_NoPorts(t *testing.T) {
-	ports := getBindingPorts(BindingConfig{}, RepoData{})
+	ports := getBindingPorts(BindingConfig{}, RepoInfo{})
 
 	assert.Len(t, ports, 0)
 }
@@ -141,7 +141,7 @@ func TestGetBindingPorts_SinglePort(t *testing.T) {
 			Port: 1234,
 		},
 	}
-	ports := getBindingPorts(binding, RepoData{})
+	ports := getBindingPorts(binding, RepoInfo{})
 
 	expectedPorts := []uint32{1234}
 
@@ -172,7 +172,7 @@ func TestGetBindingPorts_MultiplePorts(t *testing.T) {
 			},
 		},
 	}
-	repo := RepoData{
+	repo := RepoInfo{
 		MaxAllowedListeners: 3,
 	}
 	ports := getBindingPorts(binding, repo)

--- a/cyral/provider.go
+++ b/cyral/provider.go
@@ -8,9 +8,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cyralinc/terraform-provider-cyral/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/cyralinc/terraform-provider-cyral/client"
 )
 
 const (
@@ -117,6 +118,9 @@ func Provider() *schema.Provider {
 			"cyral_role_sso_groups":                  resourceRoleSSOGroups(),
 			"cyral_sidecar":                          resourceSidecar(),
 			"cyral_sidecar_credentials":              resourceSidecarCredentials(),
+			// The Sidecar Listener resource will be reenabled when the port-multiplexing
+			// feature is completed. Jira: https://cyralinc.atlassian.net/browse/ENG-9398
+			//"cyral_sidecar_listener":                 resourceSidecarListener(),
 		},
 		ConfigureContextFunc: providerConfigure,
 	}

--- a/cyral/resource_cyral_repository.go
+++ b/cyral/resource_cyral_repository.go
@@ -1,19 +1,33 @@
 package cyral
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/cyralinc/terraform-provider-cyral/client"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 const (
+	// Schema keys
+	RepoIDKey                = "id"
+	RepoTypeKey              = "type"
+	RepoNameKey              = "name"
+	RepoLabelsKey            = "labels"
+	RepoConnDrainingKey      = "connection_draining"
+	RepoConnDrainingAutoKey  = "auto"
+	RepoConnDrainingWaitTime = "wait_time"
+
+	// Deprecated schema keys
+	RepoHostKey              = "host"
+	RepoPortKey              = "port"
+	RepoPropertiesKey        = "properties"
+	RepoMongoDBReplicaSetKey = "mongodb_replica_set"
+	RepoMaxNodesKey          = "max_nodes"
+	RepoReplicaSetIDKey      = "replica_set_id"
+
+	// Values related to deprecrated fields.
 	mongodbRepoType                  = "mongodb"
 	mongodbReplicaSetServerType      = "replicaset"
 	deprecatedHostAndPortMessage     = "`%s` is deprecated. Use `repoNodes` instead, which support single as well as multi-node repo types."
@@ -41,10 +55,6 @@ func repositoryTypes() []string {
 	}
 }
 
-type GetRepoByIDResponse struct {
-	Repo RepoInfo `json:"repo"`
-}
-
 type RepoInfo struct {
 	ID                       string                `json:"id"`
 	Name                     string                `json:"name"`
@@ -69,9 +79,6 @@ type ConnDraining struct {
 	WaitTime uint32 `json:"waitTime"`
 }
 
-// RepositoryProperties relates to the field "properties" of the v1/repos
-// API. All fields of this struct _must_ be of type string, to comply with the
-// API.
 type RepositoryProperties struct {
 	// Replica set
 	MongoDBReplicaSetName string `json:"mongodb-replicaset-name,omitempty"`
@@ -88,7 +95,6 @@ type BindingKey struct {
 	BindingID string `json:"bindingId,omitempty"`
 }
 
-// RepoNode represents a node in a repo
 type RepoNode struct {
 	Name    string `json:"name"`
 	Host    string `json:"host"`
@@ -96,44 +102,117 @@ type RepoNode struct {
 	Dynamic bool   `json:"dynamic"`
 }
 
-func (data *RepoInfo) WriteToSchema(d *schema.ResourceData) error {
-	d.Set("type", data.Type)
-	d.Set("host", data.Host)
-	d.Set("port", data.Port)
-	d.Set("name", data.Name)
-	d.Set("labels", data.Labels)
+type GetRepoByIDResponse struct {
+	Repo RepoInfo `json:"repo"`
+}
 
-	if properties := data.PropertiesAsInterface(); properties != nil {
+func (res *GetRepoByIDResponse) WriteToSchema(d *schema.ResourceData) error {
+	return res.Repo.WriteToSchema(d)
+}
+
+func (res *RepoInfo) WriteToSchema(d *schema.ResourceData) error {
+	d.Set(RepoTypeKey, res.Type)
+	d.Set(RepoHostKey, res.Host)
+	d.Set(RepoPortKey, res.Port)
+	d.Set(RepoNameKey, res.Name)
+	d.Set(RepoLabelsKey, res.LabelsAsInterface())
+	d.Set(RepoConnDrainingKey, res.ConnDrainingAsInterface())
+	if properties := res.PropertiesAsInterface(); properties != nil {
 		d.Set("properties", properties)
 	}
 	return nil
 }
 
-func (data *RepoInfo) ReadFromSchema(d *schema.ResourceData) error {
-	return nil
+func (r *RepoInfo) LabelsAsInterface() []interface{} {
+	if r.Labels == nil {
+		return nil
+	}
+	result := make([]interface{}, len(r.Labels))
+	for i, v := range r.Labels {
+		result[i] = v
+	}
+	return result
 }
 
-func (data *GetRepoByIDResponse) WriteToSchema(d *schema.ResourceData) error {
-	return nil
+func (r *RepoInfo) LabelsFromInterface(i []interface{}) {
+	labels := make([]string, len(i))
+	for i, v := range i {
+		labels[i] = v.(string)
+	}
+	r.Labels = labels
 }
 
-func (data *RepoInfo) PropertiesAsInterface() []interface{} {
-	var properties []interface{}
-	if data.Properties != nil {
-		if data.IsReplicaSet() {
-			propertiesMap := make(map[string]interface{})
-			var rset []interface{}
-			rsetMap := make(map[string]interface{})
-			rsetMap["max_nodes"] = data.MaxAllowedListeners
-			rsetMap["replica_set_id"] = data.Properties.MongoDBReplicaSetName
-			rset = append(rset, rsetMap)
-
-			propertiesMap["mongodb_replica_set"] = rset
-			properties = append(properties, propertiesMap)
-		}
+func (r *RepoInfo) ConnDrainingAsInterface() []interface{} {
+	if r.ConnParams == nil || r.ConnParams.ConnDraining == nil {
+		return nil
 	}
 
-	return properties
+	return []interface{}{map[string]interface{}{
+		RepoConnDrainingAutoKey:  r.ConnParams.ConnDraining.Auto,
+		RepoConnDrainingWaitTime: r.ConnParams.ConnDraining.WaitTime,
+	}}
+}
+
+func (r *RepoInfo) ConnDrainingFromInterface(i []interface{}) {
+	if len(i) == 0 {
+		return
+	}
+	r.ConnParams = &ConnParams{
+		ConnDraining: &ConnDraining{
+			Auto:     i[0].(map[string]interface{})[RepoConnDrainingAutoKey].(bool),
+			WaitTime: uint32(i[0].(map[string]interface{})[RepoConnDrainingWaitTime].(int)),
+		},
+	}
+}
+
+func (r *RepoInfo) PropertiesAsInterface() []interface{} {
+	if !r.IsReplicaSet() {
+		return nil
+	}
+
+	return []interface{}{map[string]interface{}{
+		RepoMongoDBReplicaSetKey: []interface{}{map[string]interface{}{
+			RepoMaxNodesKey:     r.MaxAllowedListeners,
+			RepoReplicaSetIDKey: r.Properties.MongoDBReplicaSetName,
+		},
+		}}}
+
+}
+
+func (r *RepoInfo) PropertiesFromInterface(i []interface{}) error {
+	if len(i) == 0 {
+		return nil
+	}
+	return r.ReplicaSetFromInterface(i[0].(map[string]interface{})[RepoMongoDBReplicaSetKey].(*schema.Set).List())
+}
+
+func (r *RepoInfo) ReplicaSetFromInterface(i []interface{}) error {
+	if len(i) == 0 {
+		return nil
+	}
+
+	if r.Type != mongodbRepoType {
+		return fmt.Errorf(
+			"replica sets are only supported for repository type '%s'",
+			mongodbRepoType)
+	}
+	r.Properties = &RepositoryProperties{
+		MongoDBReplicaSetName: i[0].(map[string]interface{})[RepoReplicaSetIDKey].(string),
+		MongoDBServerType:     mongodbReplicaSetServerType,
+	}
+	r.MaxAllowedListeners = uint32(i[0].(map[string]interface{})[RepoMaxNodesKey].(int))
+	return nil
+}
+
+func (r *RepoInfo) ReadFromSchema(d *schema.ResourceData) error {
+	r.ID = d.Id()
+	r.Name = d.Get(RepoNameKey).(string)
+	r.Type = d.Get(RepoTypeKey).(string)
+	r.Host = d.Get(RepoHostKey).(string)
+	r.Port = uint32(d.Get(RepoPortKey).(int))
+	r.ConnDrainingFromInterface(d.Get(RepoConnDrainingKey).(*schema.Set).List())
+	r.LabelsFromInterface(d.Get(RepoLabelsKey).([]interface{}))
+	return r.PropertiesFromInterface(d.Get(RepoPropertiesKey).(*schema.Set).List())
 }
 
 func (data *RepoInfo) IsReplicaSet() bool {
@@ -151,7 +230,7 @@ var ReadRepositoryConfig = ResourceOperationConfig{
 		)
 	},
 	NewResponseData: func(_ *schema.ResourceData) ResponseData {
-		return &RepoInfo{}
+		return &GetRepoByIDResponse{}
 	},
 }
 
@@ -174,12 +253,12 @@ func resourceRepository() *schema.Resource {
 					return &RepoInfo{}
 				},
 				NewResponseData: func(_ *schema.ResourceData) ResponseData {
-					return &GetRepoByIDResponse{}
+					return &IDBasedResponse{}
 				},
 			},
 			ReadRepositoryConfig,
 		),
-		ReadContext: ReadResource(ReadRepositoryUserAccountConfig),
+		ReadContext: ReadResource(ReadRepositoryConfig),
 		UpdateContext: UpdateResource(
 			ResourceOperationConfig{
 				Name:       "RepositoryUpdate",
@@ -212,35 +291,35 @@ func resourceRepository() *schema.Resource {
 		),
 
 		Schema: map[string]*schema.Schema{
-			"id": {
+			RepoIDKey: {
 				Description: "ID of this resource in Cyral environment.",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
-			"type": {
+			RepoTypeKey: {
 				Description:  "Repository type. List of supported types:" + supportedTypesMarkdown(repositoryTypes()),
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.StringInSlice(repositoryTypes(), false),
 			},
-			"host": {
+			RepoHostKey: {
 				Description: "Repository host name (ex: `somerepo.cyral.com`).",
 				Type:        schema.TypeString,
 				Required:    true,
 				Deprecated:  fmt.Sprintf(deprecatedHostAndPortMessage, "host"),
 			},
-			"port": {
+			RepoPortKey: {
 				Description: "Repository access port (ex: `3306`).",
 				Type:        schema.TypeInt,
 				Required:    true,
 				Deprecated:  fmt.Sprintf(deprecatedHostAndPortMessage, "port"),
 			},
-			"name": {
+			RepoNameKey: {
 				Description: "Repository name that will be used internally in the control plane (ex: `your_repo_name`).",
 				Type:        schema.TypeString,
 				Required:    true,
 			},
-			"labels": {
+			RepoLabelsKey: {
 				Description: "Labels enable you to categorize your repository.",
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -248,7 +327,27 @@ func resourceRepository() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"properties": {
+			RepoConnDrainingKey: {
+				Description: "Parameters related to connection draining.",
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						RepoConnDrainingAutoKey: {
+							Description: "Whether connections should be drained automatically after a listener is dead",
+							Type:        schema.TypeBool,
+							Optional:    true,
+						},
+						RepoConnDrainingWaitTime: {
+							Description: "Seconds to wait to let connections drain before starting to kill all the connections, " +
+								"if auto is set to true.",
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+					},
+				},
+			},
+			RepoPropertiesKey: {
 				Description: "Contains advanced repository configuration.",
 				Type:        schema.TypeSet,
 				Optional:    true,
@@ -256,21 +355,21 @@ func resourceRepository() *schema.Resource {
 				Deprecated:  fmt.Sprintf(deprecatedRepoProperitiesMessage, "properties"),
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"mongodb_replica_set": {
+						RepoMongoDBReplicaSetKey: {
 							Description: "Used to configure a MongoDB cluster.",
 							Type:        schema.TypeSet,
 							Optional:    true,
 							MaxItems:    1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"max_nodes": {
+									RepoMaxNodesKey: {
 										Description:  "Maximum number of nodes of the replica set cluster.",
 										Type:         schema.TypeInt,
 										Required:     true,
 										Deprecated:   fmt.Sprintf(deprecatedRepoProperitiesMessage, "max_nodes"),
 										ValidateFunc: validation.IntAtLeast(1),
 									},
-									"replica_set_id": {
+									RepoReplicaSetIDKey: {
 										Description:  "Identifier of the replica set cluster. Used to construct the URI command (available in Cyral's Access Portal page) that your users will need for connecting to the repository via Cyral.",
 										Type:         schema.TypeString,
 										Required:     true,
@@ -288,139 +387,4 @@ func resourceRepository() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 	}
-}
-
-func resourceRepositoryCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] Init resourceRepositoryCreate")
-	c := m.(*client.Client)
-
-	resourceData, err := getRepoDataFromResource(c, d)
-	if err != nil {
-		return createError("Unable to create repository", fmt.Sprintf("%v", err))
-	}
-
-	url := fmt.Sprintf("https://%s/v1/repos", c.ControlPlane)
-
-	body, err := c.DoRequest(url, http.MethodPost, resourceData)
-	if err != nil {
-		return createError("Unable to create repository", fmt.Sprintf("%v", err))
-	}
-
-	response := IDBasedResponse{}
-	if err := json.Unmarshal(body, &response); err != nil {
-		return createError("Unable to unmarshall JSON", fmt.Sprintf("%v", err))
-	}
-	log.Printf("[DEBUG] Response body (unmarshalled): %#v", response)
-
-	d.SetId(response.ID)
-
-	log.Printf("[DEBUG] End resourceRepositoryCreate")
-
-	return resourceRepositoryRead(ctx, d, m)
-}
-
-func resourceRepositoryRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] Init resourceRepositoryRead")
-	c := m.(*client.Client)
-
-	url := fmt.Sprintf("https://%s/v1/repos/%s", c.ControlPlane, d.Id())
-
-	body, err := c.DoRequest(url, http.MethodGet, nil)
-	if err != nil {
-		return createError(fmt.Sprintf("Unable to read repository. RepositoryID: %s",
-			d.Id()), fmt.Sprintf("%v", err))
-	}
-
-	response := GetRepoByIDResponse{}
-	if err := json.Unmarshal(body, &response); err != nil {
-		return createError(fmt.Sprintf("Unable to unmarshall JSON"), fmt.Sprintf("%v", err))
-	}
-	log.Printf("[DEBUG] Response body (unmarshalled): %#v", response)
-
-	response.Repo.WriteToSchema(d)
-
-	log.Printf("[DEBUG] End resourceRepositoryRead")
-
-	return diag.Diagnostics{}
-}
-
-func resourceRepositoryUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] Init resourceRepositoryUpdate")
-	c := m.(*client.Client)
-
-	resourceData, err := getRepoDataFromResource(c, d)
-	if err != nil {
-		return createError("Unable to update repository", fmt.Sprintf("%v", err))
-	}
-
-	url := fmt.Sprintf("https://%s/v1/repos/%s", c.ControlPlane, d.Id())
-
-	if _, err = c.DoRequest(url, http.MethodPut, resourceData); err != nil {
-		return createError("Unable to update repository", fmt.Sprintf("%v", err))
-	}
-
-	log.Printf("[DEBUG] End resourceRepositoryUpdate")
-
-	return resourceRepositoryRead(ctx, d, m)
-}
-
-func resourceRepositoryDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] Init resourceRepositoryDelete")
-	c := m.(*client.Client)
-
-	url := fmt.Sprintf("https://%s/v1/repos/%s", c.ControlPlane, d.Id())
-
-	if _, err := c.DoRequest(url, http.MethodDelete, nil); err != nil {
-		return createError("Unable to delete repository", fmt.Sprintf("%v", err))
-	}
-
-	log.Printf("[DEBUG] End resourceRepositoryDelete")
-
-	return diag.Diagnostics{}
-}
-
-func getRepoDataFromResource(c *client.Client, d *schema.ResourceData) (RepoInfo, error) {
-	repoData := RepoInfo{
-		ID:   d.Id(),
-		Type: d.Get("type").(string),
-		Host: d.Get("host").(string),
-		Name: d.Get("name").(string),
-		Port: uint32(d.Get("port").(int)),
-	}
-
-	labels := d.Get("labels").([]interface{})
-	repositoryDataLabels := make([]string, len(labels))
-	for i, label := range labels {
-		repositoryDataLabels[i] = (label).(string)
-	}
-	repoData.Labels = repositoryDataLabels
-
-	var maxAllowedListeners uint32
-	var properties *RepositoryProperties
-	if propertiesIface, ok := d.Get("properties").(*schema.Set); ok {
-		for _, propertiesMap := range propertiesIface.List() {
-			properties = new(RepositoryProperties)
-			propertiesMap := propertiesMap.(map[string]interface{})
-
-			// Replica set properties
-			if rsetIface, ok := propertiesMap["mongodb_replica_set"]; ok {
-				if repoData.Type != mongodbRepoType {
-					return RepoInfo{}, fmt.Errorf(
-						"replica sets are only supported for repository type '%s'",
-						mongodbRepoType)
-				}
-
-				for _, rsetMap := range rsetIface.(*schema.Set).List() {
-					rsetMap := rsetMap.(map[string]interface{})
-					maxAllowedListeners = uint32(rsetMap["max_nodes"].(int))
-					properties.MongoDBReplicaSetName = rsetMap["replica_set_id"].(string)
-				}
-				properties.MongoDBServerType = mongodbReplicaSetServerType
-			}
-		}
-	}
-	repoData.MaxAllowedListeners = maxAllowedListeners
-	repoData.Properties = properties
-
-	return repoData, nil
 }

--- a/cyral/resource_cyral_repository_test.go
+++ b/cyral/resource_cyral_repository_test.go
@@ -11,35 +11,35 @@ const (
 	repositoryResourceName = "repository"
 )
 
-var initialRepoConfig RepoData = RepoData{
-	Name:     accTestName(repositoryResourceName, "repo"),
-	Host:     "mongo.local",
-	Port:     3333,
-	RepoType: "mongodb",
-	Labels:   []string{"rds", "us-east-2"},
+var initialRepoConfig RepoInfo = RepoInfo{
+	Name:   accTestName(repositoryResourceName, "repo"),
+	Host:   "mongo.local",
+	Port:   3333,
+	Type:   "mongodb",
+	Labels: []string{"rds", "us-east-2"},
 }
 
-var updatedRepoConfig RepoData = RepoData{
-	Name:     accTestName(repositoryResourceName, "repo-updated"),
-	Host:     "mongo-updated.local",
-	Port:     3334,
-	RepoType: "mongodb",
-	Labels:   []string{"rds", "us-east-1"},
+var updatedRepoConfig RepoInfo = RepoInfo{
+	Name:   accTestName(repositoryResourceName, "repo-updated"),
+	Host:   "mongo-updated.local",
+	Port:   3334,
+	Type:   "mongodb",
+	Labels: []string{"rds", "us-east-1"},
 }
 
-var emptyPropertiesRepoConfig RepoData = RepoData{
+var emptyPropertiesRepoConfig RepoInfo = RepoInfo{
 	Name:       accTestName(repositoryResourceName, "repo-empty-properties"),
 	Host:       "mongo-cluster.local",
 	Port:       27017,
-	RepoType:   "mongodb",
+	Type:       "mongodb",
 	Properties: &RepositoryProperties{},
 }
 
-var replicaSetRepoConfig RepoData = RepoData{
+var replicaSetRepoConfig RepoInfo = RepoInfo{
 	Name:                accTestName(repositoryResourceName, "repo-replica-set"),
 	Host:                "mongo-cluster.local",
 	Port:                27017,
-	RepoType:            "mongodb",
+	Type:                "mongodb",
 	MaxAllowedListeners: 2,
 	Properties: &RepositoryProperties{
 		MongoDBReplicaSetName: "replica-set-1",
@@ -88,14 +88,14 @@ func TestAccRepositoryResource(t *testing.T) {
 	})
 }
 
-func setupRepositoryTest(repoData RepoData, resName string) (string, resource.TestCheckFunc) {
+func setupRepositoryTest(repoData RepoInfo, resName string) (string, resource.TestCheckFunc) {
 	configuration := formatRepoDataIntoConfig(repoData, resName)
 
 	resourceFullName := fmt.Sprintf("cyral_repository.%s", resName)
 
 	checkFuncs := []resource.TestCheckFunc{
 		resource.TestCheckResourceAttr(resourceFullName,
-			"type", repoData.RepoType),
+			"type", repoData.Type),
 		resource.TestCheckResourceAttr(resourceFullName,
 			"host", repoData.Host),
 		resource.TestCheckResourceAttr(resourceFullName,
@@ -123,7 +123,7 @@ func setupRepositoryTest(repoData RepoData, resName string) (string, resource.Te
 	return configuration, testFunction
 }
 
-func formatRepoDataIntoConfig(data RepoData, resName string) string {
+func formatRepoDataIntoConfig(data RepoInfo, resName string) string {
 	var propertiesStr string
 	if data.Properties != nil {
 		properties := data.Properties
@@ -150,7 +150,7 @@ func formatRepoDataIntoConfig(data RepoData, resName string) string {
 		name  = "%s"
 		labels = %s
 		%s
-	}`, resName, data.RepoType, data.Host,
+	}`, resName, data.Type, data.Host,
 		data.Port, data.Name, listToStr(data.Labels), propertiesStr)
 	return config
 }

--- a/cyral/resource_cyral_role.go
+++ b/cyral/resource_cyral_role.go
@@ -78,12 +78,6 @@ func resourceRole() *schema.Resource {
 							Optional:    true,
 							Default:     false,
 						},
-						"view_sidecars_and_repositories": {
-							Description: "Allows viewing sidecars and repositories for this role. Defaults to `false`.",
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Default:     false,
-						},
 						"view_audit_logs": {
 							Description: "Allows viewing audit logs for this role. Defaults to `false`.",
 							Type:        schema.TypeBool,
@@ -104,6 +98,18 @@ func resourceRole() *schema.Resource {
 						},
 						"view_datamaps": {
 							Description: "Allows viewing datamaps for this role. Defaults to `false`.",
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+						},
+						"approval_management": {
+							Description: "Allows approving or denying approval requests. Defaults to `false`.",
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+						},
+						"repo_crawler": {
+							Description: "Allows reporting of cyral_repository_user_accounts. Defaults to `false`.",
 							Type:        schema.TypeBool,
 							Optional:    true,
 							Default:     false,

--- a/cyral/resource_cyral_role_test.go
+++ b/cyral/resource_cyral_role_test.go
@@ -24,33 +24,36 @@ var onlyFalsePermissions = map[string]string{
 	"modify_sidecars_and_repositories": "false",
 	"modify_users":                     "false",
 	"modify_policies":                  "false",
-	"view_sidecars_and_repositories":   "false",
 	"view_audit_logs":                  "false",
 	"modify_integrations":              "false",
 	"modify_roles":                     "false",
 	"view_datamaps":                    "false",
+	"repo_crawler":                     "false",
+	"approval_management":              "false",
 }
 
 var trueAndFalsePermissions = map[string]string{
 	"modify_sidecars_and_repositories": "true",
 	"modify_users":                     "true",
 	"modify_policies":                  "true",
-	"view_sidecars_and_repositories":   "true",
 	"view_audit_logs":                  "false",
 	"modify_integrations":              "false",
 	"modify_roles":                     "false",
 	"view_datamaps":                    "false",
+	"repo_crawler":                     "true",
+	"approval_management":              "true",
 }
 
 var onlyTruePermissions = map[string]string{
 	"modify_sidecars_and_repositories": "true",
 	"modify_users":                     "true",
 	"modify_policies":                  "true",
-	"view_sidecars_and_repositories":   "true",
 	"view_audit_logs":                  "true",
 	"modify_integrations":              "true",
 	"modify_roles":                     "true",
 	"view_datamaps":                    "true",
+	"repo_crawler":                     "true",
+	"approval_management":              "true",
 }
 
 func TestAccRoleResource(t *testing.T) {
@@ -164,11 +167,12 @@ func testAccRoleConfig_OnlyFalsePermissions(resName string) string {
 			modify_sidecars_and_repositories = false
 			modify_users = false
 			modify_policies = false
-			view_sidecars_and_repositories = false
 			view_audit_logs = false
 			modify_integrations = false
 			modify_roles = false
 			view_datamaps = false
+			repo_crawler = false
+			approval_management = false
 		}
 	}
 	`, resName, updatedRoleName())
@@ -191,11 +195,12 @@ func testAccRoleConfig_TrueAndFalsePermissions(resName string) string {
 			modify_sidecars_and_repositories = true
 			modify_users = true
 			modify_policies = true
-			view_sidecars_and_repositories = true
 			view_audit_logs = false
 			modify_integrations = false
 			modify_roles = false
 			view_datamaps = false
+			repo_crawler = true
+			approval_management = true
 		}
 	}
 	`, resName, updatedRoleName())
@@ -218,11 +223,12 @@ func testAccRoleConfig_OnlyTruePermissions(resName string) string {
 			modify_sidecars_and_repositories = true
 			modify_users = true
 			modify_policies = true
-			view_sidecars_and_repositories = true
 			view_audit_logs = true
 			modify_integrations = true
 			modify_roles = true
 			view_datamaps = true
+			repo_crawler = true
+			approval_management = true
 		}
 	}
 	`, resName, updatedRoleName())

--- a/cyral/resource_cyral_sidecar_listener.go
+++ b/cyral/resource_cyral_sidecar_listener.go
@@ -1,0 +1,363 @@
+package cyral
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/cyralinc/terraform-provider-cyral/client"
+)
+
+// create a constant block for schema keys
+
+const (
+	SidecarIdKey        = "sidecar_id"
+	ListenerIdKey       = "listener_id"
+	RepoTypesKey        = "repo_types"
+	NetworkAddressKey   = "network_address"
+	PortKey             = "port"
+	HostKey             = "host"
+	MySQLSettingsKey    = "mysql_settings"
+	DbVersionKey        = "db_version"
+	CharacterSetKey     = "character_set"
+	S3SettingsKey       = "s3_settings"
+	ProxyModeKey        = "proxy_mode"
+	DynamoDbSettingsKey = "dynamodb_settings"
+)
+
+// SidecarListener struct for sidecar listener.
+type SidecarListener struct {
+	SidecarId        string            `json:"-"`
+	ListenerId       string            `json:"id"`
+	RepoTypes        []string          `json:"repoTypes"`
+	NetworkAddress   *NetworkAddress   `json:"address,omitempty"`
+	MySQLSettings    *MySQLSettings    `json:"mysqlSettings,omitempty"`
+	S3Settings       *S3Settings       `json:"s3Settings,omitempty"`
+	DynamoDbSettings *DynamoDbSettings `json:"dynamoDbSettings,omitempty"`
+}
+type NetworkAddress struct {
+	Host string `json:"host,omitempty"`
+	Port int    `json:"port"`
+}
+type MySQLSettings struct {
+	DbVersion    string `json:"dbVersion,omitempty"`
+	CharacterSet string `json:"characterSet,omitempty"`
+}
+type S3Settings struct {
+	ProxyMode bool `json:"proxyMode,omitempty"`
+}
+type DynamoDbSettings struct {
+	ProxyMode bool `json:"proxyMode,omitempty"`
+}
+
+var ReadSidecarListenersConfig = ResourceOperationConfig{
+	Name:       "SidecarListenersResourceRead",
+	HttpMethod: http.MethodGet,
+	CreateURL: func(d *schema.ResourceData, c *client.Client) string {
+		return fmt.Sprintf("https://%s/v1/sidecars/%s/listeners/%s",
+			c.ControlPlane,
+			d.Get(SidecarIdKey).(string),
+			d.Get(ListenerIdKey).(string))
+	},
+	NewResponseData: func(_ *schema.ResourceData) ResponseData { return &ReadSidecarListenerAPIResponse{} },
+}
+
+type ReadSidecarListenerAPIResponse struct {
+	ListenerConfig *SidecarListener `json:"listenerConfig"`
+}
+type CreateListenerAPIResponse struct {
+	ListenerId string `json:"listenerId"`
+}
+
+func (c CreateListenerAPIResponse) WriteToSchema(d *schema.ResourceData) error {
+	d.SetId(marshalComposedID([]string{d.Get(SidecarIdKey).(string), c.ListenerId}, "/"))
+	return d.Set(ListenerIdKey, c.ListenerId)
+}
+
+func (data ReadSidecarListenerAPIResponse) WriteToSchema(d *schema.ResourceData) error {
+	if data.ListenerConfig != nil {
+		_ = d.Set(ListenerIdKey, data.ListenerConfig.ListenerId)
+		_ = d.Set(RepoTypesKey, data.ListenerConfig.RepoTypesAsInterface())
+		_ = d.Set(NetworkAddressKey, data.ListenerConfig.NetworkAddressAsInterface())
+		_ = d.Set(S3SettingsKey, data.ListenerConfig.S3SettingsAsInterface())
+		_ = d.Set(MySQLSettingsKey, data.ListenerConfig.MySQLSettingsAsInterface())
+		_ = d.Set(DynamoDbSettingsKey, data.ListenerConfig.DynamoDbSettingsAsInterface())
+	}
+	return nil
+}
+func (l *SidecarListener) RepoTypesAsInterface() []interface{} {
+	if l.RepoTypes == nil {
+		return nil
+	}
+	result := make([]interface{}, len(l.RepoTypes))
+	for i, v := range l.RepoTypes {
+		result[i] = v
+	}
+	return result
+}
+func (l *SidecarListener) RepoTypesFromInterface(anInterface []interface{}) {
+	repoTypes := make([]string, len(anInterface))
+	for i, v := range anInterface {
+		repoTypes[i] = v.(string)
+	}
+	l.RepoTypes = repoTypes
+}
+func (l *SidecarListener) NetworkAddressAsInterface() []interface{} {
+	if l.NetworkAddress == nil {
+		return nil
+	}
+	return []interface{}{
+		map[string]interface{}{
+			HostKey: l.NetworkAddress.Host,
+			PortKey: l.NetworkAddress.Port,
+		},
+	}
+}
+func (l *SidecarListener) NetworkAddressFromInterface(anInterface []interface{}) {
+	if len(anInterface) == 0 {
+		return
+	}
+	l.NetworkAddress = &NetworkAddress{
+		Host: anInterface[0].(map[string]interface{})[HostKey].(string),
+		Port: anInterface[0].(map[string]interface{})[PortKey].(int),
+	}
+}
+func (l *SidecarListener) MySQLSettingsAsInterface() []interface{} {
+	if l.MySQLSettings == nil {
+		return nil
+	}
+	return []interface{}{map[string]interface{}{
+		DbVersionKey:    l.MySQLSettings.DbVersion,
+		CharacterSetKey: l.MySQLSettings.CharacterSet,
+	}}
+}
+func (l *SidecarListener) MySQLSettingsFromInterface(anInterface []interface{}) {
+	if len(anInterface) == 0 {
+		return
+	}
+	l.MySQLSettings = &MySQLSettings{
+		DbVersion:    anInterface[0].(map[string]interface{})[DbVersionKey].(string),
+		CharacterSet: anInterface[0].(map[string]interface{})[CharacterSetKey].(string),
+	}
+}
+func (l *SidecarListener) S3SettingsAsInterface() []interface{} {
+	if l.S3Settings == nil {
+		return nil
+	}
+	return []interface{}{map[string]interface{}{
+		ProxyModeKey: l.S3Settings.ProxyMode,
+	}}
+}
+func (l *SidecarListener) S3SettingsFromInterface(anInterface []interface{}) {
+	if len(anInterface) == 0 {
+		return
+	}
+	l.S3Settings = &S3Settings{
+		ProxyMode: anInterface[0].(map[string]interface{})[ProxyModeKey].(bool),
+	}
+}
+func (l *SidecarListener) DynamoDbSettingsAsInterface() []interface{} {
+	if l.DynamoDbSettings == nil {
+		return nil
+	}
+	return []interface{}{map[string]interface{}{
+		ProxyModeKey: l.DynamoDbSettings.ProxyMode,
+	}}
+}
+func (l *SidecarListener) DynamoDbSettingsFromInterface(anInterface []interface{}) {
+	if len(anInterface) == 0 {
+		return
+	}
+	l.DynamoDbSettings = &DynamoDbSettings{
+		ProxyMode: anInterface[0].(map[string]interface{})[ProxyModeKey].(bool),
+	}
+}
+
+// SidecarListenerResource represents the payload of a create or update a listener request
+type SidecarListenerResource struct {
+	ListenerConfig SidecarListener `json:"listenerConfig"`
+}
+
+// ReadFromSchema populates the SidecarListenerResource from the schema
+func (s *SidecarListenerResource) ReadFromSchema(d *schema.ResourceData) error {
+	s.ListenerConfig = SidecarListener{
+		SidecarId:  d.Get(SidecarIdKey).(string),
+		ListenerId: d.Get(ListenerIdKey).(string),
+	}
+	s.ListenerConfig.RepoTypesFromInterface(d.Get(RepoTypesKey).([]interface{}))
+	s.ListenerConfig.NetworkAddressFromInterface(d.Get(NetworkAddressKey).(*schema.Set).List())
+	s.ListenerConfig.MySQLSettingsFromInterface(d.Get(MySQLSettingsKey).(*schema.Set).List())
+	s.ListenerConfig.S3SettingsFromInterface(d.Get(S3SettingsKey).(*schema.Set).List())
+	s.ListenerConfig.DynamoDbSettingsFromInterface(d.Get(DynamoDbSettingsKey).(*schema.Set).List())
+	return nil
+}
+
+// resourceSidecarListener returns the schema and methods for provisioning a sidecar listener
+// Sidecar listeners API is {{baseURL}}/sidecars/:sidecarID/listeners/:listenerID
+// GET {{baseURL}}/sidecars/:sidecarID/listeners/:listenerID (Get one listener)
+// POST {{baseURL}}/sidecars/:sidecarID/listeners/ (Create a listener)
+// PUT {{baseURL}}/sidecars/:sidecarID/listeners/:listenerID (Update a listener)
+// DELETE {{baseURL}}/sidecars/:sidecarID/listeners/:listenerID (Delete a listener)
+func resourceSidecarListener() *schema.Resource {
+	return &schema.Resource{
+		Description: "Manages [sidecar listeners](https://cyral.com/docs/sidecars/sidecar-listeners).",
+		CreateContext: CreateResource(
+			ResourceOperationConfig{
+				Name:       "SidecarListenersResourceCreate",
+				HttpMethod: http.MethodPost,
+				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
+					return fmt.Sprintf("https://%s/v1/sidecars/%s/listeners",
+						c.ControlPlane,
+						d.Get(SidecarIdKey).(string))
+
+				},
+				NewResourceData: func() ResourceData { return &SidecarListenerResource{} },
+				NewResponseData: func(_ *schema.ResourceData) ResponseData { return &CreateListenerAPIResponse{} },
+			}, ReadSidecarListenersConfig,
+		),
+		ReadContext: ReadResource(ReadSidecarListenersConfig),
+		UpdateContext: UpdateResource(
+			ResourceOperationConfig{
+				Name:       "SidecarListenersResourceUpdate",
+				HttpMethod: http.MethodPut,
+				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
+					return fmt.Sprintf("https://%s/v1/sidecars/%s/listeners/%s",
+						c.ControlPlane,
+						d.Get(SidecarIdKey).(string),
+						d.Get(ListenerIdKey).(string))
+
+				},
+				NewResourceData: func() ResourceData { return &SidecarListenerResource{} },
+			}, ReadSidecarListenersConfig,
+		),
+		DeleteContext: DeleteResource(
+			ResourceOperationConfig{
+				Name:       "SidecarListenersResourceDelete",
+				HttpMethod: http.MethodDelete,
+				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
+					return fmt.Sprintf("https://%s/v1/sidecars/%s/listeners/%s",
+						c.ControlPlane,
+						d.Get(SidecarIdKey).(string),
+						d.Get(ListenerIdKey).(string))
+				},
+			},
+		),
+		Schema: map[string]*schema.Schema{
+			ListenerIdKey: {
+				Description: "ID of the listener that will be bound to the sidecar.",
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Computed:    true,
+			},
+			SidecarIdKey: {
+				Description: "ID of the sidecar that the listener will be bound to.",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
+			RepoTypesKey: {
+				Description: "List of repository types that the listener supports. Currently limited to one repo type from supported repo types:" + supportedTypesMarkdown(repositoryTypes()),
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			NetworkAddressKey: {
+				Description: "The network address that the sidecar listens on.",
+				Type:        schema.TypeSet,
+				Required:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						HostKey: {
+							Description: "Host where the sidecar will listen for the given repository. Omit to listen on all interfaces.",
+							Type:        schema.TypeString,
+							Optional:    true,
+						},
+						PortKey: {
+							Description: "Port where the sidecar will listen for the given repository.",
+							Type:        schema.TypeInt,
+							Required:    true,
+						},
+					},
+				},
+			},
+			MySQLSettingsKey: {
+				Description: "MySQL settings represents the listener settings for a [`mysql`, `galera`, `mariadb`] data repository.",
+				Type:        schema.TypeSet,
+				Optional:    true,
+				// Notice the MaxItems: 1 here. This ensures that the user can only specify one this block.
+				MaxItems:      1,
+				ConflictsWith: []string{S3SettingsKey, DynamoDbSettingsKey},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						DbVersionKey: {
+							Description: "MySQL DB version. Required (and only relevant) for listeners of type `mysql`.",
+							Type:        schema.TypeString,
+							Optional:    true,
+						},
+						CharacterSetKey: {
+							Description: "MySQL character set. Optional (and only relevant) for listeners of type `mysql`.",
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+						},
+					},
+				},
+			},
+			S3SettingsKey: {
+				Description: "S3 settings.",
+				Type:        schema.TypeSet,
+				Optional:    true,
+				// Notice the MaxItems: 1 here. This ensures that the user can only specify one this block.
+				MaxItems:      1,
+				ConflictsWith: []string{MySQLSettingsKey, DynamoDbSettingsKey},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						ProxyModeKey: {
+							Description: "S3 proxy mode, only relevant for S3 listeners. Defaults to false.",
+							Type:        schema.TypeBool,
+							Optional:    true,
+						},
+					},
+				},
+			},
+			DynamoDbSettingsKey: {
+				Description: "DynamoDB settings.",
+				Type:        schema.TypeSet,
+				Optional:    true,
+				// Notice the MaxItems: 1 here. This ensures that the user can only specify one this block.
+				MaxItems:      1,
+				ConflictsWith: []string{S3SettingsKey, MySQLSettingsKey},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						ProxyModeKey: {
+							Description: "DynamoDB proxy mode. Only relevant for listeners of type `dynamodb`. Note " +
+								"that `proxy_mode` must be set to `true` for listeners of type `dynamodb`. Defaults to false.",
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+		Importer: &schema.ResourceImporter{
+			StateContext: func(
+				ctx context.Context,
+				d *schema.ResourceData,
+				m interface{},
+			) ([]*schema.ResourceData, error) {
+				ids, err := unmarshalComposedID(d.Id(), "/", 2)
+				if err != nil {
+					return nil, err
+				}
+				_ = d.Set(SidecarIdKey, ids[0])
+				_ = d.Set(ListenerIdKey, ids[1])
+				return []*schema.ResourceData{d}, nil
+			},
+		},
+	}
+}

--- a/cyral/resource_cyral_sidecar_listener_test.go
+++ b/cyral/resource_cyral_sidecar_listener_test.go
@@ -1,0 +1,356 @@
+package cyral
+
+// import (
+// 	"fmt"
+// 	"strconv"
+// 	"testing"
+
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// )
+
+// const (
+// 	sidecarListenerTestSidecarResourceName = "sidecar-for-listeners"
+// )
+
+// func sidecarListenerSidecarConfig() string {
+// 	return formatBasicSidecarIntoConfig(
+// 		basicSidecarResName,
+// 		accTestName(sidecarListenerTestSidecarResourceName, "sidecar"),
+// 		"docker",
+// 	)
+// }
+
+// func TestSidecarListenerResource(t *testing.T) {
+// 	testSteps := make([]resource.TestStep, 0, 10)
+// 	testSteps = append(testSteps, updateTest()...)
+// 	testSteps = append(testSteps, settingsTest()...)
+// 	testSteps = append(testSteps, multipleListenersAndImportTest()...)
+
+// 	resource.ParallelTest(t, resource.TestCase{
+// 		ProviderFactories: providerFactories,
+// 		Steps:             testSteps,
+// 	})
+// }
+
+// func updateTest() []resource.TestStep {
+// 	// Start with a bare bones mySQL sidecar listener
+// 	onlyRequiredFields := SidecarListener{
+// 		RepoTypes: []string{"mysql"},
+// 		NetworkAddress: &NetworkAddress{
+// 			Port: 8000,
+// 		},
+// 	}
+// 	// Change port.
+// 	changePort := SidecarListener{
+// 		RepoTypes: []string{"mysql"},
+// 		NetworkAddress: &NetworkAddress{
+// 			Port: 443,
+// 		},
+// 	}
+// 	// Add host.
+// 	addHost := SidecarListener{
+// 		RepoTypes: []string{"mysql"},
+// 		NetworkAddress: &NetworkAddress{
+// 			Port: 443,
+// 			Host: "https://mysql.test.com",
+// 		},
+// 	}
+// 	// Add settings.
+// 	addSettings := SidecarListener{
+// 		RepoTypes: []string{"mysql"},
+// 		NetworkAddress: &NetworkAddress{
+// 			Port: 443,
+// 			Host: "https://s3.test.com",
+// 		},
+// 		MySQLSettings: &MySQLSettings{
+// 			DbVersion: "3.4.0",
+// 		},
+// 	}
+
+// 	return []resource.TestStep{
+// 		setupSidecarListenerTestStep(
+// 			"update_test",
+// 			onlyRequiredFields,
+// 		),
+// 		setupSidecarListenerTestStep(
+// 			"update_test",
+// 			changePort,
+// 		),
+// 		setupSidecarListenerTestStep(
+// 			"update_test",
+// 			addHost,
+// 		),
+// 		setupSidecarListenerTestStep(
+// 			"update_test",
+// 			addSettings,
+// 		),
+// 	}
+// }
+
+// func settingsTest() []resource.TestStep {
+// 	// MySQL listener with no character set defined.
+// 	mySQLNoCharSet := SidecarListener{
+// 		RepoTypes: []string{"mysql"},
+// 		NetworkAddress: &NetworkAddress{
+// 			Port: 8000,
+// 			Host: "https://mysql.test.com",
+// 		},
+// 		MySQLSettings: &MySQLSettings{
+// 			DbVersion: "2.1.0",
+// 		},
+// 	}
+// 	// MySQL listener with character set defined.
+// 	mySQLWithCharSet := SidecarListener{
+// 		RepoTypes: []string{"mysql"},
+// 		NetworkAddress: &NetworkAddress{
+// 			Port: 8001,
+// 			Host: "https://mysql.test.com",
+// 		},
+// 		MySQLSettings: &MySQLSettings{
+// 			DbVersion:    "2.1.0",
+// 			CharacterSet: "ujis_japanese_ci",
+// 		},
+// 	}
+// 	// S3 listeners with proxy mode.
+// 	s3 := SidecarListener{
+// 		RepoTypes: []string{"s3"},
+// 		NetworkAddress: &NetworkAddress{
+// 			Port: 8002,
+// 			Host: "https://mysql.test.com",
+// 		},
+// 		S3Settings: &S3Settings{
+// 			ProxyMode: true,
+// 		},
+// 	}
+// 	// DynamoDB with proxy mode (required for all DynamoDB repo types).
+// 	dynamodb := SidecarListener{
+// 		RepoTypes: []string{"dynamodb"},
+// 		NetworkAddress: &NetworkAddress{
+// 			Port: 8003,
+// 			Host: "https://mysql.test.com",
+// 		},
+// 		DynamoDbSettings: &DynamoDbSettings{
+// 			ProxyMode: true,
+// 		},
+// 	}
+
+// 	return []resource.TestStep{
+// 		setupSidecarListenerTestStep(
+// 			"mySQL_no_charset",
+// 			mySQLNoCharSet,
+// 		),
+// 		setupSidecarListenerTestStep(
+// 			"mySQL_with_charset",
+// 			mySQLWithCharSet,
+// 		),
+// 		setupSidecarListenerTestStep(
+// 			"s3_with_proxy",
+// 			s3,
+// 		),
+// 		setupSidecarListenerTestStep(
+// 			"dynamo_db_with_proxy",
+// 			dynamodb,
+// 		),
+// 	}
+// }
+
+// func multipleListenersAndImportTest() []resource.TestStep {
+// 	// Define first listener resource.
+// 	listener1ResName := "listener1-multiple-test"
+// 	listener1 := SidecarListener{
+// 		RepoTypes: []string{"oracle"},
+// 		NetworkAddress: &NetworkAddress{
+// 			Port: 6003,
+// 		},
+// 	}
+// 	// Define second listener resource.
+// 	listener2ResName := "listener2-multiple-test"
+// 	listener2 := SidecarListener{
+// 		RepoTypes: []string{"postgresql"},
+// 		NetworkAddress: &NetworkAddress{
+// 			Port: 6018,
+// 		},
+// 	}
+
+// 	// Setup config containing both listeners.
+// 	listener1Config := setupSidecarListenerConfig(
+// 		listener1ResName, listener1)
+// 	listener2Config := setupSidecarListenerConfig(
+// 		listener2ResName, listener2)
+// 	multipleListenersConfig := sidecarListenerSidecarConfig() +
+// 		listener1Config + listener2Config
+
+// 	// Setup check for both listeners.
+// 	listener1Check := setupSidecarListenerCheck(listener1ResName, listener1)
+// 	listener2Check := setupSidecarListenerCheck(listener2ResName, listener2)
+// 	multipleListenersCheck := resource.ComposeTestCheckFunc(
+// 		listener1Check, listener2Check)
+
+// 	// Create multiple listeners test step.
+// 	multipleListenersTest := resource.TestStep{
+// 		Config: multipleListenersConfig,
+// 		Check:  multipleListenersCheck,
+// 	}
+
+// 	// Create import test.
+// 	resourceToImport := fmt.Sprintf("cyral_sidecar_listener.%s", listener1ResName)
+// 	importTest := resource.TestStep{
+// 		ImportState:       true,
+// 		ImportStateVerify: true,
+// 		ResourceName:      resourceToImport,
+// 	}
+
+// 	return []resource.TestStep{
+// 		multipleListenersTest,
+// 		importTest,
+// 	}
+// }
+
+// func setupSidecarListenerTestStep(resName string, listener SidecarListener) resource.TestStep {
+// 	return resource.TestStep{
+// 		Config: sidecarListenerSidecarConfig() +
+// 			setupSidecarListenerConfig(resName, listener),
+// 		Check: setupSidecarListenerCheck(resName, listener),
+// 	}
+// }
+
+// func setupSidecarListenerCheck(resourceName string, listener SidecarListener) resource.TestCheckFunc {
+// 	resFullName := fmt.Sprintf("cyral_sidecar_listener.%s", resourceName)
+// 	var checkFuncs []resource.TestCheckFunc
+
+// 	// Required attributes
+// 	checkFuncs = append(checkFuncs, []resource.TestCheckFunc{
+// 		resource.TestCheckResourceAttrPair(
+// 			resFullName, SidecarIdKey,
+// 			fmt.Sprintf("cyral_sidecar.%s", basicSidecarResName), "id"),
+// 		resource.TestCheckResourceAttr(resFullName,
+// 			fmt.Sprintf("%s.0", RepoTypesKey), listener.RepoTypes[0]),
+// 	}...)
+
+// 	// Optional attributes
+// 	if listener.NetworkAddress != nil {
+// 		checkFuncs = append(checkFuncs, []resource.TestCheckFunc{
+// 			// Exactly one Network Address conf.
+// 			resource.TestCheckResourceAttr(resFullName,
+// 				fmt.Sprintf("%s.#", NetworkAddressKey),
+// 				"1"),
+// 			// Check host.
+// 			resource.TestCheckResourceAttr(resFullName,
+// 				fmt.Sprintf("%s.0.%s", NetworkAddressKey, HostKey),
+// 				listener.NetworkAddress.Host),
+// 			// Check port.
+// 			resource.TestCheckResourceAttr(resFullName,
+// 				fmt.Sprintf("%s.0.%s", NetworkAddressKey, PortKey),
+// 				strconv.Itoa(listener.NetworkAddress.Port)),
+// 		}...,
+// 		)
+// 	}
+
+// 	if listener.MySQLSettings != nil {
+// 		expectedCharSet := "unspecified"
+// 		if listener.MySQLSettings.CharacterSet != "" {
+// 			expectedCharSet = listener.MySQLSettings.CharacterSet
+// 		}
+
+// 		checkFuncs = append(checkFuncs, []resource.TestCheckFunc{
+// 			// Exactly one mySQL Settings.
+// 			resource.TestCheckResourceAttr(resFullName,
+// 				fmt.Sprintf("%s.#", MySQLSettingsKey),
+// 				"1"),
+// 			// Check DB version.
+// 			resource.TestCheckResourceAttr(resFullName,
+// 				fmt.Sprintf("%s.0.%s", MySQLSettingsKey, DbVersionKey),
+// 				listener.MySQLSettings.DbVersion),
+// 			// Check character set.
+// 			resource.TestCheckResourceAttr(resFullName,
+// 				fmt.Sprintf("%s.0.%s", MySQLSettingsKey, CharacterSetKey),
+// 				expectedCharSet),
+// 		}...,
+// 		)
+// 	}
+
+// 	if listener.S3Settings != nil {
+// 		checkFuncs = append(checkFuncs, []resource.TestCheckFunc{
+// 			// Exactly one S3 Settings.
+// 			resource.TestCheckResourceAttr(resFullName,
+// 				fmt.Sprintf("%s.#", S3SettingsKey),
+// 				"1"),
+// 			// Check proxy mode.
+// 			resource.TestCheckResourceAttr(resFullName,
+// 				fmt.Sprintf("%s.0.%s", S3SettingsKey, ProxyModeKey),
+// 				strconv.FormatBool(listener.S3Settings.ProxyMode)),
+// 		}...,
+// 		)
+// 	}
+
+// 	if listener.DynamoDbSettings != nil {
+// 		checkFuncs = append(checkFuncs, []resource.TestCheckFunc{
+// 			// Exactly one S3 Settings.
+// 			resource.TestCheckResourceAttr(resFullName,
+// 				fmt.Sprintf("%s.#", DynamoDbSettingsKey),
+// 				"1"),
+// 			// Check proxy mode.
+// 			resource.TestCheckResourceAttr(resFullName,
+// 				fmt.Sprintf("%s.0.%s", DynamoDbSettingsKey, ProxyModeKey),
+// 				strconv.FormatBool(listener.DynamoDbSettings.ProxyMode)),
+// 		}...,
+// 		)
+// 	}
+
+// 	return resource.ComposeTestCheckFunc(checkFuncs...)
+// }
+
+// func setupSidecarListenerConfig(resourceName string, listener SidecarListener) string {
+// 	var config string
+// 	var networkAddressStr string
+// 	if listener.NetworkAddress != nil {
+// 		var host, port string
+// 		if listener.NetworkAddress.Host != "" {
+// 			host = fmt.Sprintf(`host = "%s"`, listener.NetworkAddress.Host)
+// 		}
+// 		if listener.NetworkAddress.Port != 0 {
+// 			port = fmt.Sprintf(`port = %d`, listener.NetworkAddress.Port)
+// 		}
+// 		networkAddressStr = fmt.Sprintf(`
+// 			network_address {
+// 				%s
+// 				%s
+// 			}`, host, port)
+// 	}
+
+// 	var settings string
+// 	switch {
+// 	case listener.MySQLSettings != nil:
+// 		dbVersion, charSet := "null", "null"
+// 		if listener.MySQLSettings.CharacterSet != "" {
+// 			charSet = fmt.Sprintf(`"%s"`, listener.MySQLSettings.CharacterSet)
+// 		}
+// 		if listener.MySQLSettings.DbVersion != "" {
+// 			dbVersion = fmt.Sprintf(`"%s"`, listener.MySQLSettings.DbVersion)
+// 		}
+// 		settings = fmt.Sprintf(`
+// 		mysql_settings {
+// 			db_version = %s
+// 			character_set = %s
+// 		}`, dbVersion, charSet)
+// 	case listener.DynamoDbSettings != nil:
+// 		settings = fmt.Sprintf(`
+// 		dynamodb_settings {
+// 			proxy_mode = %s
+// 		}`, strconv.FormatBool(listener.DynamoDbSettings.ProxyMode))
+// 	case listener.S3Settings != nil:
+// 		settings = fmt.Sprintf(`
+// 		s3_settings {
+// 			proxy_mode = %s
+// 		}`, strconv.FormatBool(listener.S3Settings.ProxyMode))
+// 	}
+
+// 	config += fmt.Sprintf(`
+// 	resource "cyral_sidecar_listener" "%s" {
+// 		sidecar_id = %s
+// 		repo_types = ["%s"]
+// 		%s
+// 		%s
+// 	}`, resourceName, basicSidecarID, listener.RepoTypes[0], networkAddressStr, settings)
+// 	return config
+// }

--- a/cyral/testutils.go
+++ b/cyral/testutils.go
@@ -73,8 +73,10 @@ func formatBasicRepositoryIntoConfig(resName, repoName, typ, host string, port i
 	resource "cyral_repository" "%s" {
 		name = "%s"
 		type = "%s"
-		host = "%s"
-		port = %d
+		repo_node {
+			host = "%s"
+			port = %d
+		}
 	}`, resName, repoName, typ, host, port)
 }
 

--- a/docs/data-sources/repository.md
+++ b/docs/data-sources/repository.md
@@ -46,27 +46,19 @@ Retrieve and filter repositories.
 
 Read-Only:
 
-- `host` (String)
 - `id` (String)
 - `labels` (List of String)
 - `name` (String)
-- `port` (Number)
-- `properties` (Set of Object) (see [below for nested schema](#nestedobjatt--repository_list--properties))
+- `repo_node` (List of Object) (see [below for nested schema](#nestedobjatt--repository_list--repo_node))
 - `type` (String)
 
-<a id="nestedobjatt--repository_list--properties"></a>
+<a id="nestedobjatt--repository_list--repo_node"></a>
 
-### Nested Schema for `repository_list.properties`
-
-Read-Only:
-
-- `mongodb_replica_set` (Set of Object) (see [below for nested schema](#nestedobjatt--repository_list--properties--mongodb_replica_set))
-
-<a id="nestedobjatt--repository_list--properties--mongodb_replica_set"></a>
-
-### Nested Schema for `repository_list.properties.mongodb_replica_set`
+### Nested Schema for `repository_list.repo_node`
 
 Read-Only:
 
-- `max_nodes` (Number)
-- `replica_set_id` (String)
+- `dynamic` (Boolean)
+- `host` (String)
+- `name` (String)
+- `port` (Number)

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -25,11 +25,12 @@ resource "cyral_role" "some_resource_name" {
     modify_sidecars_and_repositories = true
     modify_users = true
     modify_policies = true
-    view_sidecars_and_repositories = true
     view_audit_logs = false
     modify_integrations = false
     modify_roles = false
     view_datamaps = false
+    repo_crawler = false
+    approval_management = false
   }
 }
 ```
@@ -56,11 +57,12 @@ resource "cyral_role" "some_resource_name" {
 
 Optional:
 
+- `approval_management` (Boolean) Allows approving or denying approval requests. Defaults to `false`.
 - `modify_integrations` (Boolean) Allows modifying integrations for this role. Defaults to `false`.
 - `modify_policies` (Boolean) Allows modifying policies for this role. Defaults to `false`.
 - `modify_roles` (Boolean) Allows modifying roles for this role. Defaults to `false`.
 - `modify_sidecars_and_repositories` (Boolean) Allows modifying sidecars and repositories for this role. Defaults to `false`.
 - `modify_users` (Boolean) Allows modifying users for this role. Defaults to `false`.
+- `repo_crawler` (Boolean) Allows reporting of cyral_repository_user_accounts. Defaults to `false`.
 - `view_audit_logs` (Boolean) Allows viewing audit logs for this role. Defaults to `false`.
 - `view_datamaps` (Boolean) Allows viewing datamaps for this role. Defaults to `false`.
-- `view_sidecars_and_repositories` (Boolean) Allows viewing sidecars and repositories for this role. Defaults to `false`.

--- a/examples/resources/cyral_repository/resource.tf
+++ b/examples/resources/cyral_repository/resource.tf
@@ -1,36 +1,63 @@
-### Single repository
+### Minimal Repository
 resource "cyral_repository" "some_resource_name" {
-    host = ""
-    port = 0
-    type = ""
-    name = ""
-}
+    type = "mongodb"
+    name = "some_repo_name"
 
-### Multiple repositories using a local variable
-locals {
-    repos = {
-        mymongodb = {
-            host = "mongodb.cyral.com"
-            port = 27017
-            type = "mongodb"
-        }
-        mymariadb = {
-            host = "mariadb.cyral.com"
-            port = 3310
-            type = "mariadb"
-        }
-        mypostgresql = {
-            host = "postgresql.cyral.com"
-            port = 5432
-            type = "postgresql"
-        }
+    repo_node {
+        name = "node-1"
+        host = "mongodb.cyral.com"
+        port = 27017
     }
 }
 
-resource "cyral_repository" "repositories" {
-    for_each = local.repos
-    name  = each.key
-    type  = each.value.type
-    host  = each.value.host
-    port  = each.value.port
+### Repository with Connection Draining, Preferred Access Gateway, and Labels
+resource "cyral_repository" "some_resource_name" {
+    type = "mongodb"
+    name = "some_repo_name"
+    labels = [ "single-node", "us-east-1" ]
+
+    repo_node {
+        name = "node-1"
+        host = "mongodb.cyral.com"
+        port = 0
+    }
+
+    connection_draining {
+      auto = true
+      wait_time = 30
+    }
+
+    preferred_access_gateway {
+      sidecar_id = "some-sidecar-id"
+      binding_id = "some-binding-id"
+    }
+}
+
+### Multi-Node MongoDB Repository with Replicaset
+resource "cyral_repository" "some_resource_name" {
+    type = "mongodb"
+    name = "some_repo_name"
+    labels = [ "multi-node", "us-east-2" ]
+
+    repo_node {
+        name = "node-1"
+        host = "mongodb-node1.cyral.com"
+        port = 27017
+    }
+
+    repo_node {
+        name = "node-2"
+        host = "mongodb-node2.cyral.com"
+        port = 27017
+    }
+
+    repo_node {
+        name = "node-3"
+        dynamic = true
+    }
+
+    mongodb_settings {
+      replica_set_name = "some-replica-set"
+      server_type = "replicaset"
+    }
 }

--- a/examples/resources/cyral_role/resource.tf
+++ b/examples/resources/cyral_role/resource.tf
@@ -10,10 +10,11 @@ resource "cyral_role" "some_resource_name" {
     modify_sidecars_and_repositories = true
     modify_users = true
     modify_policies = true
-    view_sidecars_and_repositories = true
     view_audit_logs = false
     modify_integrations = false
     modify_roles = false
     view_datamaps = false
+    repo_crawler = false
+    approval_management = false
   }
 }

--- a/scripts/3.0-migration.sh
+++ b/scripts/3.0-migration.sh
@@ -63,23 +63,20 @@ tf_json=$(terraform show -json | jq ".values.root_module.resources[]")
 
 # Find all cyral_repository_identity_maps and cyral_repository_local_accounts
 for resource in ${tf_state[@]}; do
-  tmp_out=$(echo $tf_json | jq "select(.address == \"$resource\")")
-  # Get repoID
-  repo_id=$(echo $tmp_out | jq -r ".values.repository_id")
   if [[ $resource == cyral_repository_identity_map.* ]]
   then
     # We will need to delete this identity map from the .tf file, store its name
     identity_maps_to_delete+=($resource)
-    # Get local account ID, identity_type and access_duration for the identity map.
-    values_arr=($(echo $tmp_out | jq -r ".values.repository_local_account_id, .values.identity_type, .values.access_duration"))
-    if [[ ${values_arr[2]} != $empty_access_duration ]] && [[ ${values_arr[1]} == "user" ]]; then
+    # Get repo ID, local account ID, identity_type and access_duration for the identity map.
+    values_arr=($(jq -r "select(.address == \"$resource\") | .values.repository_id, .values.repository_local_account_id, .values.identity_type, .values.access_duration"<<<$tf_json))
+    if [[ ${values_arr[3]} != $empty_access_duration ]] && [[ ${values_arr[2]} == "user" ]]; then
         # Identity map was migrated to be an approval, which is not managed through terraform-- do nothing.
         continue
     fi
     # Construct import ID for the access rule that was migrated from this identity map.
-    import_id="$repo_id/${values_arr[0]}"
+    import_id="${values_arr[0]}/${values_arr[1]}"
     # Remove [] from the resource as they are not supported and substitute [ for _
-    resource=$(echo $resource | sed 's/\[/_/g'| sed 's/\]//g')
+    resource=$(sed -e 's/[]]//g;s/[[]/_/g'<<<$resource)
     # Construct name of the access rule that will be imported.
     import_name=cyral_repository_access_rules.${resource##"cyral_repository_identity_map."}
     # Save name of the new access rule, so that it can be added to the .tf file
@@ -93,11 +90,11 @@ for resource in ${tf_state[@]}; do
     # We will need to delete this local account from the .tf file, store its name
     local_accounts_to_delete+=($resource)
     # Get local account ID for the local account.
-    local_account_id=$(echo $tmp_out | jq -r ".values.id")
+    values_arr=($(jq -r "select(.address == \"$resource\") | .values.repository_id, .values.id"<<<$tf_json))
     # Construct import ID for the user account that was migrated from this local account.
-    import_id="$repo_id/$local_account_id"
+    import_id="${values_arr[0]}/${values_arr[1]}"
     # Remove [] from the resource as they are not supported and substitute [ for _
-    resource=$(echo $resource | sed 's/\[/_/g'| sed 's/\]//g')
+    resource=$(sed -e 's/[]]//g;s/[[]/_/g'<<<$resource)
     # Construct name of the user account that will be imported.
     import_name=cyral_repository_user_account.${resource##"cyral_repository_local_account."}
     # Save name of the migrated user account, so that it can be added to the .tf file
@@ -127,7 +124,7 @@ fi
 echo; echo; echo;
 echo "Now its time to upgrade your Cyral Terraform Provider to version 3!"
 echo
-echo "Before we proceed, you will need to do the following:
+echo -e "Before we proceed, you will need to do the following:
     1.  Open your Terraform .tf configuration file.
     2.  Change the version number of the cyral provider in the required_providers
         section of your .tf configuration file to '~>3.0'. It should look like this:
@@ -169,11 +166,11 @@ echo "Importing the following cyral_repository_access_rules into your Terraform 
 printf '%s\n' "${access_rule_resource_names[@]}"
 echo
 
-for ((i = 0; i < ${#user_account_import_ids[@]}; i++));do
-    terraform import ${user_account_import_ids[$i]}
+for user_account_id in ${user_account_import_ids[@]};do
+    terraform import $user_account_id
 done
-for ((i = 0; i < ${#access_rule_import_ids[@]}; i++));do
-    terraform import ${access_rule_import_ids[$i]}
+for access_rule_id in ${access_rule_import_ids[@]};do
+    terraform import $access_rule_id
 done
 
 echo
@@ -184,19 +181,19 @@ echo "Removing the following cyral_repository_identity_maps:"
 printf '%s\n' "${identity_maps_to_delete[@]}"
 echo
 
-for ((i = 0; i < ${#local_accounts_to_delete[@]}; i++));do
-    terraform state rm ${local_accounts_to_delete[$i]}
+for local_account in ${local_accounts_to_delete[@]};do
+    terraform state rm $local_account
 done
 
-for ((i = 0; i < ${#identity_maps_to_delete[@]}; i++));do
-    terraform state rm ${identity_maps_to_delete[$i]}
+for identity_map in ${identity_maps_to_delete[@]};do
+    terraform state rm $identity_map
 done
 
-for ((i = 0; i < ${#user_account_resource_names[@]}; i++));do
-    terraform state show -no-color ${user_account_resource_names[$i]} | grep -v "   user_account_id" | grep -v "   id " >> cyral_migration_repository_access_rules_and_user_accounts.txt
+for user_account in ${user_account_resource_names[@]};do
+    terraform state show -no-color $user_account | grep -v "   user_account_id" | grep -v "   id " >> cyral_migration_repository_access_rules_and_user_accounts.txt
 done
-for ((i = 0; i < ${#access_rule_resource_names[@]}; i++));do
-    terraform state show -no-color ${access_rule_resource_names[$i]} | grep -v "   id " >> cyral_migration_repository_access_rules_and_user_accounts.txt
+for access_rule in ${access_rule_resource_names[@]};do
+    terraform state show -no-color $access_rule | grep -v "   id " >> cyral_migration_repository_access_rules_and_user_accounts.txt
 done
 
 mv cyral_migration_repository_access_rules_and_user_accounts.txt cyral_migration_repository_access_rules_and_user_accounts.tf


### PR DESCRIPTION
## Description of the change

The repository resource was updated to align with the new version of the API, which is described on [this confluence page](https://cyralinc.atlassian.net/wiki/spaces/EN/pages/1804271617/Sidecar+Listener+REST+API#Use-case-studies). 

This PR introduces the following new fields:
- Repo Nodes (Host, Port, Name, Dynamic)
- Connection parameters (this already existed in the API, but not in Terraform)
- Preferred Access Gateway (Sidecar ID and Binding ID)
- MongoDB Settings

It also removes the following fields, that have been deprecated:
- Host
- Port
- MaxAllowedListeners
- Properties (Mongo related settings)

All tests related to cyral_repository resources and data sources currently pass in development (against a control plane running the new APIs). However, some of the other tests are currently breaking, as some of these changes depend on updating the binding resource. When the binding resource has been properly updated, I will go through all the tests that depend on repositories & bindings and ensure they are working as expected. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Jira issue referenced in commit message and/or PR title

### Testing

> Description of testing
