### PR TITLE
ENG-10716: Special case for cyral_repository_conf_auth resources fix.

### DIFF
--- a/docs/guides/4.0-migration-guide.md
+++ b/docs/guides/4.0-migration-guide.md
@@ -24,35 +24,91 @@ for `cyral_repository` data sources, you will need to rewrite them after migrati
 
 The following steps should be taken to upgrade the Cyral CP and the Cyral Terraform provider:
 
-1. **Before upgrading the CP to V4**, please run `terraform apply` to ensure your Terraform state is up-to-date.
+1.  If you are currently using a `for_each` loop to create any resources that reference `repository_id` fields,
+    _please remove the code block creating these resources from terraform before attempting migration_. Here is an example
+    of what that might look like:
 
-2. Upgrade the Cyral CP to MAJOR version 4.
+        ```
+        resource "some_resource_type" "some_resource_name" {
+          for_each = cyral_repository.all_repositories
+          repository_id = each.value.id
+          ...
+        }
+        ```
 
-3. Remove all `cyral_repository` data source output blocks. If you have any output blocks configured
-   for `cyral_repository` data sources, you will need to rewrite them based on the new schema after
-   migration is completed.
+    Please make sure to carefully check for all code blocks that iterate over `cyral_repository` resources to extract the `repository_id` field.
 
-4. Run the Cyral Terraform Provider [V4 Migration Script](..scripts/4.0-migration.sh) after upgrading
-   the Cyral CP to MAJOR version 4.
+2.  **Before upgrading the CP to V4**, please run `terraform apply` to ensure your Terraform state is up-to-date.
 
-~> **WARNING** It is essential that the Cyral Terraform Provider V4 Migration is run **after** the CP has been upgraded.
+3.  Upgrade the Cyral CP to MAJOR version 4.
+
+4.  Remove all `cyral_repository` data source output blocks. If you have any output blocks configured
+    for `cyral_repository` data sources, you will need to rewrite them based on the new schema after
+    migration is completed.
+
+5.  Run the Cyral Terraform Provider [V4 Migration Script](..scripts/4.0-migration.sh) after upgrading
+    the Cyral CP to MAJOR version 4.
+
+6.  If you previously used a `for_each` loop to create resources referencing a `repository_id` field, you will need to
+    re-add the code block after migration. Open the file `cyral_migration_repositories_bindings_listeners.tf`
+    that was created by the script. At the top, you will see a new local variable containing the `repository_id`
+    values for all the newly migrated `cyral_repository` resources. Use this variable to re-create your
+    resources as follows, adding all relavent settings that are desired:
+
+        ```
+        resource "cyral_repository_conf_auth" "all_auth_config" {
+          for_each = toset(local.cyral_repository_resource_names)
+          repository_id = each.value
+          ...
+        }
+        ```
+
+~> **WARNING:** It is essential that the Cyral Terraform Provider V4 Migration is run **after** the CP has been upgraded.
 
 ### Migrating from 2.X to 4.0
 
 The following steps should be taken to upgrade the Cyral CP and the Cyral Terraform provider:
 
-1. **Before upgrading the CP to V4**, please run `terraform apply` to ensure your Terraform state is up-to-date.
+1.  If you are currently using a `for_each` loop to create any resources that reference `repository_id` fields,
+    _please remove the code block creating these resources from terraform before attempting migration_. Here is an example
+    of what that might look like:
 
-2. Upgrade the Cyral CP to MAJOR version 4.
+        ```
+        resource "some_resource_type" "some_resource_name" {
+          for_each = cyral_repository.all_repositories
+          repository_id = each.value.id
+          ...
+        }
+        ```
 
-3. Remove all `cyral_repository` data source output blocks. If you have any output blocks configured
-   for `cyral_repository` data sources, you will need to rewrite them based on the new schema after
-   migration is completed.
+    Please make sure to carefully check for all code blocks that iterate over `cyral_repository` resources to extract the `repository_id` field.
 
-4. Run the Cyral Terraform Provider [V2-V4 Migration Script](..scripts/2.X-4.0-migration.sh) after upgrading
-   the Cyral CP to MAJOR version 4.
+2.  **Before upgrading the CP to V4**, please run `terraform apply` to ensure your Terraform state is up-to-date.
 
-~> **WARNING** It is essential that the Cyral Terraform Provider V2-V4 Migration is run **after** the CP has been upgraded.
+3.  Upgrade the Cyral CP to MAJOR version 4.
+
+4.  Remove all `cyral_repository` data source output blocks. If you have any output blocks configured
+    for `cyral_repository` data sources, you will need to rewrite them based on the new schema after
+    migration is completed.
+
+5.  Run the Cyral Terraform Provider [V2-V4 Migration Script](..scripts/2.X-4.0-migration.sh) after upgrading
+    the Cyral CP to MAJOR version 4.
+
+6.  If you previously used a `for_each` loop to create resources referencing a `repository_id` field, you will need to
+    re-add the code block after migration. Open the file `cyral_migration_repositories_bindings_listeners.tf`
+    that was created by the script. At the top, you will see a new local variable containing the `repository_id`
+    values for all the newly migrated `cyral_repository` resources. Use this variable to re-create your
+    resources as follows, adding all relavent settings that are desired:
+
+        ```
+        resource "some_resource_type" "some_resource_name" {
+          for_each = toset(local.cyral_repository_resource_names)
+          repository_id = each.value
+          ...
+        }
+        ```
+
+~> **WARNING:** It is essential that the Cyral Terraform Provider V2-V4 Migration is run **after** the CP has been upgraded.
 
 ## Prerequisites
 

