### PR TITLE
ENG-12107: Add missing validation to idp saml resource

### DIFF
--- a/cyral/resource.go
+++ b/cyral/resource.go
@@ -49,11 +49,11 @@ type ResourceOperationConfig struct {
 }
 
 func CRUDResources(config []ResourceConfig) func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
-	return HandleRequest(config)
+	return HandleRequests(config)
 }
 
 func CreateResource(createConfig, readConfig ResourceOperationConfig) schema.CreateContextFunc {
-	return HandleRequest(
+	return HandleRequests(
 		[]ResourceConfig{
 			{
 				Type:            create,
@@ -68,7 +68,7 @@ func CreateResource(createConfig, readConfig ResourceOperationConfig) schema.Cre
 }
 
 func ReadResource(readConfig ResourceOperationConfig) schema.ReadContextFunc {
-	return HandleRequest(
+	return HandleRequests(
 		[]ResourceConfig{
 			{
 				Type:            read,
@@ -79,7 +79,7 @@ func ReadResource(readConfig ResourceOperationConfig) schema.ReadContextFunc {
 }
 
 func UpdateResource(updateConfig, readConfig ResourceOperationConfig) schema.UpdateContextFunc {
-	return HandleRequest(
+	return HandleRequests(
 		[]ResourceConfig{
 			{
 				Type:            update,
@@ -94,7 +94,7 @@ func UpdateResource(updateConfig, readConfig ResourceOperationConfig) schema.Upd
 }
 
 func DeleteResource(deleteConfig ResourceOperationConfig) schema.DeleteContextFunc {
-	return HandleRequest(
+	return HandleRequests(
 		[]ResourceConfig{
 			{
 				Type:            delete,
@@ -104,11 +104,11 @@ func DeleteResource(deleteConfig ResourceOperationConfig) schema.DeleteContextFu
 	)
 }
 
-func HandleRequest(
-	configSlice []ResourceConfig,
+func HandleRequests(
+	configs []ResourceConfig,
 ) func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
 	return func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-		for _, config := range configSlice {
+		for _, config := range configs {
 			log.Printf("[DEBUG] Init %s", config.OperationConfig.Name)
 			c := m.(*client.Client)
 

--- a/cyral/resource.go
+++ b/cyral/resource.go
@@ -48,8 +48,8 @@ type ResourceOperationConfig struct {
 	NewResponseData func(d *schema.ResourceData) ResponseData
 }
 
-func CRUDResources(config []ResourceOperation) func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
-	return HandleRequests(config)
+func CRUDResources(resourceOperations []ResourceOperation) func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
+	return HandleRequests(resourceOperations)
 }
 
 func CreateResource(createConfig, readConfig ResourceOperationConfig) schema.CreateContextFunc {

--- a/cyral/resource_cyral_integration_idp_saml.go
+++ b/cyral/resource_cyral_integration_idp_saml.go
@@ -67,6 +67,18 @@ func CreateGenericSAMLConfig() ResourceOperationConfig {
 	}
 }
 
+func ValidateGenericSAMLConfig() ResourceOperationConfig {
+	return ResourceOperationConfig{
+		Name:       "GenericSAMLResourceValidation",
+		HttpMethod: http.MethodPost,
+		CreateURL: func(d *schema.ResourceData, c *client.Client) string {
+			return fmt.Sprintf("https://%s/v1/conf/identityProviders/%s", c.ControlPlane, d.Id())
+		},
+		NewResourceData: func() ResourceData { return &IdentityProviderData{} },
+		NewResponseData: func(_ *schema.ResourceData) ResponseData { return &IdentityProviderData{} },
+	}
+}
+
 func ReadGenericSAMLConfig() ResourceOperationConfig {
 	return ResourceOperationConfig{
 		Name:       "GenericSAMLResourceRead",
@@ -93,9 +105,21 @@ func resourceIntegrationIdPSAML() *schema.Resource {
 		Description: "Manages identity provider (IdP) integrations using SAML to allow " +
 			"[Single Sing-On](https://cyral.com/docs/sso/overview) to Cyral.\n\nSee also " +
 			"the remaining SAML-related resources and data sources.",
-		CreateContext: CreateResource(
-			CreateGenericSAMLConfig(),
-			ReadGenericSAMLConfig(),
+		CreateContext: CRUDResources(
+			[]ResourceConfig{
+				{
+					Type:            create,
+					OperationConfig: CreateGenericSAMLConfig(),
+				},
+				{
+					Type:            read,
+					OperationConfig: ReadGenericSAMLConfig(),
+				},
+				{
+					Type:            update,
+					OperationConfig: ValidateGenericSAMLConfig(),
+				},
+			},
 		),
 		ReadContext:   ReadResource(ReadGenericSAMLConfig()),
 		DeleteContext: DeleteResource(DeleteGenericSAMLConfig()),

--- a/cyral/resource_cyral_integration_idp_saml.go
+++ b/cyral/resource_cyral_integration_idp_saml.go
@@ -106,18 +106,18 @@ func resourceIntegrationIdPSAML() *schema.Resource {
 			"[Single Sing-On](https://cyral.com/docs/sso/overview) to Cyral.\n\nSee also " +
 			"the remaining SAML-related resources and data sources.",
 		CreateContext: CRUDResources(
-			[]ResourceConfig{
+			[]ResourceOperation{
 				{
-					Type:            create,
-					OperationConfig: CreateGenericSAMLConfig(),
+					Type:   create,
+					Config: CreateGenericSAMLConfig(),
 				},
 				{
-					Type:            read,
-					OperationConfig: ReadGenericSAMLConfig(),
+					Type:   read,
+					Config: ReadGenericSAMLConfig(),
 				},
 				{
-					Type:            update,
-					OperationConfig: ValidateGenericSAMLConfig(),
+					Type:   update,
+					Config: ValidateGenericSAMLConfig(),
 				},
 			},
 		),

--- a/cyral/resource_cyral_integration_idp_saml.go
+++ b/cyral/resource_cyral_integration_idp_saml.go
@@ -67,7 +67,7 @@ func CreateGenericSAMLConfig() ResourceOperationConfig {
 	}
 }
 
-func ValidateGenericSAMLConfig() ResourceOperationConfig {
+func CreateIdPConfig() ResourceOperationConfig {
 	return ResourceOperationConfig{
 		Name:       "GenericSAMLResourceValidation",
 		HttpMethod: http.MethodPost,
@@ -116,8 +116,8 @@ func resourceIntegrationIdPSAML() *schema.Resource {
 					Config: ReadGenericSAMLConfig(),
 				},
 				{
-					Type:   update,
-					Config: ValidateGenericSAMLConfig(),
+					Type:   create,
+					Config: CreateIdPConfig(),
 				},
 			},
 		),


### PR DESCRIPTION
## Description of the change

A missing validation step caused the generic SAML integrations to error out during user log in.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

```
=== RUN   TestNewClient_WhenTLSSkipVerifyIsEnabled_ThenInsecureSkipVerifyIsTrue
2023/07/12 22:57:11 [DEBUG] Init NewClient
2023/07/12 22:57:11 [DEBUG] TokenSource: &{0xc00000ee70 {0 0} <nil>}
2023/07/12 22:57:11 [DEBUG] End NewClient
--- PASS: TestNewClient_WhenTLSSkipVerifyIsEnabled_ThenInsecureSkipVerifyIsTrue (0.00s)
=== RUN   TestNewClient_WhenTLSSkipVerifyIsDisabled_ThenInsecureSkipVerifyIsFalse
2023/07/12 22:57:11 [DEBUG] Init NewClient
2023/07/12 22:57:11 [DEBUG] TokenSource: &{0xc00000eea0 {0 0} <nil>}
2023/07/12 22:57:11 [DEBUG] End NewClient
--- PASS: TestNewClient_WhenTLSSkipVerifyIsDisabled_ThenInsecureSkipVerifyIsFalse (0.00s)
=== RUN   TestNewClient_WhenClientIDIsEmpty_ThenThrowError
2023/07/12 22:57:11 [DEBUG] Init NewClient
--- PASS: TestNewClient_WhenClientIDIsEmpty_ThenThrowError (0.00s)
=== RUN   TestNewClient_WhenClientSecretIsEmpty_ThenThrowError
2023/07/12 22:57:11 [DEBUG] Init NewClient
--- PASS: TestNewClient_WhenClientSecretIsEmpty_ThenThrowError (0.00s)
=== RUN   TestNewClient_WhenControlPlaneIsEmpty_ThenThrowError
2023/07/12 22:57:11 [DEBUG] Init NewClient
--- PASS: TestNewClient_WhenControlPlaneIsEmpty_ThenThrowError (0.00s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/client     0.039s
=== RUN   TestAccDatalabelDataSource
=== PAUSE TestAccDatalabelDataSource
=== RUN   TestAccIntegrationIdPSAMLDataSource
=== PAUSE TestAccIntegrationIdPSAMLDataSource
=== RUN   TestAccLoggingIntegrationDataSource
=== PAUSE TestAccLoggingIntegrationDataSource
=== RUN   TestAccRepositoryDataSource
=== PAUSE TestAccRepositoryDataSource
=== RUN   TestAccRoleDataSource
=== PAUSE TestAccRoleDataSource
=== RUN   TestAccSAMLCertificateDataSource
=== PAUSE TestAccSAMLCertificateDataSource
=== RUN   TestAccSAMLConfigurationDataSource
=== PAUSE TestAccSAMLConfigurationDataSource
=== RUN   TestAccSidecarBoundPortsDataSource
=== PAUSE TestAccSidecarBoundPortsDataSource
=== RUN   TestAccSidecarCftTemplateDataSource
=== PAUSE TestAccSidecarCftTemplateDataSource
=== RUN   TestAccSidecarIDDataSource
=== PAUSE TestAccSidecarIDDataSource
=== RUN   TestAccSidecarInstanceIDsDataSource
=== PAUSE TestAccSidecarInstanceIDsDataSource
=== RUN   TestAccSidecarListenerDataSource
=== PAUSE TestAccSidecarListenerDataSource
=== RUN   TestIntegrationsData_GetValue_Default
--- PASS: TestIntegrationsData_GetValue_Default (0.00s)
=== RUN   TestIntegrationsData_GetValue_Splunk
--- PASS: TestIntegrationsData_GetValue_Splunk (0.00s)
=== RUN   TestAccProvider
2023/07/12 22:57:12 [DEBUG] Init dataSourceSidecarListener
2023/07/12 22:57:12 [DEBUG] End dataSourceSidecarListener
--- PASS: TestAccProvider (0.00s)
=== RUN   TestAccDatalabelResource
=== PAUSE TestAccDatalabelResource
=== RUN   TestAccDatadogIntegrationResource
=== PAUSE TestAccDatadogIntegrationResource
=== RUN   TestAccELKIntegrationResource
=== PAUSE TestAccELKIntegrationResource
=== RUN   TestAccHCVaultIntegrationResource
=== PAUSE TestAccHCVaultIntegrationResource
=== RUN   TestAccIntegrationIdPSAMLDraftResource
=== PAUSE TestAccIntegrationIdPSAMLDraftResource
=== RUN   TestAccIntegrationIdPSAMLResource
=== PAUSE TestAccIntegrationIdPSAMLResource
=== RUN   TestAccIdPIntegrationResource
=== PAUSE TestAccIdPIntegrationResource
=== RUN   TestAccLogsIntegrationResourceCloudWatch
=== PAUSE TestAccLogsIntegrationResourceCloudWatch
=== RUN   TestAccLogsIntegrationResourceDataDog
=== PAUSE TestAccLogsIntegrationResourceDataDog
=== RUN   TestAccLogsIntegrationResourceElk
=== PAUSE TestAccLogsIntegrationResourceElk
=== RUN   TestAccLogsIntegrationResourceSplunk
=== PAUSE TestAccLogsIntegrationResourceSplunk
=== RUN   TestAccLogsIntegrationResourceSumologic
=== PAUSE TestAccLogsIntegrationResourceSumologic
=== RUN   TestAccLogsIntegrationResourceFluentbit
=== PAUSE TestAccLogsIntegrationResourceFluentbit
=== RUN   TestAccLogstashIntegrationResource
=== PAUSE TestAccLogstashIntegrationResource
=== RUN   TestAccLookerIntegrationResource
=== PAUSE TestAccLookerIntegrationResource
=== RUN   TestAccDuoMFAIntegrationResource
=== PAUSE TestAccDuoMFAIntegrationResource
=== RUN   TestAccPagerDutyIntegrationResource
=== PAUSE TestAccPagerDutyIntegrationResource
=== RUN   TestAccSlackAlertsIntegrationResource
=== PAUSE TestAccSlackAlertsIntegrationResource
=== RUN   TestAccSplunkIntegrationResource
=== PAUSE TestAccSplunkIntegrationResource
=== RUN   TestAccSumoLogicIntegrationResource
=== PAUSE TestAccSumoLogicIntegrationResource
=== RUN   TestAccMsTeamsIntegrationResource
=== PAUSE TestAccMsTeamsIntegrationResource
=== RUN   TestAccPolicyRuleResource
=== PAUSE TestAccPolicyRuleResource
=== RUN   TestPolicyRuleResourceUpgradeV0
--- PASS: TestPolicyRuleResourceUpgradeV0 (0.00s)
=== RUN   TestAccPolicyResource
=== PAUSE TestAccPolicyResource
=== RUN   TestAccRepositoryAccessGatewayResource
=== PAUSE TestAccRepositoryAccessGatewayResource
=== RUN   TestAccRepositoryAccessRulesResource
=== PAUSE TestAccRepositoryAccessRulesResource
=== RUN   TestAccRepositoryBindingResource
=== PAUSE TestAccRepositoryBindingResource
=== RUN   TestAccRepositoryConfAnalysisResource
=== PAUSE TestAccRepositoryConfAnalysisResource
=== RUN   TestRepositoryConfAnalysisResourceUpgradeV0
--- PASS: TestRepositoryConfAnalysisResourceUpgradeV0 (0.00s)
=== RUN   TestAccRepositoryConfAuthResource
=== PAUSE TestAccRepositoryConfAuthResource
=== RUN   TestRepositoryConfAuthResourceUpgradeV0
--- PASS: TestRepositoryConfAuthResourceUpgradeV0 (0.00s)
=== RUN   TestAccRepositoryDatamapResource
=== PAUSE TestAccRepositoryDatamapResource
=== RUN   TestAccRepositoryNetworkAccessPolicyResource
=== PAUSE TestAccRepositoryNetworkAccessPolicyResource
=== RUN   TestAccRepositoryResource
=== PAUSE TestAccRepositoryResource
=== RUN   TestAccRepositoryUserAccountResource
=== PAUSE TestAccRepositoryUserAccountResource
=== RUN   TestAccRoleSSOGroupsResource
=== PAUSE TestAccRoleSSOGroupsResource
=== RUN   TestRoleSSOGroupsResourceUpgradeV0
--- PASS: TestRoleSSOGroupsResourceUpgradeV0 (0.00s)
=== RUN   TestAccRoleResource
=== PAUSE TestAccRoleResource
=== RUN   TestAccSidecarCredentialsResource
=== PAUSE TestAccSidecarCredentialsResource
=== RUN   TestSidecarListenerResource
=== PAUSE TestSidecarListenerResource
=== RUN   TestAccSidecarResource
=== PAUSE TestAccSidecarResource
=== RUN   TestElementsMatch
--- PASS: TestElementsMatch (0.00s)
=== CONT  TestAccDatalabelDataSource
=== CONT  TestAccLogsIntegrationResourceFluentbit
=== CONT  TestAccDatalabelResource
=== CONT  TestAccRepositoryAccessRulesResource
=== CONT  TestAccLogstashIntegrationResource
--- PASS: TestAccLogsIntegrationResourceFluentbit (13.94s)
=== CONT  TestAccLogsIntegrationResourceSumologic
--- PASS: TestAccDatalabelResource (15.00s)
=== CONT  TestAccLogsIntegrationResourceSplunk
--- PASS: TestAccLogstashIntegrationResource (19.35s)
=== CONT  TestAccLogsIntegrationResourceElk
--- PASS: TestAccRepositoryAccessRulesResource (19.47s)
=== CONT  TestAccLogsIntegrationResourceDataDog
--- PASS: TestAccDatalabelDataSource (23.43s)
=== CONT  TestAccIdPIntegrationResource
--- PASS: TestAccLogsIntegrationResourceSumologic (12.07s)
=== CONT  TestAccLogsIntegrationResourceCloudWatch
--- PASS: TestAccLogsIntegrationResourceSplunk (12.21s)
=== CONT  TestAccDatadogIntegrationResource
--- PASS: TestAccLogsIntegrationResourceDataDog (12.15s)
=== CONT  TestAccSidecarListenerDataSource
=== CONT  TestAccSidecarInstanceIDsDataSource
--- PASS: TestAccLogsIntegrationResourceElk (12.67s)
--- PASS: TestAccLogsIntegrationResourceCloudWatch (12.05s)
=== CONT  TestAccSidecarCftTemplateDataSource
--- PASS: TestAccDatadogIntegrationResource (12.01s)
=== CONT  TestAccSidecarIDDataSource
=== CONT  TestAccSidecarBoundPortsDataSource
--- PASS: TestAccSidecarInstanceIDsDataSource (20.63s)
--- PASS: TestAccSidecarIDDataSource (13.61s)
=== CONT  TestAccSAMLConfigurationDataSource
=== CONT  TestAccRoleDataSource
--- PASS: TestAccSidecarListenerDataSource (22.91s)
--- PASS: TestAccSidecarCftTemplateDataSource (16.99s)
=== CONT  TestAccSAMLCertificateDataSource
--- PASS: TestAccIdPIntegrationResource (40.39s)
=== CONT  TestAccLoggingIntegrationDataSource
--- PASS: TestAccSAMLCertificateDataSource (9.81s)
=== CONT  TestAccRepositoryDataSource
--- PASS: TestAccSAMLConfigurationDataSource (13.53s)
=== CONT  TestAccIntegrationIdPSAMLDataSource
--- PASS: TestAccRoleDataSource (13.65s)
=== CONT  TestAccIntegrationIdPSAMLDraftResource
=== CONT  TestAccIntegrationIdPSAMLResource
--- PASS: TestAccSidecarBoundPortsDataSource (18.56s)
--- PASS: TestAccLoggingIntegrationDataSource (14.66s)
=== CONT  TestAccHCVaultIntegrationResource
--- PASS: TestAccIntegrationIdPSAMLDraftResource (15.11s)
=== CONT  TestAccELKIntegrationResource
--- PASS: TestAccRepositoryDataSource (19.85s)
=== CONT  TestAccSlackAlertsIntegrationResource
--- PASS: TestAccHCVaultIntegrationResource (12.97s)
=== CONT  TestAccRepositoryAccessGatewayResource
--- PASS: TestAccIntegrationIdPSAMLDataSource (26.64s)
=== CONT  TestAccRepositoryBindingResource
--- PASS: TestAccSlackAlertsIntegrationResource (10.95s)
=== CONT  TestAccPolicyRuleResource
--- PASS: TestAccELKIntegrationResource (12.96s)
=== CONT  TestAccPolicyResource
--- PASS: TestAccIntegrationIdPSAMLResource (28.40s)
=== CONT  TestAccMsTeamsIntegrationResource
--- PASS: TestAccRepositoryBindingResource (14.61s)
=== CONT  TestAccSumoLogicIntegrationResource
--- PASS: TestAccPolicyResource (11.45s)
=== CONT  TestAccPagerDutyIntegrationResource
--- PASS: TestAccMsTeamsIntegrationResource (11.12s)
=== CONT  TestAccSplunkIntegrationResource
--- PASS: TestAccRepositoryAccessGatewayResource (23.08s)
=== CONT  TestAccDuoMFAIntegrationResource
--- PASS: TestAccPolicyRuleResource (21.07s)
=== CONT  TestAccLookerIntegrationResource
--- PASS: TestAccSumoLogicIntegrationResource (12.04s)
=== CONT  TestAccRepositoryResource
--- PASS: TestAccPagerDutyIntegrationResource (12.98s)
=== CONT  TestAccSidecarResource
=== CONT  TestAccRepositoryNetworkAccessPolicyResource
--- PASS: TestAccSplunkIntegrationResource (12.49s)
--- PASS: TestAccDuoMFAIntegrationResource (12.40s)
=== CONT  TestSidecarListenerResource
=== CONT  TestAccRoleResource
--- PASS: TestAccLookerIntegrationResource (12.56s)
--- PASS: TestAccRepositoryResource (22.78s)
=== CONT  TestAccSidecarCredentialsResource
=== CONT  TestAccRoleSSOGroupsResource
--- PASS: TestAccRepositoryNetworkAccessPolicyResource (23.07s)
--- PASS: TestAccRoleResource (19.61s)
=== CONT  TestAccRepositoryUserAccountResource
--- PASS: TestAccSidecarResource (29.11s)
=== CONT  TestAccRepositoryDatamapResource
=== CONT  TestAccRepositoryConfAnalysisResource
--- PASS: TestAccSidecarCredentialsResource (11.57s)
--- PASS: TestSidecarListenerResource (31.20s)
=== CONT  TestAccRepositoryConfAuthResource
--- PASS: TestAccRoleSSOGroupsResource (17.77s)
--- PASS: TestAccRepositoryConfAnalysisResource (12.56s)
--- PASS: TestAccRepositoryDatamapResource (23.04s)
--- PASS: TestAccRepositoryConfAuthResource (17.57s)
--- PASS: TestAccRepositoryUserAccountResource (41.60s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral      190.659s
```