### PR TITLE
ENG-10659: Adding Force New Directives to Access Gateway resource

### DIFF
--- a/cyral/resource_cyral_repository_access_gateway.go
+++ b/cyral/resource_cyral_repository_access_gateway.go
@@ -109,15 +109,17 @@ func resourceRepositoryAccessGateway() *schema.Resource {
 				Required: true,
 			},
 			SidecarIDKey: {
-				Description: "ID of the sidecar that will be set as the access gatway for the given repository.",
+				Description: "ID of the sidecar that will be set as the access gateway for the given repository.",
 				Type:        schema.TypeString,
 				Required:    true,
 			},
 			BindingIDKey: {
-				Description: "ID of the binding that will be set as the access gatway for the given repository.",
-				Type:        schema.TypeString,
-				ForceNew:    true,
-				Required:    true,
+				Description: "ID of the binding that will be set as the access gateway for the given repository.  " +
+					"Note that modifications to this field will result in terraform replacing the given " +
+					"access gateway resource, since the access gateway must be deleted before binding. ",
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/cyral/resource_cyral_repository_access_gateway.go
+++ b/cyral/resource_cyral_repository_access_gateway.go
@@ -105,6 +105,7 @@ func resourceRepositoryAccessGateway() *schema.Resource {
 				Description: "ID of the repository the access gateway is associated with. This is also the " +
 					"import ID for this resource.",
 				Type:     schema.TypeString,
+				ForceNew: true,
 				Required: true,
 			},
 			SidecarIDKey: {
@@ -115,6 +116,7 @@ func resourceRepositoryAccessGateway() *schema.Resource {
 			BindingIDKey: {
 				Description: "ID of the binding that will be set as the access gatway for the given repository.",
 				Type:        schema.TypeString,
+				ForceNew:    true,
 				Required:    true,
 			},
 		},

--- a/docs/resources/repository_access_gateway.md
+++ b/docs/resources/repository_access_gateway.md
@@ -59,9 +59,9 @@ resource "cyral_repository_access_gateway" "access_gateway" {
 
 ### Required
 
-- `binding_id` (String) ID of the binding that will be set as the access gatway for the given repository.
+- `binding_id` (String) ID of the binding that will be set as the access gateway for the given repository. Note that modifications to this field will result in terraform replacing the given access gateway resource, since the access gateway must be deleted before binding.
 - `repository_id` (String) ID of the repository the access gateway is associated with. This is also the import ID for this resource.
-- `sidecar_id` (String) ID of the sidecar that will be set as the access gatway for the given repository.
+- `sidecar_id` (String) ID of the sidecar that will be set as the access gateway for the given repository.
 
 ### Read-Only
 


### PR DESCRIPTION
## Description of the change

> The access gateway resource was written before a validation was added, and the tests are now failing. See this [E2E test report](https://00f74ba44bff38344111bc65e7eedffdc64bd22884-apidata.googleusercontent.com/download/storage/v1/b/cyral-artifacts-dev/o/nightly-e2e-tests%2Freport.2cd2d3e6-f908-4213-bbae-933ab09e513f.html?jk=AFshE3UjCbwRGL4uImJD_qVJ82cGBhmvupcRX1jQlTKS5uiPNZKFed3qxZaB7h5PtawRoBZe3tbmRChCBBZsh8_l7x7riP08Csehgwe7jgAc_xO_5rekfzQx1Le6iLyOk4XDPaotKtteEa_UXjWIAMBTg1CWj1KMoY6ORPWlTIgWBcuAG3Bm0U_YoM8_y5mrxwO8bPwTDlWRDkAs1t9Chrsq0wfW6juLK3gmUqnXatr_o1KFw3ZRMQwCXbIC9u9HnuivMzatooub2bPDGIC0IIsfEkkA2MKlsP9Lv0_oA_OppK8386C33T5wnmE_mU3snN63I2r_uR9fylkRQaCQ2yW4a22DTV8a-UXagk3qhvcex3F-p8cdSK1mJ4TWbKPkSNpfgrjARdGmZ6gFPy5YjSF0TyDE70ltfXom4r4mXzvfM4FcbsEKzVGMcGD-RWwczeLl1XeW_oMkR7iWNOkPfihJcMrRcgq2qnQNQW-wQDI-75-hRovNh0jWdV4L0d-I0SNNPDBKLwiZNq16r1B5BAvCS9_tTy5C2hZJq4Y0P4xouloyYADGgU7h3bqGk3NwqNfVB2WNW0mQE1alVcAYQ_mQMrkNg1u_aERv9JhDBmUopPvc1rXG0R9OlryDzyttBK1_rWxKaYPsM5PtQiMfkBLg1ppKtWZRLIn7InzJ6AKfDrHc3Tfcd9Mak_CSUQVAUgmv0clFNRUmzGa8lcB5PQoVPvvZ_GKSlr-1G9oNFDjNSFh0UAZGi5z726DS9gXeBC465OIw4J_zj3J1Hffg5nUxFAy0VAZC5nHT5SdfpCWRKQ9vuakqGYzHRvwE9CJl3Oh0kSZTFujOWamZyQZk9VityLVMxbz5fvTMXHTPhIlq9cNhZnVdJX-ZfhHAp78CqwjtPGvksyCeMfWJSistd778oKJ7Kt96dGJ6j9Rjcj_xxmUhNaL-YDVe3A5gJ315rxN6Kj_YYslrFJroDPpLSx1PV7uFm3HzN1rZ9aTz5MeAl35an6fPGkzXu7IpLooi8sGt1roQgk6iRpGiJXSSmUoHyzV67F6n1VhDbceD_dq3u1B2OxU6uNjPcvWLoutNwX-ALLKv5fWIZTACwOLfAnsuPANxv0sE74pGxDPwoKmWWJfcX2xXrLMAWR1qJxY7Wmk4v9gJntqf4Grl9eaWJMGaRfLq0tLgrjhQfhVlUsJ3NOEE0mqoeLNvle3T6-01rq3BXDchX7INZSjnx7nsrvs5QBXGrX0VTFyyOHfNzsuNQrY&isca=1). 
The issue was that the API does not explicitly mark the the access gateway as dependent on the binding. Attempting to delete a binding that is in use as an access gateway will fail. We addressed this by using the force new directive for the access gateway binding ID. This directive ensures that the access gateway is deleted when the binding it refers to changes, so that terraform won’t attempt to delete the binding it refers to.

Jira: https://cyralinc.atlassian.net/browse/ENG-10659

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Jira issue referenced in commit message and/or PR title

### Testing

> Tested on current main branch (prerelease for 4.0) on k8s. 