--- a/templates/guides/4.0-migration-guide.md.tmpl
+++ b/templates/guides/4.0-migration-guide.md.tmpl
@@ -24,35 +24,91 @@ for `cyral_repository` data sources, you will need to rewrite them after migrati
 
 The following steps should be taken to upgrade the Cyral CP and the Cyral Terraform provider:
 
-1. **Before upgrading the CP to V4**, please run `terraform apply` to ensure your Terraform state is up-to-date.
+1.  If you are currently using a `for_each` loop to create any resources that reference `repository_id` fields,
+    *please remove the code block creating these resources from terraform before attempting migration*. Here is an example
+    of what that might look like:
 
-2. Upgrade the Cyral CP to MAJOR version 4.
+        ```
+        resource "some_resource_type" "some_resource_name" {
+          for_each = cyral_repository.all_repositories
+          repository_id = each.value.id
+          ...
+        }
+        ```
 
-3. Remove all `cyral_repository` data source output blocks. If you have any output blocks configured
+    Please make sure to carefully check for all code blocks that iterate over `cyral_repository` resources to extract the `repository_id` field.
+
+2. **Before upgrading the CP to V4**, please run `terraform apply` to ensure your Terraform state is up-to-date.
+
+3. Upgrade the Cyral CP to MAJOR version 4.
+
+4. Remove all `cyral_repository` data source output blocks. If you have any output blocks configured
 for `cyral_repository` data sources, you will need to rewrite them based on the new schema after
 migration is completed.
 
-4. Run the Cyral Terraform Provider [V4 Migration Script](..scripts/4.0-migration.sh) after upgrading
+5. Run the Cyral Terraform Provider [V4 Migration Script](..scripts/4.0-migration.sh) after upgrading
 the Cyral CP to MAJOR version 4.
 
-~> **WARNING** It is essential that the Cyral Terraform Provider V4 Migration is run **after** the CP has been upgraded.
+6. If you previously used a `for_each` loop to create resources referencing a `repository_id` field, you will need to
+re-add the code block after migration. Open the file  `cyral_migration_repositories_bindings_listeners.tf`
+that was created by the script. At the top, you will see a new local variable containing the `repository_id`
+values for all the newly migrated `cyral_repository` resources. Use this variable to re-create your
+resources as follows, adding all relavent settings that are desired:
+
+    ```
+    resource "cyral_repository_conf_auth" "all_auth_config" {
+      for_each = toset(local.cyral_repository_resource_names)
+      repository_id = each.value
+      ...
+    }
+    ```
+
+~> **WARNING:** It is essential that the Cyral Terraform Provider V4 Migration is run **after** the CP has been upgraded.
 
 ### Migrating from 2.X to 4.0
 
 The following steps should be taken to upgrade the Cyral CP and the Cyral Terraform provider:
 
-1. **Before upgrading the CP to V4**, please run `terraform apply` to ensure your Terraform state is up-to-date.
+1.  If you are currently using a `for_each` loop to create any resources that reference `repository_id` fields,
+    *please remove the code block creating these resources from terraform before attempting migration*. Here is an example
+    of what that might look like:
 
-2. Upgrade the Cyral CP to MAJOR version 4.
+        ```
+        resource "some_resource_type" "some_resource_name" {
+          for_each = cyral_repository.all_repositories
+          repository_id = each.value.id
+          ...
+        }
+        ```
 
-3. Remove all `cyral_repository` data source output blocks. If you have any output blocks configured
+    Please make sure to carefully check for all code blocks that iterate over `cyral_repository` resources to extract the `repository_id` field.
+
+2. **Before upgrading the CP to V4**, please run `terraform apply` to ensure your Terraform state is up-to-date.
+
+3. Upgrade the Cyral CP to MAJOR version 4.
+
+4. Remove all `cyral_repository` data source output blocks. If you have any output blocks configured
 for `cyral_repository` data sources, you will need to rewrite them based on the new schema after
 migration is completed.
 
-4. Run the Cyral Terraform Provider [V2-V4 Migration Script](..scripts/2.X-4.0-migration.sh) after upgrading
+5. Run the Cyral Terraform Provider [V2-V4 Migration Script](..scripts/2.X-4.0-migration.sh) after upgrading
 the Cyral CP to MAJOR version 4.
 
-~> **WARNING** It is essential that the Cyral Terraform Provider V2-V4 Migration is run **after** the CP has been upgraded.
+6. If you previously used a `for_each` loop to create resources referencing a `repository_id` field, you will need to
+re-add the code block after migration. Open the file  `cyral_migration_repositories_bindings_listeners.tf`
+that was created by the script. At the top, you will see a new local variable containing the `repository_id`
+values for all the newly migrated `cyral_repository` resources. Use this variable to re-create your
+resources as follows, adding all relavent settings that are desired:
+
+    ```
+    resource "some_resource_type" "some_resource_name" {
+      for_each = toset(local.cyral_repository_resource_names)
+      repository_id = each.value
+      ...
+    }
+    ```
+
+~> **WARNING:** It is essential that the Cyral Terraform Provider V2-V4 Migration is run **after** the CP has been upgraded.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Description of the change

> When migrating from 2.x to 4.0 the terraform script fails to migrate cyral_repository_conf_auth resources if they are created using for_each loops. This is due to the fact that cyral_repository resource names will by changed by script when *they* are also created by a for_each loop, as terraform does not allow brackets in resource names. This change introduces a fix.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Jira issue referenced in commit message and/or PR title

### Testing

> This was tested on CP migration from 3.0 to 4.0 on k8s. 
