### PR TITLE
Fix conflicting log integration ID

### DIFF
--- a/cyral/resource_cyral_sidecar.go
+++ b/cyral/resource_cyral_sidecar.go
@@ -267,7 +267,6 @@ func resourceSidecarRead(ctx context.Context, d *schema.ResourceData, m interfac
 		d.Set("deployment_method", properties.DeploymentMethod)
 		d.Set("activity_log_integration_id", properties.LogIntegrationID)
 		d.Set("diagnostic_log_integration_id", properties.DiagnosticLogIntegrationID)
-		d.Set("log_integration_id", properties.LogIntegrationID)
 	}
 	d.Set("labels", response.Labels)
 	d.Set("user_endpoint", response.UserEndpoint)

--- a/cyral/testutils.go
+++ b/cyral/testutils.go
@@ -134,9 +134,8 @@ func formatBasicSidecarIntoConfig(resName, sidecarName, deploymentMethod, logInt
 	resource "cyral_sidecar" "%s" {
 		name               = "%s"
 		deployment_method  = "%s"
-		log_integration_id = "%s"
 		activity_log_integration_id = "%s"
-	}`, resName, sidecarName, deploymentMethod, logIntegrationID, logIntegrationID,
+	}`, resName, sidecarName, deploymentMethod, logIntegrationID,
 	)
 }
 


### PR DESCRIPTION
## Description of the change

Fix issue where `log_integration_id` conflicted with `activity_log_integration_id` during `terraform plan`.

Tests passed:

