### PR TITLE
ENG-12193: Terrraform provider panics when ELK integration creds are not set

### DIFF
--- a/cyral/data_source_cyral_integration_logging_test.go
+++ b/cyral/data_source_cyral_integration_logging_test.go
@@ -66,9 +66,9 @@ func testIntegrationLoggingDataSourceConfigDependencies(resName string) string {
 
 func TestAccLoggingIntegrationDataSource(t *testing.T) {
 	testConfig1, testFunc1 := testIntegrationLoggingDataSource(t,
-		"test1", "CLOUDWATCH")
+		accTestName(integrationLogsDataSourceName, "test1"), "CLOUDWATCH")
 	testConfig2, testFunc2 := testIntegrationLoggingDataSource(t,
-		"test2", "DATADOG")
+		accTestName(integrationLogsDataSourceName, "test2"), "DATADOG")
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,

--- a/cyral/model_integration_logging.go
+++ b/cyral/model_integration_logging.go
@@ -20,9 +20,9 @@ type EsCredentials struct {
 }
 
 type ElkConfig struct {
-	EsURL         string        `json:"esUrl"`
-	KibanaURL     string        `json:"kibanaUrl"`
-	EsCredentials EsCredentials `json:"esCredentials"`
+	EsURL         string         `json:"esUrl"`
+	KibanaURL     string         `json:"kibanaUrl"`
+	EsCredentials *EsCredentials `json:"esCredentials"`
 }
 
 type SplunkConfig struct {

--- a/cyral/resource_cyral_integration_logging.go
+++ b/cyral/resource_cyral_integration_logging.go
@@ -33,18 +33,21 @@ func getLoggingConfig(resource *LoggingIntegration) (string, []interface{}, erro
 		}
 	case resource.Elk != nil:
 		configType = ElkKey
-		configScheme = []interface{}{
-			map[string]interface{}{
-				"es_url":     resource.Elk.EsURL,
-				"kibana_url": resource.Elk.KibanaURL,
-				"es_credentials": []interface{}{
-					map[string]interface{}{
-						"username": resource.Elk.EsCredentials.Username,
-						"password": resource.Elk.EsCredentials.Password,
-					},
-				},
-			},
+		configScheme := []interface{}{}
+		elkConfig := map[string]interface{}{
+			"es_url":     resource.Elk.EsURL,
+			"kibana_url": resource.Elk.KibanaURL,
 		}
+		// Optional, so we need to verify separately
+		if resource.Elk.EsCredentials != nil {
+			elkConfig["es_credentials"] = []interface{}{
+				map[string]interface{}{
+					"username": resource.Elk.EsCredentials.Username,
+					"password": resource.Elk.EsCredentials.Password,
+				},
+			}
+		}
+		configScheme = append(configScheme, elkConfig)
 	case resource.Splunk != nil:
 		configType = SplunkKey
 		configScheme = []interface{}{
@@ -131,18 +134,18 @@ func (integrationLogConfig *LoggingIntegration) ReadFromSchema(d *schema.Resourc
 			ApiKey: m["api_key"].(string),
 		}
 	case ElkKey:
-		credentialsSet := m["es_credentials"].(*schema.Set).List()
-		credentialScheme := make(map[string]interface{})
-		if len(credentialsSet) != 0 {
-			credentialScheme = credentialsSet[0].(map[string]interface{})
-		}
 		integrationLogConfig.Elk = &ElkConfig{
 			EsURL:     m["es_url"].(string),
 			KibanaURL: m["kibana_url"].(string),
-			EsCredentials: EsCredentials{
+		}
+		credentialsSet := m["es_credentials"].(*schema.Set).List()
+		if len(credentialsSet) != 0 {
+			credentialScheme := make(map[string]interface{})
+			credentialScheme = credentialsSet[0].(map[string]interface{})
+			integrationLogConfig.Elk.EsCredentials = &EsCredentials{
 				Username: credentialScheme["username"].(string),
 				Password: credentialScheme["password"].(string),
-			},
+			}
 		}
 	case SplunkKey:
 		integrationLogConfig.Splunk = &SplunkConfig{

--- a/cyral/resource_cyral_integration_logging.go
+++ b/cyral/resource_cyral_integration_logging.go
@@ -33,7 +33,6 @@ func getLoggingConfig(resource *LoggingIntegration) (string, []interface{}, erro
 		}
 	case resource.Elk != nil:
 		configType = ElkKey
-		configScheme := []interface{}{}
 		elkConfig := map[string]interface{}{
 			"es_url":     resource.Elk.EsURL,
 			"kibana_url": resource.Elk.KibanaURL,
@@ -47,7 +46,7 @@ func getLoggingConfig(resource *LoggingIntegration) (string, []interface{}, erro
 				},
 			}
 		}
-		configScheme = append(configScheme, elkConfig)
+		configScheme = []interface{}{elkConfig}
 	case resource.Splunk != nil:
 		configType = SplunkKey
 		configScheme = []interface{}{


### PR DESCRIPTION
## Description of the change

Terrraform provider panics when ELK integration creds are not set

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

Tested different resources manually:

`terraform init/apply` them

![image](https://github.com/cyralinc/terraform-provider-cyral/assets/37452507/2ff75ad5-3cc6-470a-9504-f569739074d0)
![image](https://github.com/cyralinc/terraform-provider-cyral/assets/37452507/a6fefb94-e4ca-4fac-8148-3d18b54f2901)

`terraform show`

![image](https://github.com/cyralinc/terraform-provider-cyral/assets/37452507/6db21096-de91-415e-b617-79da17b11375)


trying only `kibana_url` and `terraform apply/show`
![image](https://github.com/cyralinc/terraform-provider-cyral/assets/37452507/63b4b522-f0ac-44db-a031-a131f713ff0c)
