### PR TITLE
Make mongodb_settings mandatory if cyral_repository.type = mongodb

### DIFF
--- a/cyral/data_source_cyral_repository_test.go
+++ b/cyral/data_source_cyral_repository_test.go
@@ -35,6 +35,9 @@ func repositoryDataSourceTestRepos() []RepoInfo {
 					Port: 27017,
 				},
 			},
+			MongoDBSettings: &MongoDBSettings{
+				ServerType: Standalone,
+			},
 		},
 	}
 }

--- a/cyral/resource_cyral_repository.go
+++ b/cyral/resource_cyral_repository.go
@@ -30,29 +30,51 @@ const (
 	RepoMongoDBServerTypeKey     = "server_type"
 )
 
+const (
+	Denodo          = "denodo"
+	Dremio          = "dremio"
+	DynamoDB        = "dynamodb"
+	DynamoDBStreams = "dynamodbstreams"
+	Galera          = "galera"
+	MariaDB         = "mariadb"
+	MongoDB         = "mongodb"
+	MySQL           = "mysql"
+	Oracle          = "oracle"
+	PostgreSQL      = "postgresql"
+	Redshift        = "redshift"
+	S3              = "s3"
+	Snowflake       = "snowflake"
+	SQLServer       = "sqlserver"
+)
+
 func repositoryTypes() []string {
 	return []string{
-		"denodo",
-		"dremio",
-		"dynamodb",
-		"dynamodbstreams",
-		"galera",
-		"mariadb",
-		"mongodb",
-		"mysql",
-		"oracle",
-		"postgresql",
-		"redshift",
-		"s3",
-		"snowflake",
-		"sqlserver",
+		Denodo,
+		Dremio,
+		DynamoDB,
+		DynamoDBStreams,
+		Galera,
+		MariaDB,
+		MongoDB,
+		MySQL,
+		Oracle,
+		PostgreSQL,
+		Redshift,
+		S3,
+		Snowflake,
+		SQLServer,
 	}
 }
 
+const (
+	ReplicaSet = "replicaset"
+	Standalone = "standalone"
+)
+
 func mongoServerTypes() []string {
 	return []string{
-		"replicaset",
-		"standalone",
+		ReplicaSet,
+		Standalone,
 	}
 }
 
@@ -114,7 +136,11 @@ func (r *RepoInfo) ReadFromSchema(d *schema.ResourceData) error {
 	r.LabelsFromInterface(d.Get(RepoLabelsKey).([]interface{}))
 	r.RepoNodesFromInterface(d.Get(RepoNodesKey).([]interface{}))
 	r.ConnDrainingFromInterface(d.Get(RepoConnDrainingKey).(*schema.Set).List())
-	r.MongoDBSettingsFromInterface(d.Get(RepoMongoDBSettingsKey).(*schema.Set).List())
+	var mongoDBSettings = d.Get(RepoMongoDBSettingsKey).(*schema.Set).List()
+	if r.Type == MongoDB && (mongoDBSettings == nil || len(mongoDBSettings) == 0) {
+		return fmt.Errorf("block '%s' is mandatory when 'type=%s'", RepoMongoDBSettingsKey, MongoDB)
+	}
+	r.MongoDBSettingsFromInterface(mongoDBSettings)
 	return nil
 }
 
@@ -378,7 +404,7 @@ func resourceRepository() *schema.Resource {
 						RepoMongoDBServerTypeKey: {
 							Description:  "Type of the MongoDB server. Allowed values: " + supportedTypesMarkdown(mongoServerTypes()),
 							Type:         schema.TypeString,
-							Optional:     true,
+							Required:     true,
 							ValidateFunc: validation.StringInSlice(mongoServerTypes(), false),
 						},
 					},