```
$ make
go clean -i github.com/cyralinc/terraform-provider-cyral/...
rm -f terraform-provider-cyral_v4.5.0
rm -rf ./out
rm -rf ~/.terraform.d/plugins/local/terraform/cyral/4.5.0
gofmt -w .
mkdir -p out/
# Build for both MacOS and Linux
GOOS=darwin GOARCH=amd64 go build -o out/darwin_amd64/terraform-provider-cyral_v4.5.0 .
GOOS=darwin GOARCH=arm64 go build -o out/darwin_arm64/terraform-provider-cyral_v4.5.0 .
GOOS=linux GOARCH=amd64 go build -o out/linux_amd64/terraform-provider-cyral_v4.5.0 .
mkdir -p ~/.terraform.d/plugins/local/terraform/cyral/4.5.0/darwin_amd64
mkdir -p ~/.terraform.d/plugins/local/terraform/cyral/4.5.0/darwin_arm64
mkdir -p ~/.terraform.d/plugins/local/terraform/cyral/4.5.0/linux_amd64
cp out/darwin_arm64/terraform-provider-cyral_v4.5.0 ~/.terraform.d/plugins/local/terraform/cyral/4.5.0/darwin_arm64
cp out/linux_amd64/terraform-provider-cyral_v4.5.0 ~/.terraform.d/plugins/local/terraform/cyral/4.5.0/linux_amd64
cp out/darwin_amd64/terraform-provider-cyral_v4.5.0 ~/.terraform.d/plugins/local/terraform/cyral/4.5.0/darwin_amd64
go test github.com/cyralinc/terraform-provider-cyral/... -v -race -timeout 20m
?       github.com/cyralinc/terraform-provider-cyral    [no test files]
=== RUN   TestNewClient_WhenTLSSkipVerifyIsEnabled_ThenInsecureSkipVerifyIsTrue
2023/07/11 12:44:59 [DEBUG] Init NewClient
2023/07/11 12:44:59 [DEBUG] TokenSource: &{0xc00013ad98 {0 0} <nil>}
2023/07/11 12:44:59 [DEBUG] End NewClient
--- PASS: TestNewClient_WhenTLSSkipVerifyIsEnabled_ThenInsecureSkipVerifyIsTrue (0.00s)
=== RUN   TestNewClient_WhenTLSSkipVerifyIsDisabled_ThenInsecureSkipVerifyIsFalse
2023/07/11 12:44:59 [DEBUG] Init NewClient
2023/07/11 12:44:59 [DEBUG] TokenSource: &{0xc00013ade0 {0 0} <nil>}
2023/07/11 12:44:59 [DEBUG] End NewClient
--- PASS: TestNewClient_WhenTLSSkipVerifyIsDisabled_ThenInsecureSkipVerifyIsFalse (0.00s)
=== RUN   TestNewClient_WhenClientIDIsEmpty_ThenThrowError
2023/07/11 12:44:59 [DEBUG] Init NewClient
--- PASS: TestNewClient_WhenClientIDIsEmpty_ThenThrowError (0.00s)
=== RUN   TestNewClient_WhenClientSecretIsEmpty_ThenThrowError
2023/07/11 12:44:59 [DEBUG] Init NewClient
--- PASS: TestNewClient_WhenClientSecretIsEmpty_ThenThrowError (0.00s)
=== RUN   TestNewClient_WhenControlPlaneIsEmpty_ThenThrowError
2023/07/11 12:44:59 [DEBUG] Init NewClient
--- PASS: TestNewClient_WhenControlPlaneIsEmpty_ThenThrowError (0.00s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/client     (cached)
=== RUN   TestAccDatalabelDataSource
=== PAUSE TestAccDatalabelDataSource
=== RUN   TestAccIntegrationIdPSAMLDataSource
=== PAUSE TestAccIntegrationIdPSAMLDataSource
=== RUN   TestAccLoggingIntegrationDataSource
=== PAUSE TestAccLoggingIntegrationDataSource
=== RUN   TestAccRepositoryDataSource
=== PAUSE TestAccRepositoryDataSource
=== RUN   TestAccRoleDataSource
=== PAUSE TestAccRoleDataSource
=== RUN   TestAccSAMLCertificateDataSource
=== PAUSE TestAccSAMLCertificateDataSource
=== RUN   TestAccSAMLConfigurationDataSource
=== PAUSE TestAccSAMLConfigurationDataSource
=== RUN   TestAccSidecarBoundPortsDataSource
=== PAUSE TestAccSidecarBoundPortsDataSource
=== RUN   TestAccSidecarCftTemplateDataSource
=== PAUSE TestAccSidecarCftTemplateDataSource
=== RUN   TestAccSidecarIDDataSource
=== PAUSE TestAccSidecarIDDataSource
=== RUN   TestAccSidecarInstanceIDsDataSource
=== PAUSE TestAccSidecarInstanceIDsDataSource
=== RUN   TestAccSidecarListenerDataSource
=== PAUSE TestAccSidecarListenerDataSource
=== RUN   TestIntegrationsData_GetValue_Default
--- PASS: TestIntegrationsData_GetValue_Default (0.00s)
=== RUN   TestIntegrationsData_GetValue_Splunk
--- PASS: TestIntegrationsData_GetValue_Splunk (0.00s)
=== RUN   TestAccProvider
2023/07/12 13:30:44 [DEBUG] Init dataSourceSidecarListener
2023/07/12 13:30:44 [DEBUG] End dataSourceSidecarListener
--- PASS: TestAccProvider (0.01s)
=== RUN   TestAccDatalabelResource
=== PAUSE TestAccDatalabelResource
=== RUN   TestAccDatadogIntegrationResource
=== PAUSE TestAccDatadogIntegrationResource
=== RUN   TestAccELKIntegrationResource
=== PAUSE TestAccELKIntegrationResource
=== RUN   TestAccHCVaultIntegrationResource
=== PAUSE TestAccHCVaultIntegrationResource
=== RUN   TestAccIntegrationIdPSAMLDraftResource
=== PAUSE TestAccIntegrationIdPSAMLDraftResource
=== RUN   TestAccIntegrationIdPSAMLResource
=== PAUSE TestAccIntegrationIdPSAMLResource
=== RUN   TestAccIdPIntegrationResource
=== PAUSE TestAccIdPIntegrationResource
=== RUN   TestAccLogsIntegrationResourceCloudWatch
=== PAUSE TestAccLogsIntegrationResourceCloudWatch
=== RUN   TestAccLogsIntegrationResourceDataDog
=== PAUSE TestAccLogsIntegrationResourceDataDog
=== RUN   TestAccLogsIntegrationResourceElk
=== PAUSE TestAccLogsIntegrationResourceElk
=== RUN   TestAccLogsIntegrationResourceSplunk
=== PAUSE TestAccLogsIntegrationResourceSplunk
=== RUN   TestAccLogsIntegrationResourceSumologic
=== PAUSE TestAccLogsIntegrationResourceSumologic
=== RUN   TestAccLogsIntegrationResourceFluentbit
=== PAUSE TestAccLogsIntegrationResourceFluentbit
=== RUN   TestAccLogstashIntegrationResource
=== PAUSE TestAccLogstashIntegrationResource
=== RUN   TestAccLookerIntegrationResource
=== PAUSE TestAccLookerIntegrationResource
=== RUN   TestAccDuoMFAIntegrationResource
=== PAUSE TestAccDuoMFAIntegrationResource
=== RUN   TestAccPagerDutyIntegrationResource
=== PAUSE TestAccPagerDutyIntegrationResource
=== RUN   TestAccSlackAlertsIntegrationResource
=== PAUSE TestAccSlackAlertsIntegrationResource
=== RUN   TestAccSplunkIntegrationResource
=== PAUSE TestAccSplunkIntegrationResource
=== RUN   TestAccSumoLogicIntegrationResource
=== PAUSE TestAccSumoLogicIntegrationResource
=== RUN   TestAccMsTeamsIntegrationResource
=== PAUSE TestAccMsTeamsIntegrationResource
=== RUN   TestAccPolicyRuleResource
=== PAUSE TestAccPolicyRuleResource
=== RUN   TestPolicyRuleResourceUpgradeV0
--- PASS: TestPolicyRuleResourceUpgradeV0 (0.00s)
=== RUN   TestAccPolicyResource
=== PAUSE TestAccPolicyResource
=== RUN   TestAccRepositoryAccessGatewayResource
=== PAUSE TestAccRepositoryAccessGatewayResource
=== RUN   TestAccRepositoryAccessRulesResource
=== PAUSE TestAccRepositoryAccessRulesResource
=== RUN   TestAccRepositoryBindingResource
=== PAUSE TestAccRepositoryBindingResource
=== RUN   TestAccRepositoryConfAnalysisResource
=== PAUSE TestAccRepositoryConfAnalysisResource
=== RUN   TestRepositoryConfAnalysisResourceUpgradeV0
--- PASS: TestRepositoryConfAnalysisResourceUpgradeV0 (0.00s)
=== RUN   TestAccRepositoryConfAuthResource
=== PAUSE TestAccRepositoryConfAuthResource
=== RUN   TestRepositoryConfAuthResourceUpgradeV0
--- PASS: TestRepositoryConfAuthResourceUpgradeV0 (0.00s)
=== RUN   TestAccRepositoryDatamapResource
=== PAUSE TestAccRepositoryDatamapResource
=== RUN   TestAccRepositoryNetworkAccessPolicyResource
=== PAUSE TestAccRepositoryNetworkAccessPolicyResource
=== RUN   TestAccRepositoryResource
=== PAUSE TestAccRepositoryResource
=== RUN   TestAccRepositoryUserAccountResource
=== PAUSE TestAccRepositoryUserAccountResource
=== RUN   TestAccRoleSSOGroupsResource
=== PAUSE TestAccRoleSSOGroupsResource
=== RUN   TestRoleSSOGroupsResourceUpgradeV0
--- PASS: TestRoleSSOGroupsResourceUpgradeV0 (0.00s)
=== RUN   TestAccRoleResource
=== PAUSE TestAccRoleResource
=== RUN   TestAccSidecarCredentialsResource
=== PAUSE TestAccSidecarCredentialsResource
=== RUN   TestSidecarListenerResource
=== PAUSE TestSidecarListenerResource
=== RUN   TestAccSidecarResource
=== PAUSE TestAccSidecarResource
=== RUN   TestElementsMatch
--- PASS: TestElementsMatch (0.00s)
=== CONT  TestAccIntegrationIdPSAMLDataSource
=== CONT  TestAccLogsIntegrationResourceFluentbit
=== CONT  TestAccELKIntegrationResource
=== CONT  TestAccLogsIntegrationResourceSumologic
=== CONT  TestAccLogstashIntegrationResource
=== CONT  TestAccLogsIntegrationResourceSplunk
=== CONT  TestAccLogsIntegrationResourceDataDog
=== CONT  TestAccLogsIntegrationResourceElk
=== CONT  TestAccIdPIntegrationResource
=== CONT  TestAccIntegrationIdPSAMLResource
=== CONT  TestAccIntegrationIdPSAMLDraftResource
=== CONT  TestAccRepositoryBindingResource
=== CONT  TestAccHCVaultIntegrationResource
--- PASS: TestAccLogsIntegrationResourceFluentbit (12.13s)
=== CONT  TestAccLogsIntegrationResourceCloudWatch
--- PASS: TestAccELKIntegrationResource (12.19s)
--- PASS: TestAccLogsIntegrationResourceDataDog (12.21s)
=== CONT  TestAccDatadogIntegrationResource
=== CONT  TestAccMsTeamsIntegrationResource
--- PASS: TestAccLogsIntegrationResourceSplunk (12.29s)
--- PASS: TestAccLogsIntegrationResourceSumologic (12.31s)
=== CONT  TestAccSplunkIntegrationResource
--- PASS: TestAccLogsIntegrationResourceElk (13.74s)
=== CONT  TestAccRepositoryAccessRulesResource
--- PASS: TestAccRepositoryBindingResource (14.84s)
=== CONT  TestAccSidecarCredentialsResource
--- PASS: TestAccIntegrationIdPSAMLDraftResource (16.48s)
=== CONT  TestAccPagerDutyIntegrationResource
--- PASS: TestAccLogstashIntegrationResource (21.50s)
=== CONT  TestAccRoleSSOGroupsResource
=== CONT  TestAccRepositoryUserAccountResource
--- PASS: TestAccHCVaultIntegrationResource (9.52s)
--- PASS: TestAccMsTeamsIntegrationResource (10.47s)
=== CONT  TestAccPolicyResource
--- PASS: TestAccSplunkIntegrationResource (11.17s)
=== CONT  TestAccLookerIntegrationResource
--- PASS: TestAccDatadogIntegrationResource (11.33s)
=== CONT  TestAccRepositoryConfAuthResource
--- PASS: TestAccLogsIntegrationResourceCloudWatch (11.39s)
=== CONT  TestAccRepositoryNetworkAccessPolicyResource
--- PASS: TestAccIntegrationIdPSAMLDataSource (23.62s)
=== CONT  TestAccSAMLConfigurationDataSource
--- PASS: TestAccSidecarCredentialsResource (9.60s)
=== CONT  TestAccRepositoryDataSource
=== CONT  TestAccDuoMFAIntegrationResource
--- PASS: TestAccPagerDutyIntegrationResource (9.63s)
=== CONT  TestAccSidecarInstanceIDsDataSource
--- PASS: TestAccPolicyResource (8.99s)
--- PASS: TestAccLookerIntegrationResource (9.26s)
=== CONT  TestAccRoleDataSource
--- PASS: TestAccIntegrationIdPSAMLResource (32.93s)
=== CONT  TestAccSidecarIDDataSource
--- PASS: TestAccRepositoryAccessRulesResource (20.18s)
=== CONT  TestAccLoggingIntegrationDataSource
--- PASS: TestAccSAMLConfigurationDataSource (11.69s)
=== CONT  TestAccDatalabelDataSource
=== CONT  TestAccRepositoryAccessGatewayResource
--- PASS: TestAccDuoMFAIntegrationResource (9.81s)
--- PASS: TestAccRepositoryDataSource (15.65s)
--- PASS: TestAccRoleSSOGroupsResource (18.58s)
=== CONT  TestAccSlackAlertsIntegrationResource
=== CONT  TestSidecarListenerResource
--- PASS: TestAccRoleDataSource (7.86s)
=== CONT  TestAccPolicyRuleResource
=== CONT  TestAccRoleResource
--- PASS: TestAccSidecarIDDataSource (8.36s)
--- PASS: TestAccSidecarInstanceIDsDataSource (9.78s)
=== CONT  TestAccRepositoryConfAnalysisResource
--- PASS: TestAccRepositoryConfAuthResource (21.78s)
=== CONT  TestAccSumoLogicIntegrationResource
--- PASS: TestAccLoggingIntegrationDataSource (13.56s)
=== CONT  TestAccSidecarResource
=== CONT  TestAccRepositoryResource
--- PASS: TestAccSlackAlertsIntegrationResource (12.05s)
--- PASS: TestAccIdPIntegrationResource (56.90s)
=== CONT  TestAccSidecarListenerDataSource
--- PASS: TestAccRepositoryConfAnalysisResource (15.65s)
=== CONT  TestAccSidecarBoundPortsDataSource
--- PASS: TestAccRepositoryNetworkAccessPolicyResource (33.70s)
=== CONT  TestAccRepositoryDatamapResource
--- PASS: TestAccSumoLogicIntegrationResource (12.48s)
=== CONT  TestAccSAMLCertificateDataSource
=== CONT  TestAccDatalabelResource
--- PASS: TestAccDatalabelDataSource (25.89s)
--- PASS: TestAccRepositoryAccessGatewayResource (26.36s)
=== CONT  TestAccSidecarCftTemplateDataSource
--- PASS: TestAccSAMLCertificateDataSource (6.67s)
--- PASS: TestAccRoleResource (31.77s)
--- PASS: TestAccSidecarCftTemplateDataSource (11.53s)
--- PASS: TestAccDatalabelResource (12.77s)
--- PASS: TestAccPolicyRuleResource (34.11s)
--- PASS: TestAccSidecarBoundPortsDataSource (17.53s)
--- PASS: TestAccSidecarListenerDataSource (21.10s)
--- PASS: TestAccRepositoryResource (31.28s)
--- PASS: TestAccRepositoryDatamapResource (28.38s)
--- PASS: TestAccRepositoryUserAccountResource (64.11s)
--- PASS: TestSidecarListenerResource (46.27s)
--- PASS: TestAccSidecarResource (39.54s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral      88.243s
```

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

> Description of testing
