### PR TITLE
Deprecate old resources

### DIFF
--- a/cyral/resource_cyral_integration_datadog.go
+++ b/cyral/resource_cyral_integration_datadog.go
@@ -38,6 +38,7 @@ var ReadDatadogConfig = ResourceOperationConfig{
 
 func resourceIntegrationDatadog() *schema.Resource {
 	return &schema.Resource{
+		DeprecationMessage: "If configuring Datadog for logging purposes, use resource `cyral_integration_logging` instead.",
 		Description: "Manages [integration with DataDog](https://cyral.com/docs/integrations/apm/datadog/) " +
 			"to push sidecar logs and/or metrics.",
 		CreateContext: CreateResource(

--- a/cyral/resource_cyral_integration_elk.go
+++ b/cyral/resource_cyral_integration_elk.go
@@ -41,7 +41,8 @@ var ReadELKConfig = ResourceOperationConfig{
 
 func resourceIntegrationELK() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manages [integration with ELK](https://cyral.com/docs/integrations/siem/elk/) to push sidecar metrics.",
+		DeprecationMessage: "Use resource `cyral_integration_logging` instead.",
+		Description:        "Manages [integration with ELK](https://cyral.com/docs/integrations/siem/elk/) to push sidecar metrics.",
 		CreateContext: CreateResource(
 			ResourceOperationConfig{
 				Name:       "ELKResourceCreate",

--- a/cyral/resource_cyral_integration_logstash.go
+++ b/cyral/resource_cyral_integration_logstash.go
@@ -45,7 +45,8 @@ var ReadLogstashConfig = ResourceOperationConfig{
 
 func resourceIntegrationLogstash() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manages integration with Logstash.",
+		DeprecationMessage: "Use resource `cyral_integration_logging` instead.",
+		Description:        "Manages integration with Logstash.",
 		CreateContext: CreateResource(
 			ResourceOperationConfig{
 				Name:       "LogstashResourceCreate",

--- a/cyral/resource_cyral_integration_looker.go
+++ b/cyral/resource_cyral_integration_looker.go
@@ -39,7 +39,8 @@ var ReadLookerConfig = ResourceOperationConfig{
 
 func resourceIntegrationLooker() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manages integration with Looker.",
+		DeprecationMessage: "Integration no longer supported.",
+		Description:        "Manages integration with Looker.",
 		CreateContext: CreateResource(
 			ResourceOperationConfig{
 				Name:       "LookerResourceCreate",

--- a/cyral/resource_cyral_integration_splunk.go
+++ b/cyral/resource_cyral_integration_splunk.go
@@ -49,7 +49,8 @@ var ReadSplunkConfig = ResourceOperationConfig{
 
 func resourceIntegrationSplunk() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manages [integration with Splunk](https://cyral.com/docs/integrations/siem/splunk/#procedure).",
+		DeprecationMessage: "Use resource `cyral_integration_logging` instead.",
+		Description:        "Manages [integration with Splunk](https://cyral.com/docs/integrations/siem/splunk/#procedure).",
 		CreateContext: CreateResource(
 			ResourceOperationConfig{
 				Name:       "SplunkResourceCreate",

--- a/cyral/resource_cyral_integration_sumo_logic.go
+++ b/cyral/resource_cyral_integration_sumo_logic.go
@@ -36,7 +36,8 @@ var ReadSumoLogicConfig = ResourceOperationConfig{
 
 func resourceIntegrationSumoLogic() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manages integration with [Sumo Logic to push sidecar logs](https://cyral.com/docs/integrations/siem/sumo-logic/).",
+		DeprecationMessage: "Use resource `cyral_integration_logging` instead.",
+		Description:        "Manages integration with [Sumo Logic to push sidecar logs](https://cyral.com/docs/integrations/siem/sumo-logic/).",
 		CreateContext: CreateResource(
 			ResourceOperationConfig{
 				Name:       "SumoLogicResourceCreate",

--- a/docs/resources/integration_datadog.md
+++ b/docs/resources/integration_datadog.md
@@ -3,12 +3,12 @@
 page_title: "cyral_integration_datadog Resource - cyral"
 subcategory: ""
 description: |-
-  Manages integration with DataDog https://cyral.com/docs/integrations/apm/datadog/ to push sidecar logs and/or metrics.
+  ~> DEPRECATED If configuring Datadog for logging purposes, use resource cyral_integration_logging instead.
 ---
 
 # cyral_integration_datadog (Resource)
 
-Manages [integration with DataDog](https://cyral.com/docs/integrations/apm/datadog/) to push sidecar logs and/or metrics.
+~> **DEPRECATED** If configuring Datadog for logging purposes, use resource `cyral_integration_logging` instead.
 
 ## Example Usage
 

--- a/docs/resources/integration_elk.md
+++ b/docs/resources/integration_elk.md
@@ -3,12 +3,12 @@
 page_title: "cyral_integration_elk Resource - cyral"
 subcategory: ""
 description: |-
-  Manages integration with ELK https://cyral.com/docs/integrations/siem/elk/ to push sidecar metrics.
+  ~> DEPRECATED Use resource cyral_integration_logging instead.
 ---
 
 # cyral_integration_elk (Resource)
 
-Manages [integration with ELK](https://cyral.com/docs/integrations/siem/elk/) to push sidecar metrics.
+~> **DEPRECATED** Use resource `cyral_integration_logging` instead.
 
 ## Example Usage
 

--- a/docs/resources/integration_logstash.md
+++ b/docs/resources/integration_logstash.md
@@ -3,12 +3,12 @@
 page_title: "cyral_integration_logstash Resource - cyral"
 subcategory: ""
 description: |-
-  Manages integration with Logstash.
+  ~> DEPRECATED Use resource cyral_integration_logging instead.
 ---
 
 # cyral_integration_logstash (Resource)
 
-Manages integration with Logstash.
+~> **DEPRECATED** Use resource `cyral_integration_logging` instead.
 
 ## Example Usage
 

--- a/docs/resources/integration_looker.md
+++ b/docs/resources/integration_looker.md
@@ -3,12 +3,12 @@
 page_title: "cyral_integration_looker Resource - cyral"
 subcategory: ""
 description: |-
-  Manages integration with Looker.
+  ~> DEPRECATED Integration no longer supported.
 ---
 
 # cyral_integration_looker (Resource)
 
-Manages integration with Looker.
+~> **DEPRECATED** Integration no longer supported.
 
 ## Example Usage
 

--- a/docs/resources/integration_splunk.md
+++ b/docs/resources/integration_splunk.md
@@ -3,12 +3,12 @@
 page_title: "cyral_integration_splunk Resource - cyral"
 subcategory: ""
 description: |-
-  Manages integration with Splunk https://cyral.com/docs/integrations/siem/splunk/#procedure.
+  ~> DEPRECATED Use resource cyral_integration_logging instead.
 ---
 
 # cyral_integration_splunk (Resource)
 
-Manages [integration with Splunk](https://cyral.com/docs/integrations/siem/splunk/#procedure).
+~> **DEPRECATED** Use resource `cyral_integration_logging` instead.
 
 ## Example Usage
 

--- a/docs/resources/integration_sumo_logic.md
+++ b/docs/resources/integration_sumo_logic.md
@@ -3,12 +3,12 @@
 page_title: "cyral_integration_sumo_logic Resource - cyral"
 subcategory: ""
 description: |-
-  Manages integration with Sumo Logic to push sidecar logs https://cyral.com/docs/integrations/siem/sumo-logic/.
+  ~> DEPRECATED Use resource cyral_integration_logging instead.
 ---
 
 # cyral_integration_sumo_logic (Resource)
 
-Manages integration with [Sumo Logic to push sidecar logs](https://cyral.com/docs/integrations/siem/sumo-logic/).
+~> **DEPRECATED** Use resource `cyral_integration_logging` instead.
 
 ## Example Usage
 


### PR DESCRIPTION
## Description of the change

Deprecate the following resources:

`cyral_logging_datadog`
`cyral_logging_elk`
`cyral_logging_logstash`
`cyral_logging_looker`
`cyral_logging_splunk`
`cyral_logging_sumologic`

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

NA
