### PR TITLE
ENG-10482: teach Terraform provider about MongoDB SRV Records

### DIFF
--- a/cyral/data_source_cyral_repository.go
+++ b/cyral/data_source_cyral_repository.go
@@ -179,6 +179,11 @@ func dataSourceRepository() *schema.Resource {
 										Type:        schema.TypeString,
 										Computed:    true,
 									},
+									RepoMongoDBSRVRecordName: {
+										Description: "Name of a DNS SRV record which contains cluster topology details",
+										Type:        schema.TypeString,
+										Optional:    true,
+									},
 								},
 							},
 						},

--- a/cyral/resource_cyral_repository.go
+++ b/cyral/resource_cyral_repository.go
@@ -28,6 +28,7 @@ const (
 	RepoMongoDBSettingsKey       = "mongodb_settings"
 	RepoMongoDBReplicaSetNameKey = "replica_set_name"
 	RepoMongoDBServerTypeKey     = "server_type"
+	RepoMongoDBSRVRecordName     = "srv_record_name"
 )
 
 const (
@@ -69,12 +70,14 @@ func repositoryTypes() []string {
 const (
 	ReplicaSet = "replicaset"
 	Standalone = "standalone"
+	Sharded    = "sharded"
 )
 
 func mongoServerTypes() []string {
 	return []string{
 		ReplicaSet,
 		Standalone,
+		Sharded,
 	}
 }
 
@@ -102,6 +105,7 @@ type ConnDraining struct {
 type MongoDBSettings struct {
 	ReplicaSetName string `json:"replicaSetName,omitempty"`
 	ServerType     string `json:"serverType,omitempty"`
+	SRVRecordName  string `json:"srvRecordName,omitempty"`
 }
 
 type RepoNode struct {
@@ -229,6 +233,7 @@ func (r *RepoInfo) MongoDBSettingsAsInterface() []interface{} {
 	return []interface{}{map[string]interface{}{
 		RepoMongoDBReplicaSetNameKey: r.MongoDBSettings.ReplicaSetName,
 		RepoMongoDBServerTypeKey:     r.MongoDBSettings.ServerType,
+		RepoMongoDBSRVRecordName:     r.MongoDBSettings.SRVRecordName,
 	}}
 }
 
@@ -249,6 +254,7 @@ func (r *RepoInfo) MongoDBSettingsFromInterface(i []interface{}) error {
 	r.MongoDBSettings = &MongoDBSettings{
 		ReplicaSetName: i[0].(map[string]interface{})[RepoMongoDBReplicaSetNameKey].(string),
 		ServerType:     i[0].(map[string]interface{})[RepoMongoDBServerTypeKey].(string),
+		SRVRecordName:  i[0].(map[string]interface{})[RepoMongoDBSRVRecordName].(string),
 	}
 	return nil
 }
@@ -418,6 +424,11 @@ func resourceRepository() *schema.Resource {
 							Type:         schema.TypeString,
 							Required:     true,
 							ValidateFunc: validation.StringInSlice(mongoServerTypes(), false),
+						},
+						RepoMongoDBSRVRecordName: {
+							Description: "Name of a DNS SRV record which contains cluster topology details",
+							Type:        schema.TypeString,
+							Optional:    true,
 						},
 					},
 				},

--- a/cyral/resource_cyral_repository.go
+++ b/cyral/resource_cyral_repository.go
@@ -243,13 +243,22 @@ func (r *RepoInfo) MongoDBSettingsFromInterface(i []interface{}) error {
 	}
 	var replicaSetName = i[0].(map[string]interface{})[RepoMongoDBReplicaSetNameKey].(string)
 	var serverType = i[0].(map[string]interface{})[RepoMongoDBServerTypeKey].(string)
+	var srvRecordName = i[0].(map[string]interface{})[RepoMongoDBSRVRecordName].(string)
 	if serverType == ReplicaSet && replicaSetName == "" {
 		return fmt.Errorf("'%s' must be provided when '%s=\"%s\"'", RepoMongoDBReplicaSetNameKey,
 			RepoMongoDBServerTypeKey, ReplicaSet)
 	}
-	if serverType == Standalone && replicaSetName != "" {
+	if serverType != ReplicaSet && replicaSetName != "" {
 		return fmt.Errorf("'%s' cannot be provided when '%s=\"%s\"'", RepoMongoDBReplicaSetNameKey,
-			RepoMongoDBServerTypeKey, Standalone)
+			RepoMongoDBServerTypeKey, serverType)
+	}
+	if serverType == Standalone && srvRecordName != "" {
+		return fmt.Errorf(
+			"'%s' cannot be provided when '%s=\"%s\"'",
+			RepoMongoDBSRVRecordName,
+			RepoMongoDBServerTypeKey,
+			Standalone,
+		)
 	}
 	r.MongoDBSettings = &MongoDBSettings{
 		ReplicaSetName: i[0].(map[string]interface{})[RepoMongoDBReplicaSetNameKey].(string),

--- a/docs/data-sources/repository.md
+++ b/docs/data-sources/repository.md
@@ -101,6 +101,7 @@ Read-Only:
 
 - `replica_set_name` (String)
 - `server_type` (String)
+- `srv_record_name` (String)
 
 <a id="nestedobjatt--repository_list--repo_node"></a>
 

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -140,8 +140,10 @@ Required:
 
 - `server_type` (String) Type of the MongoDB server. Allowed values:
   - `replicaset`
+  - `sharded`
   - `standalone`
 
 Optional:
 
 - `replica_set_name` (String) Name of the replica set, if applicable.
+- `srv_record_name` (String) Name of a DNS SRV record which contains cluster topology details

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -140,8 +140,8 @@ Required:
 
 - `server_type` (String) Type of the MongoDB server. Allowed values:
   - `replicaset`
-  - `sharded`
   - `standalone`
+  - `sharded`
 
 Optional:
 


### PR DESCRIPTION
## Description of the change

Repo creation can now take a new optional argument for `MongoDBSettings`, called `SRVRecordName`. This PR updates our TF provider so that it can also use that new argument.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Jira issue referenced in commit message and/or PR title

### Testing
Using a local CP I created a replica set repo with all-dynamic repo nodes, as well as a sharded repo. Both worked fine. Acceptance tests were also updated.