--- a/cyral/resource_cyral_repository.go
+++ b/cyral/resource_cyral_repository.go
@@ -138,7 +138,9 @@ func (r *RepoInfo) ReadFromSchema(d *schema.ResourceData) error {
 	r.ConnDrainingFromInterface(d.Get(RepoConnDrainingKey).(*schema.Set).List())
 	var mongoDBSettings = d.Get(RepoMongoDBSettingsKey).(*schema.Set).List()
 	if r.Type == MongoDB && (mongoDBSettings == nil || len(mongoDBSettings) == 0) {
-		return fmt.Errorf("block '%s' is mandatory when 'type=%s'", RepoMongoDBSettingsKey, MongoDB)
+		return fmt.Errorf("'%s' block is mandatory when 'type=%s'", RepoMongoDBSettingsKey, MongoDB)
+	} else if r.Type != MongoDB && len(mongoDBSettings) > 0 {
+		return fmt.Errorf("'%s' block is only allowed when 'type=%s'", RepoMongoDBSettingsKey, MongoDB)
 	}
 	r.MongoDBSettingsFromInterface(mongoDBSettings)
 	return nil

--- a/cyral/resource_cyral_repository_network_access_policy.go
+++ b/cyral/resource_cyral_repository_network_access_policy.go
@@ -18,8 +18,8 @@ const (
 
 func repositoryTypesNetworkShield() []string {
 	return []string{
-		"sqlserver",
-		"oracle",
+		SQLServer,
+		Oracle,
 	}
 }
 

--- a/cyral/resource_cyral_repository_test.go
+++ b/cyral/resource_cyral_repository_test.go
@@ -15,7 +15,7 @@ const (
 var (
 	initialRepoConfig = RepoInfo{
 		Name:   accTestName(repositoryResourceName, "repo"),
-		Type:   "mongodb",
+		Type:   MongoDB,
 		Labels: []string{"rds", "us-east-2"},
 		RepoNodes: []*RepoNode{
 			{
@@ -23,11 +23,14 @@ var (
 				Port: 3333,
 			},
 		},
+		MongoDBSettings: &MongoDBSettings{
+			ServerType: Standalone,
+		},
 	}
 
 	updatedRepoConfig = RepoInfo{
 		Name:   accTestName(repositoryResourceName, "repo-updated"),
-		Type:   "mongodb",
+		Type:   MongoDB,
 		Labels: []string{"rds", "us-east-1"},
 		RepoNodes: []*RepoNode{
 			{
@@ -35,11 +38,14 @@ var (
 				Port: 3334,
 			},
 		},
+		MongoDBSettings: &MongoDBSettings{
+			ServerType: Standalone,
+		},
 	}
 
 	emptyConnDrainingConfig = RepoInfo{
 		Name: accTestName(repositoryResourceName, "repo-empty-conn-draining"),
-		Type: "mongodb",
+		Type: MongoDB,
 		ConnParams: &ConnParams{
 			ConnDraining: &ConnDraining{},
 		},
@@ -49,11 +55,14 @@ var (
 				Port: 27017,
 			},
 		},
+		MongoDBSettings: &MongoDBSettings{
+			ServerType: Standalone,
+		},
 	}
 
 	connDrainingConfig = RepoInfo{
 		Name: accTestName(repositoryResourceName, "repo-conn-draining"),
-		Type: "mongodb",
+		Type: MongoDB,
 		ConnParams: &ConnParams{
 			ConnDraining: &ConnDraining{
 				Auto:     true,
@@ -66,11 +75,14 @@ var (
 				Port: 27017,
 			},
 		},
+		MongoDBSettings: &MongoDBSettings{
+			ServerType: Standalone,
+		},
 	}
 
 	mixedMultipleNodesConfig = RepoInfo{
 		Name: accTestName(repositoryResourceName, "repo-mixed-multi-node"),
-		Type: "mongodb",
+		Type: MongoDB,
 		ConnParams: &ConnParams{
 			ConnDraining: &ConnDraining{
 				Auto:     true,
@@ -103,7 +115,7 @@ var (
 		},
 		MongoDBSettings: &MongoDBSettings{
 			ReplicaSetName: "some-replica-set",
-			ServerType:     "replicaset",
+			ServerType:     ReplicaSet,
 		},
 	}
 )
@@ -194,11 +206,14 @@ func repoCheckFuctions(repo RepoInfo, resName string) resource.TestCheckFunc {
 	}
 
 	if repo.MongoDBSettings != nil {
+		if repo.MongoDBSettings.ServerType == ReplicaSet {
+			checkFuncs = append(checkFuncs, []resource.TestCheckFunc{
+				resource.TestCheckResourceAttr(resourceFullName,
+					"mongodb_settings.0.replica_set_name",
+					repo.MongoDBSettings.ReplicaSetName),
+			}...)
+		}
 		checkFuncs = append(checkFuncs, []resource.TestCheckFunc{
-			resource.TestCheckResourceAttr(resourceFullName,
-				"mongodb_settings.0.replica_set_name",
-				repo.MongoDBSettings.ReplicaSetName),
-
 			resource.TestCheckResourceAttr(resourceFullName,
 				"mongodb_settings.0.server_type",
 				repo.MongoDBSettings.ServerType),

--- a/cyral/testutils.go
+++ b/cyral/testutils.go
@@ -71,15 +71,30 @@ func importStateComposedIDFunc(
 }
 
 func formatBasicRepositoryIntoConfig(resName, repoName, typ, host string, port int) string {
-	return fmt.Sprintf(`
-	resource "cyral_repository" "%s" {
-		name = "%s"
-		type = "%s"
-		repo_node {
-			host = "%s"
-			port = %d
-		}
-	}`, resName, repoName, typ, host, port)
+	if typ == MongoDB {
+		return fmt.Sprintf(`
+		resource "cyral_repository" "%s" {
+			name = "%s"
+			type = "%s"
+			repo_node {
+				host = "%s"
+				port = %d
+			}
+			mongodb_settings {
+				server_type = "standalone"
+			}
+		}`, resName, repoName, typ, host, port)
+	} else {
+		return fmt.Sprintf(`
+		resource "cyral_repository" "%s" {
+			name = "%s"
+			type = "%s"
+			repo_node {
+				host = "%s"
+				port = %d
+			}
+		}`, resName, repoName, typ, host, port)
+	}
 }
 
 func formatBasicRepositoryBindingIntoConfig(resName, sidecarID, repositoryID, listenerID string) string {

--- a/docs/data-sources/repository.md
+++ b/docs/data-sources/repository.md
@@ -6,23 +6,26 @@ Retrieve and filter repositories.
 
 ```terraform
 resource "cyral_repository" "mongo-repository" {
-    type = "mongodb"
-    name = "tf-provider-mongo-repository"
+  type = "mongodb"
+  name = "tf-provider-mongo-repository"
 
-    repo_node {
-        host = "mongodb.cyral.com"
-        port = 27017
-    }
+  repo_node {
+    host = "mongodb.cyral.com"
+    port = 27017
+  }
+  mongodb_settings {
+    server_type = "standalone"
+  }
 }
 
 resource "cyral_repository" "mysql-repository" {
-    type = "mysql"
-    name = "tf-provider-mysql-repository"
+  type = "mysql"
+  name = "tf-provider-mysql-repository"
 
-    repo_node {
-        host = "mysql.com"
-        port = 3306
-    }
+  repo_node {
+    host = "mysql.com"
+    port = 3306
+  }
 }
 
 data "cyral_repository" "search-for-mysql-repo" {

--- a/docs/guides/4.0-migration-guide.md
+++ b/docs/guides/4.0-migration-guide.md
@@ -71,6 +71,9 @@ resource "cyral_repository" "mongo_repo" {
     host = "mongodb.cyral.com"
     port = 27017
   }
+  mongodb_settings {
+    server_type = "standalone"
+  }
 }
 
 resource "cyral_repository_binding" "binding" {

--- a/docs/guides/native_credentials_aws_sm.md
+++ b/docs/guides/native_credentials_aws_sm.md
@@ -54,8 +54,11 @@ resource "cyral_repository" "mongodb_repo" {
   type = "mongodb"
   name = "mymongodb"
   repo_node {
-      host = "mongodb.mycompany.com"
-      port = 27017
+    host = "mongodb.mycompany.com"
+    port = 27017
+  }
+  mongodb_settings {
+    server_type = "standalone"
   }
 }
 

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -20,6 +20,10 @@ resource "cyral_repository" "minimal_repo" {
         host = "mongodb.cyral.com"
         port = 27017
     }
+
+    mongodb_settings {
+      server_type = "standalone"
+    }
 }
 
 ### Repository with Connection Draining and Labels
@@ -37,6 +41,10 @@ resource "cyral_repository" "repo_with_conn_draining" {
     connection_draining {
       auto = true
       wait_time = 30
+    }
+
+    mongodb_settings {
+      server_type = "standalone"
     }
 }
 
@@ -128,9 +136,12 @@ Optional:
 
 ### Nested Schema for `mongodb_settings`
 
-Optional:
+Required:
 
-- `replica_set_name` (String) Name of the replica set, if applicable.
 - `server_type` (String) Type of the MongoDB server. Allowed values:
   - `replicaset`
   - `standalone`
+
+Optional:
+
+- `replica_set_name` (String) Name of the replica set, if applicable.

--- a/examples/data-sources/cyral_repository/data-source.tf
+++ b/examples/data-sources/cyral_repository/data-source.tf
@@ -1,21 +1,24 @@
 resource "cyral_repository" "mongo-repository" {
-    type = "mongodb"
-    name = "tf-provider-mongo-repository"
+  type = "mongodb"
+  name = "tf-provider-mongo-repository"
 
-    repo_node {
-        host = "mongodb.cyral.com"
-        port = 27017
-    }
+  repo_node {
+    host = "mongodb.cyral.com"
+    port = 27017
+  }
+  mongodb_settings {
+    server_type = "standalone"
+  }
 }
 
 resource "cyral_repository" "mysql-repository" {
-    type = "mysql"
-    name = "tf-provider-mysql-repository"
+  type = "mysql"
+  name = "tf-provider-mysql-repository"
 
-    repo_node {
-        host = "mysql.com"
-        port = 3306
-    }
+  repo_node {
+    host = "mysql.com"
+    port = 3306
+  }
 }
 
 data "cyral_repository" "search-for-mysql-repo" {

--- a/examples/guides/4.0-migration/example-resources-v4.tf
+++ b/examples/guides/4.0-migration/example-resources-v4.tf
@@ -5,6 +5,9 @@ resource "cyral_repository" "mongo_repo" {
     host = "mongodb.cyral.com"
     port = 27017
   }
+  mongodb_settings {
+    server_type = "standalone"
+  }
 }
 
 resource "cyral_repository_binding" "binding" {

--- a/examples/guides/native_credentials_aws_sm.tf
+++ b/examples/guides/native_credentials_aws_sm.tf
@@ -45,8 +45,11 @@ resource "cyral_repository" "mongodb_repo" {
   type = "mongodb"
   name = "mymongodb"
   repo_node {
-      host = "mongodb.mycompany.com"
-      port = 27017
+    host = "mongodb.mycompany.com"
+    port = 27017
+  }
+  mongodb_settings {
+    server_type = "standalone"
   }
 }
 

--- a/examples/resources/cyral_repository/resource.tf
+++ b/examples/resources/cyral_repository/resource.tf
@@ -8,6 +8,10 @@ resource "cyral_repository" "minimal_repo" {
         host = "mongodb.cyral.com"
         port = 27017
     }
+
+    mongodb_settings {
+      server_type = "standalone"
+    }
 }
 
 ### Repository with Connection Draining and Labels
@@ -25,6 +29,10 @@ resource "cyral_repository" "repo_with_conn_draining" {
     connection_draining {
       auto = true
       wait_time = 30
+    }
+
+    mongodb_settings {
+      server_type = "standalone"
     }
 }
 


### PR DESCRIPTION
## Description of the change

Fix a bug that allows empty blocks for `cyral_repository. mongodb_settings` when `cyral_repository.type = mongodb`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

Acceptance tests were executed against `stable` and all tests passed.
