### PR TITLE
ENG-10518: Remove references to deprecated fields mongodb_port_alloc_range_low/high

### DIFF
--- a/docs/guides/mongodb_cluster_okta_idp.md
+++ b/docs/guides/mongodb_cluster_okta_idp.md
@@ -120,9 +120,6 @@ locals {
     # resource `mongodb_repo` below).
     mongodb_max_nodes = 3
 
-    # See `mongodb_port_alloc_range_low` and
-    # `mongodb_port_alloc_range_high` in the cyral_sidecar module
-    # configuration.
     mongodb_ports_low  = 27017
     mongodb_ports_high = local.mongodb_ports_low + local.mongodb_max_nodes
 
@@ -268,21 +265,6 @@ module "cyral_sidecar" {
   # to other types of repositories, make sure to allocate additional
   # ports for them.
   sidecar_ports = local.mongodb_ports
-
-  # Lower and upper limit values for the port allocation range
-  # reserved for MongoDB. This range must correspond to the range of
-  # ports declared in sidecar_ports that will be used for MongoDB. If
-  # you assign to sidecar_ports the consecutive ports 27017, 27018 and
-  # 27019 for MongoDB utilization, it means that the corresponding
-  # mongodb_port_alloc_range_low is 27017 and
-  # mongodb_port_alloc_range_high is 27019. If you want to use a range
-  # of 10 ports for MongoDB, then you need to add all consecutive
-  # ports to sidecar_ports (ex: 27017, 27018, 27019, 27020, 27021,
-  # 27022, 27023, 27024, 27025, 27026) and define
-  # mongodb_port_alloc_range_low = 27017 and
-  # mongodb_port_alloc_range_high = 27026.
-  mongodb_port_alloc_range_low  = local.mongodb_ports_low
-  mongodb_port_alloc_range_high = local.mongodb_ports_high
 
   instance_type   = local.sidecar.instance_type
   log_integration = local.sidecar.log_integration

--- a/docs/guides/setup_cp_and_deploy_sidecar.md
+++ b/docs/guides/setup_cp_and_deploy_sidecar.md
@@ -166,9 +166,6 @@ module "cyral_sidecar" {
 
   sidecar_ports = [cyral_repository.pg_repo.port, cyral_repository.mysql_repo.port]
 
-  mongodb_port_alloc_range_low  = 0
-  mongodb_port_alloc_range_high = 0
-
   instance_type   = local.sidecar.instance_type
   log_integration = local.sidecar.log_integration
   vpc_id          = local.sidecar.vpc_id

--- a/examples/guides/mongodb_cluster_okta_idp_sidecar.tf
+++ b/examples/guides/mongodb_cluster_okta_idp_sidecar.tf
@@ -44,9 +44,6 @@ locals {
     # resource `mongodb_repo` below).
     mongodb_max_nodes = 3
 
-    # See `mongodb_port_alloc_range_low` and
-    # `mongodb_port_alloc_range_high` in the cyral_sidecar module
-    # configuration.
     mongodb_ports_low  = 27017
     mongodb_ports_high = local.mongodb_ports_low + local.mongodb_max_nodes
 
@@ -192,21 +189,6 @@ module "cyral_sidecar" {
   # to other types of repositories, make sure to allocate additional
   # ports for them.
   sidecar_ports = local.mongodb_ports
-
-  # Lower and upper limit values for the port allocation range
-  # reserved for MongoDB. This range must correspond to the range of
-  # ports declared in sidecar_ports that will be used for MongoDB. If
-  # you assign to sidecar_ports the consecutive ports 27017, 27018 and
-  # 27019 for MongoDB utilization, it means that the corresponding
-  # mongodb_port_alloc_range_low is 27017 and
-  # mongodb_port_alloc_range_high is 27019. If you want to use a range
-  # of 10 ports for MongoDB, then you need to add all consecutive
-  # ports to sidecar_ports (ex: 27017, 27018, 27019, 27020, 27021,
-  # 27022, 27023, 27024, 27025, 27026) and define
-  # mongodb_port_alloc_range_low = 27017 and
-  # mongodb_port_alloc_range_high = 27026.
-  mongodb_port_alloc_range_low  = local.mongodb_ports_low
-  mongodb_port_alloc_range_high = local.mongodb_ports_high
 
   instance_type   = local.sidecar.instance_type
   log_integration = local.sidecar.log_integration

--- a/examples/guides/setup_cp_and_deploy_sidecar.tf
+++ b/examples/guides/setup_cp_and_deploy_sidecar.tf
@@ -151,9 +151,6 @@ module "cyral_sidecar" {
 
   sidecar_ports = [cyral_repository.pg_repo.port, cyral_repository.mysql_repo.port]
 
-  mongodb_port_alloc_range_low  = 0
-  mongodb_port_alloc_range_high = 0
-
   instance_type   = local.sidecar.instance_type
   log_integration = local.sidecar.log_integration
   vpc_id          = local.sidecar.vpc_id


### PR DESCRIPTION
## Description of the change

These fields were initially deprecated in sidecar v3.0.0 and will be removed in a future release

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Jira issue referenced in commit message and/or PR title

### Testing

No tests performed.