### PR TITLE
ENG-11206: Replace POST by PUT in access rule creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ local/install: local/build
 	cp out/darwin_amd64/$(BINARY) ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/darwin_amd64
 
 docker/test:
-	docker-compose run -e CYRAL_TF_CONTROL_PLANE=$(CYRAL_TF_CONTROL_PLANE) -e CYRAL_TF_CLIENT_ID=$(CYRAL_TF_CLIENT_ID) \
-	  -e CYRAL_TF_CLIENT_SECRET=$(CYRAL_TF_CLIENT_SECRET) -e TF_ACC=true \
+	docker-compose run -e CYRAL_TF_CONTROL_PLANE=$$CYRAL_TF_CONTROL_PLANE -e CYRAL_TF_CLIENT_ID=$$CYRAL_TF_CLIENT_ID \
+	  -e CYRAL_TF_CLIENT_SECRET=$$CYRAL_TF_CLIENT_SECRET -e TF_ACC=true \
 	  app $(GOTEST) github.com/cyralinc/terraform-provider-cyral/... -v -race
 
 docker/build:

--- a/cyral/resource_cyral_repository_access_rules.go
+++ b/cyral/resource_cyral_repository_access_rules.go
@@ -147,7 +147,7 @@ func resourceRepositoryAccessRules() *schema.Resource {
 		CreateContext: CreateResource(
 			ResourceOperationConfig{
 				Name:       "RepositoryAccessRulesCreate",
-				HttpMethod: http.MethodPost,
+				HttpMethod: http.MethodPut,
 				CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 					repoID := d.Get("repository_id").(string)
 					userAccountID := d.Get("user_account_id").(string)


### PR DESCRIPTION
## Description of the change

Due to a backend inconsistency that leaves an empty access rule set behind, the following error could happen:
1. User creates access rules through Terraform;
2. User removes same access rules using the UI;
3. User try to re-create the very same access rules using Terraform and faces a `409` error.
The error is due to the empty access rule set that is left behind by our API. This is going to be fixed and the set will be completely removed, but in order to avoid customers from having this error and not being able to recover, we opted to switch the `POST` to a `PUT` in the access rules creation.
We could use the `POST` back after all customers are migrated to a release that contains the fix informed in the associated Jira ticket.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

Ignore the IdP test failure as the test cluster is a previous stable version and does not include this fix:

```
=== RUN   TestAccDatalabelDataSource
=== PAUSE TestAccDatalabelDataSource
=== RUN   TestAccIntegrationIdPSAMLDataSource
=== PAUSE TestAccIntegrationIdPSAMLDataSource
=== RUN   TestAccRepositoryDataSource
=== PAUSE TestAccRepositoryDataSource
=== RUN   TestAccRoleDataSource
=== PAUSE TestAccRoleDataSource
=== RUN   TestAccSAMLCertificateDataSource
=== PAUSE TestAccSAMLCertificateDataSource
=== RUN   TestAccSAMLConfigurationDataSource
=== PAUSE TestAccSAMLConfigurationDataSource
=== RUN   TestAccSidecarBoundPortsDataSource
=== PAUSE TestAccSidecarBoundPortsDataSource
=== RUN   TestAccSidecarCftTemplateDataSource
=== PAUSE TestAccSidecarCftTemplateDataSource
=== RUN   TestAccSidecarIDDataSource
=== PAUSE TestAccSidecarIDDataSource
=== RUN   TestAccSidecarInstanceIDsDataSource
=== PAUSE TestAccSidecarInstanceIDsDataSource
=== RUN   TestIntegrationsData_GetValue_Default
--- PASS: TestIntegrationsData_GetValue_Default (0.00s)
=== RUN   TestIntegrationsData_GetValue_Splunk
--- PASS: TestIntegrationsData_GetValue_Splunk (0.00s)
=== RUN   TestAccProvider
--- PASS: TestAccProvider (0.00s)
=== RUN   TestAccDatalabelResource
=== PAUSE TestAccDatalabelResource
=== RUN   TestAccDatadogIntegrationResource
=== PAUSE TestAccDatadogIntegrationResource
=== RUN   TestAccELKIntegrationResource
=== PAUSE TestAccELKIntegrationResource
=== RUN   TestAccHCVaultIntegrationResource
=== PAUSE TestAccHCVaultIntegrationResource
=== RUN   TestAccIntegrationIdPSAMLDraftResource
=== PAUSE TestAccIntegrationIdPSAMLDraftResource
=== RUN   TestAccIntegrationIdPSAMLResource
=== PAUSE TestAccIntegrationIdPSAMLResource
=== RUN   TestAccIdPIntegrationResource
=== PAUSE TestAccIdPIntegrationResource
=== RUN   TestAccLogstashIntegrationResource
=== PAUSE TestAccLogstashIntegrationResource
=== RUN   TestAccLookerIntegrationResource
=== PAUSE TestAccLookerIntegrationResource
=== RUN   TestAccDuoMFAIntegrationResource
=== PAUSE TestAccDuoMFAIntegrationResource
=== RUN   TestAccPagerDutyIntegrationResource
=== PAUSE TestAccPagerDutyIntegrationResource
=== RUN   TestAccSlackAlertsIntegrationResource
=== PAUSE TestAccSlackAlertsIntegrationResource
=== RUN   TestAccSplunkIntegrationResource
=== PAUSE TestAccSplunkIntegrationResource
=== RUN   TestAccSumoLogicIntegrationResource
=== PAUSE TestAccSumoLogicIntegrationResource
=== RUN   TestAccMsTeamsIntegrationResource
=== PAUSE TestAccMsTeamsIntegrationResource
=== RUN   TestAccPolicyRuleResource
=== PAUSE TestAccPolicyRuleResource
=== RUN   TestPolicyRuleResourceUpgradeV0
--- PASS: TestPolicyRuleResourceUpgradeV0 (0.00s)
=== RUN   TestAccPolicyResource
=== PAUSE TestAccPolicyResource
=== RUN   TestAccRepositoryAccessGatewayResource
=== PAUSE TestAccRepositoryAccessGatewayResource
=== RUN   TestAccRepositoryAccessRulesResource
=== PAUSE TestAccRepositoryAccessRulesResource
=== RUN   TestAccRepositoryBindingResource
=== PAUSE TestAccRepositoryBindingResource
=== RUN   TestAccRepositoryConfAnalysisResource
=== PAUSE TestAccRepositoryConfAnalysisResource
=== RUN   TestRepositoryConfAnalysisResourceUpgradeV0
--- PASS: TestRepositoryConfAnalysisResourceUpgradeV0 (0.00s)
=== RUN   TestAccRepositoryConfAuthResource
=== PAUSE TestAccRepositoryConfAuthResource
=== RUN   TestRepositoryConfAuthResourceUpgradeV0
--- PASS: TestRepositoryConfAuthResourceUpgradeV0 (0.00s)
=== RUN   TestAccRepositoryDatamapResource
=== PAUSE TestAccRepositoryDatamapResource
=== RUN   TestAccRepositoryNetworkAccessPolicyResource
=== PAUSE TestAccRepositoryNetworkAccessPolicyResource
=== RUN   TestAccRepositoryResource
=== PAUSE TestAccRepositoryResource
=== RUN   TestAccRepositoryUserAccountResource
=== PAUSE TestAccRepositoryUserAccountResource
=== RUN   TestAccRoleSSOGroupsResource
=== PAUSE TestAccRoleSSOGroupsResource
=== RUN   TestRoleSSOGroupsResourceUpgradeV0
--- PASS: TestRoleSSOGroupsResourceUpgradeV0 (0.00s)
=== RUN   TestAccRoleResource
=== PAUSE TestAccRoleResource
=== RUN   TestAccSidecarCredentialsResource
=== PAUSE TestAccSidecarCredentialsResource
=== RUN   TestSidecarListenerResource
=== PAUSE TestSidecarListenerResource
=== RUN   TestAccSidecarResource
=== PAUSE TestAccSidecarResource
=== RUN   TestElementsMatch
--- PASS: TestElementsMatch (0.00s)
=== CONT  TestAccDatalabelDataSource
=== CONT  TestAccSplunkIntegrationResource
=== CONT  TestAccDatalabelResource
=== CONT  TestAccPagerDutyIntegrationResource
=== CONT  TestAccDuoMFAIntegrationResource
--- PASS: TestAccPagerDutyIntegrationResource (14.10s)
=== CONT  TestAccLogstashIntegrationResource
--- PASS: TestAccDatalabelResource (14.46s)
=== CONT  TestAccIdPIntegrationResource
--- PASS: TestAccDuoMFAIntegrationResource (14.50s)
=== CONT  TestAccIntegrationIdPSAMLResource
--- PASS: TestAccSplunkIntegrationResource (14.87s)
=== CONT  TestAccLookerIntegrationResource
--- PASS: TestAccDatalabelDataSource (23.03s)
=== CONT  TestAccIntegrationIdPSAMLDraftResource
=== CONT  TestAccIdPIntegrationResource
    resource_cyral_integration_idp_test.go:18: Step 4/12 error: Error running apply: exit status 1
        
        Error: Unable to read resource
        
          with cyral_integration_idp_adfs.test_idp_integration,
          on terraform_plugin_test.tf line 2, in resource "cyral_integration_idp_adfs" "test_idp_integration":
           2:   resource "cyral_integration_idp_adfs" "test_idp_integration" {
        
        error executing GET request; status code: 500; body:
        "{\"code\":2,\"message\":\"invalid ReadSAMLServiceRequest.Alias: value length
        must be at least 1 runes\",\"details\":[]}"
--- FAIL: TestAccIdPIntegrationResource (9.07s)
=== CONT  TestAccHCVaultIntegrationResource
--- PASS: TestAccLookerIntegrationResource (16.37s)
=== CONT  TestAccDatadogIntegrationResource
--- PASS: TestAccLogstashIntegrationResource (19.19s)
=== CONT  TestAccRepositoryConfAnalysisResource
=== CONT  TestAccSidecarResource
--- PASS: TestAccHCVaultIntegrationResource (12.69s)
=== CONT  TestAccSidecarCredentialsResource
--- PASS: TestAccIntegrationIdPSAMLDraftResource (15.25s)
--- PASS: TestAccIntegrationIdPSAMLResource (24.37s)
=== CONT  TestAccRoleResource
--- PASS: TestAccDatadogIntegrationResource (12.75s)
=== CONT  TestAccRoleSSOGroupsResource
--- PASS: TestAccRepositoryConfAnalysisResource (13.75s)
=== CONT  TestSidecarListenerResource
--- PASS: TestAccSidecarCredentialsResource (11.35s)
=== CONT  TestAccRepositoryResource
--- PASS: TestAccRoleSSOGroupsResource (17.15s)
=== CONT  TestAccRepositoryNetworkAccessPolicyResource
--- PASS: TestAccRoleResource (22.33s)
=== CONT  TestAccRepositoryDatamapResource
--- PASS: TestAccSidecarResource (27.70s)
=== CONT  TestAccRepositoryUserAccountResource
--- PASS: TestAccRepositoryResource (22.89s)
=== CONT  TestAccSidecarCftTemplateDataSource
--- PASS: TestSidecarListenerResource (29.82s)
=== CONT  TestAccSidecarInstanceIDsDataSource
--- PASS: TestAccRepositoryDatamapResource (22.61s)
=== CONT  TestAccSidecarIDDataSource
--- PASS: TestAccRepositoryNetworkAccessPolicyResource (23.30s)
=== CONT  TestAccELKIntegrationResource
--- PASS: TestAccSidecarCftTemplateDataSource (14.09s)
=== CONT  TestAccSidecarBoundPortsDataSource
=== CONT  TestAccSAMLCertificateDataSource
--- PASS: TestAccSidecarInstanceIDsDataSource (12.53s)
--- PASS: TestAccSidecarIDDataSource (12.31s)
=== CONT  TestAccPolicyRuleResource
--- PASS: TestAccELKIntegrationResource (12.67s)
=== CONT  TestAccRepositoryConfAuthResource
--- PASS: TestAccSAMLCertificateDataSource (9.89s)
=== CONT  TestAccRepositoryAccessRulesResource
=== CONT  TestAccRepositoryBindingResource
--- PASS: TestAccSidecarBoundPortsDataSource (16.11s)
--- PASS: TestAccRepositoryUserAccountResource (42.06s)
=== CONT  TestAccPolicyResource
--- PASS: TestAccRepositoryConfAuthResource (18.91s)
=== CONT  TestAccRoleDataSource
--- PASS: TestAccRepositoryAccessRulesResource (17.24s)
=== CONT  TestAccSumoLogicIntegrationResource
--- PASS: TestAccPolicyRuleResource (20.49s)
=== CONT  TestAccMsTeamsIntegrationResource
--- PASS: TestAccRepositoryBindingResource (14.91s)
=== CONT  TestAccRepositoryAccessGatewayResource
--- PASS: TestAccPolicyResource (12.83s)
=== CONT  TestAccIntegrationIdPSAMLDataSource
--- PASS: TestAccMsTeamsIntegrationResource (12.81s)
=== CONT  TestAccSAMLConfigurationDataSource
--- PASS: TestAccSumoLogicIntegrationResource (13.58s)
=== CONT  TestAccSlackAlertsIntegrationResource
--- PASS: TestAccRoleDataSource (14.89s)
=== CONT  TestAccRepositoryDataSource
--- PASS: TestAccIntegrationIdPSAMLDataSource (20.49s)
--- PASS: TestAccRepositoryAccessGatewayResource (23.09s)
--- PASS: TestAccSlackAlertsIntegrationResource (10.93s)
--- PASS: TestAccSAMLConfigurationDataSource (12.33s)
--- PASS: TestAccRepositoryDataSource (16.60s)```
