### PR TITLE
Update cyral_repository_access_rules docs

### DIFF
--- a/cyral/resource_cyral_repository_access_rules.go
+++ b/cyral/resource_cyral_repository_access_rules.go
@@ -224,10 +224,11 @@ func resourceRepositoryAccessRules() *schema.Resource {
 			},
 
 			"user_account_id": {
-				Description: "ID of the database account.",
-				Required:    true,
-				Type:        schema.TypeString,
-				ForceNew:    true,
+				Description: "ID of the database account. This should be the attribute `user_account_id` " +
+					"of the resource `cyral_repository_user_account`.",
+				Required: true,
+				Type:     schema.TypeString,
+				ForceNew: true,
 			},
 
 			"rule": {

--- a/docs/resources/repository_access_rules.md
+++ b/docs/resources/repository_access_rules.md
@@ -53,7 +53,7 @@ resource "cyral_repository_access_rules" "some_resource_name" {
 
 - `repository_id` (String) ID of the repository.
 - `rule` (Block List, Min: 1) An ordered list of access rules. (see [below for nested schema](#nestedblock--rule))
-- `user_account_id` (String) ID of the database account.
+- `user_account_id` (String) ID of the database account. This should be the attribute `user_account_id` of the resource `cyral_repository_user_account`.
 
 ### Read-Only
 


### PR DESCRIPTION
## Description of the change

Improve the `cyral_repository_access_rules` docs to make clear that users should use the `user_account_id` attribute from `cyral_repository_user_account` instead of `id`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

NA
