### PR TITLE
ENG-11021: Update ADFS default value for IdP resource

### DIFF
--- a/cyral/resource_cyral_integration_idp.go
+++ b/cyral/resource_cyral_integration_idp.go
@@ -391,7 +391,7 @@ var (
 	adfsDefaultValuesMap = map[string]interface{}{
 		"display_name":                          "Active Directory",
 		"disable_post_binding_logout":           true,
-		"name_id_policy_format":                 "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
+		"name_id_policy_format":                 "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
 		"saml_xml_key_name_tranformer":          "CERT_SUBJECT",
 		"single_logout_service_url":             "",
 		"xml_sig_key_info_key_name_transformer": "CERT_SUBJECT",


### PR DESCRIPTION
## Description of the change

[ENG-11021](https://cyralinc.atlassian.net/browse/ENG-11021): Keycloak doesn't allow Transient NameID Format with SUBJECT Principal Type when creating ADFS IdP

Update the NameID Policy Format default value for ADFS to match fix in the integrations service (See https://github.com/cyralinc/integrations/pull/485).

Related PRs:
- https://github.com/cyralinc/integrations/pull/485
- https://github.com/cyralinc/cyral-docs-v2/pull/295

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Jira issue referenced in commit message and/or PR title

### Testing

Tested by running the Acceptance Tests.


[ENG-11021]: https://cyralinc.atlassian.net/browse/ENG-11021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