### PR TITLE
Fix error handling in case of states out of sync

### DIFF
--- a/cyral/error_handlers.go
+++ b/cyral/error_handlers.go
@@ -25,3 +25,21 @@ func (h *DeleteIgnoreHttpNotFound) HandleError(
 	log.Printf("[DEBUG] %s not found. Skipping deletion.", h.resName)
 	return nil
 }
+
+type ReadIgnoreHttpNotFound struct {
+	resName string
+}
+
+func (h *ReadIgnoreHttpNotFound) HandleError(
+	r *schema.ResourceData,
+	_ *client.Client,
+	err error,
+) error {
+	httpError, ok := err.(*client.HttpError)
+	if !ok || httpError.StatusCode != http.StatusNotFound {
+		return err
+	}
+	r.SetId("")
+	log.Printf("[DEBUG] %s not found. Marking resource for recreation.", h.resName)
+	return nil
+}

--- a/cyral/resource_cyral_integration_datadog.go
+++ b/cyral/resource_cyral_integration_datadog.go
@@ -33,7 +33,8 @@ var ReadDatadogConfig = ResourceOperationConfig{
 	CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 		return fmt.Sprintf("https://%s/v1/integrations/datadog/%s", c.ControlPlane, d.Id())
 	},
-	NewResponseData: func(_ *schema.ResourceData) ResponseData { return &DatadogIntegration{} },
+	NewResponseData:     func(_ *schema.ResourceData) ResponseData { return &DatadogIntegration{} },
+	RequestErrorHandler: &ReadIgnoreHttpNotFound{resName: "Integration datadog"},
 }
 
 func resourceIntegrationDatadog() *schema.Resource {

--- a/cyral/resource_cyral_integration_elk.go
+++ b/cyral/resource_cyral_integration_elk.go
@@ -36,7 +36,8 @@ var ReadELKConfig = ResourceOperationConfig{
 	CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 		return fmt.Sprintf("https://%s/v1/integrations/elk/%s", c.ControlPlane, d.Id())
 	},
-	NewResponseData: func(_ *schema.ResourceData) ResponseData { return &ELKIntegration{} },
+	NewResponseData:     func(_ *schema.ResourceData) ResponseData { return &ELKIntegration{} },
+	RequestErrorHandler: &ReadIgnoreHttpNotFound{resName: "Integration elk"},
 }
 
 func resourceIntegrationELK() *schema.Resource {

--- a/cyral/resource_cyral_integration_hcvault.go
+++ b/cyral/resource_cyral_integration_hcvault.go
@@ -32,7 +32,8 @@ var ReadHCVaultIntegrationConfig = ResourceOperationConfig{
 	CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 		return fmt.Sprintf("https://%s/v1/integrations/secretProviders/hcvault/%s", c.ControlPlane, d.Id())
 	},
-	NewResponseData: func(_ *schema.ResourceData) ResponseData { return &HCVaultIntegration{} },
+	NewResponseData:     func(_ *schema.ResourceData) ResponseData { return &HCVaultIntegration{} },
+	RequestErrorHandler: &ReadIgnoreHttpNotFound{resName: "Integration hcvault"},
 }
 
 func resourceIntegrationHCVault() *schema.Resource {

--- a/cyral/resource_cyral_integration_idp_saml.go
+++ b/cyral/resource_cyral_integration_idp_saml.go
@@ -86,7 +86,8 @@ func ReadGenericSAMLConfig() ResourceOperationConfig {
 		CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 			return fmt.Sprintf("https://%s/v1/integrations/generic-saml/sso/%s", c.ControlPlane, d.Id())
 		},
-		NewResponseData: func(_ *schema.ResourceData) ResponseData { return &ReadGenericSAMLResponse{} },
+		NewResponseData:     func(_ *schema.ResourceData) ResponseData { return &ReadGenericSAMLResponse{} },
+		RequestErrorHandler: &ReadIgnoreHttpNotFound{resName: "Generic SAML"},
 	}
 }
 

--- a/cyral/resource_cyral_integration_logging.go
+++ b/cyral/resource_cyral_integration_logging.go
@@ -187,7 +187,7 @@ var ReadLoggingIntegration = ResourceOperationConfig{
 		return fmt.Sprintf(loggingApiUrl, c.ControlPlane, d.Id())
 	},
 	NewResponseData:     func(_ *schema.ResourceData) ResponseData { return &LoggingIntegration{} },
-	RequestErrorHandler: &ReadIgnoreHttpNotFound{resName: "Logging integration"},
+	RequestErrorHandler: &ReadIgnoreHttpNotFound{resName: "Integration logging"},
 }
 
 func UpdateLoggingIntegration() ResourceOperationConfig {

--- a/cyral/resource_cyral_integration_logging.go
+++ b/cyral/resource_cyral_integration_logging.go
@@ -186,7 +186,8 @@ var ReadLoggingIntegration = ResourceOperationConfig{
 	CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 		return fmt.Sprintf(loggingApiUrl, c.ControlPlane, d.Id())
 	},
-	NewResponseData: func(_ *schema.ResourceData) ResponseData { return &LoggingIntegration{} },
+	NewResponseData:     func(_ *schema.ResourceData) ResponseData { return &LoggingIntegration{} },
+	RequestErrorHandler: &ReadIgnoreHttpNotFound{resName: "Logging integration"},
 }
 
 func UpdateLoggingIntegration() ResourceOperationConfig {

--- a/cyral/resource_cyral_integration_slack_alerts.go
+++ b/cyral/resource_cyral_integration_slack_alerts.go
@@ -31,7 +31,8 @@ var ReadSlackAlertsConfig = ResourceOperationConfig{
 	CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 		return fmt.Sprintf("https://%s/v1/integrations/notifications/slack/%s", c.ControlPlane, d.Id())
 	},
-	NewResponseData: func(_ *schema.ResourceData) ResponseData { return &SlackAlertsIntegration{} },
+	NewResponseData:     func(_ *schema.ResourceData) ResponseData { return &SlackAlertsIntegration{} },
+	RequestErrorHandler: &ReadIgnoreHttpNotFound{resName: "Integration Slack"},
 }
 
 func resourceIntegrationSlackAlerts() *schema.Resource {

--- a/cyral/resource_cyral_integration_teams.go
+++ b/cyral/resource_cyral_integration_teams.go
@@ -31,7 +31,8 @@ var ReadMsTeamsConfig = ResourceOperationConfig{
 	CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 		return fmt.Sprintf("https://%s/v1/integrations/notifications/teams/%s", c.ControlPlane, d.Id())
 	},
-	NewResponseData: func(_ *schema.ResourceData) ResponseData { return &MsTeamsIntegration{} },
+	NewResponseData:     func(_ *schema.ResourceData) ResponseData { return &MsTeamsIntegration{} },
+	RequestErrorHandler: &ReadIgnoreHttpNotFound{resName: "Integration Teams"},
 }
 
 func resourceIntegrationMsTeams() *schema.Resource {

--- a/cyral/resource_cyral_repository.go
+++ b/cyral/resource_cyral_repository.go
@@ -281,6 +281,7 @@ var ReadRepositoryConfig = ResourceOperationConfig{
 	NewResponseData: func(_ *schema.ResourceData) ResponseData {
 		return &GetRepoByIDResponse{}
 	},
+	RequestErrorHandler: &ReadIgnoreHttpNotFound{resName: "Repository"},
 }
 
 func resourceRepository() *schema.Resource {

--- a/cyral/resource_cyral_repository_access_gateway.go
+++ b/cyral/resource_cyral_repository_access_gateway.go
@@ -46,6 +46,7 @@ var ReadRepositoryAccessGatewayConfig = ResourceOperationConfig{
 	NewResponseData: func(_ *schema.ResourceData) ResponseData {
 		return &GetOrUpdateAccessGateway{}
 	},
+	RequestErrorHandler: &ReadIgnoreHttpNotFound{resName: "Repository access gateway"},
 }
 
 func resourceRepositoryAccessGateway() *schema.Resource {

--- a/cyral/resource_cyral_repository_access_rules.go
+++ b/cyral/resource_cyral_repository_access_rules.go
@@ -139,6 +139,7 @@ var ReadRepositoryAccessRulesConfig = ResourceOperationConfig{
 	NewResponseData: func(_ *schema.ResourceData) ResponseData {
 		return &AccessRulesResponse{}
 	},
+	RequestErrorHandler: &ReadIgnoreHttpNotFound{resName: "Repository access rule"},
 }
 
 func resourceRepositoryAccessRules() *schema.Resource {

--- a/cyral/resource_cyral_repository_binding.go
+++ b/cyral/resource_cyral_repository_binding.go
@@ -117,6 +117,7 @@ var ReadRepositoryBindingConfig = ResourceOperationConfig{
 	NewResponseData: func(_ *schema.ResourceData) ResponseData {
 		return &GetBindingResponse{}
 	},
+	RequestErrorHandler: &ReadIgnoreHttpNotFound{resName: "Repository binding"},
 }
 
 func resourceRepositoryBinding() *schema.Resource {

--- a/cyral/resource_cyral_repository_conf_auth.go
+++ b/cyral/resource_cyral_repository_conf_auth.go
@@ -143,7 +143,8 @@ func ReadConfAuthConfig() ResourceOperationConfig {
 		CreateURL: func(d *schema.ResourceData, c *client.Client) string {
 			return fmt.Sprintf(repositoryConfAuthURLFormat, c.ControlPlane, d.Get("repository_id"))
 		},
-		NewResponseData: func(_ *schema.ResourceData) ResponseData { return &ReadRepositoryConfAuthResponse{} },
+		NewResponseData:     func(_ *schema.ResourceData) ResponseData { return &ReadRepositoryConfAuthResponse{} },
+		RequestErrorHandler: &ReadIgnoreHttpNotFound{resName: "Repository conf auth"},
 	}
 }
 

--- a/cyral/resource_cyral_repository_network_access_policy.go
+++ b/cyral/resource_cyral_repository_network_access_policy.go
@@ -117,7 +117,8 @@ func readRepositoryNetworkAccessPolicy() ResourceOperationConfig {
 			return fmt.Sprintf(repositoryNetworkAccessPolicyURLFormat,
 				c.ControlPlane, d.Get("repository_id"))
 		},
-		NewResponseData: func(_ *schema.ResourceData) ResponseData { return &NetworkAccessPolicy{} },
+		NewResponseData:     func(_ *schema.ResourceData) ResponseData { return &NetworkAccessPolicy{} },
+		RequestErrorHandler: &ReadIgnoreHttpNotFound{resName: "Repository network access policy"},
 	}
 }
 

--- a/cyral/resource_cyral_repository_user_account.go
+++ b/cyral/resource_cyral_repository_user_account.go
@@ -318,6 +318,7 @@ var ReadRepositoryUserAccountConfig = ResourceOperationConfig{
 	NewResponseData: func(_ *schema.ResourceData) ResponseData {
 		return &UserAccountResource{}
 	},
+	RequestErrorHandler: &ReadIgnoreHttpNotFound{resName: "User account"},
 }
 
 func resourceRepositoryUserAccount() *schema.Resource {

--- a/cyral/resource_cyral_role_sso_groups.go
+++ b/cyral/resource_cyral_role_sso_groups.go
@@ -138,7 +138,8 @@ var readRoleSSOGroupsConfig = ResourceOperationConfig{
 		return fmt.Sprintf("https://%s/v1/users/groups/%s/mappings", c.ControlPlane,
 			d.Get("role_id").(string))
 	},
-	NewResponseData: func(_ *schema.ResourceData) ResponseData { return &RoleSSOGroupsReadResponse{} },
+	NewResponseData:     func(_ *schema.ResourceData) ResponseData { return &RoleSSOGroupsReadResponse{} },
+	RequestErrorHandler: &ReadIgnoreHttpNotFound{resName: "Role SSO groups"},
 }
 
 var deleteRoleSSOGroupsConfig = ResourceOperationConfig{

--- a/cyral/resource_cyral_sidecar_listener.go
+++ b/cyral/resource_cyral_sidecar_listener.go
@@ -58,7 +58,8 @@ var ReadSidecarListenersConfig = ResourceOperationConfig{
 			d.Get(SidecarIDKey).(string),
 			d.Get(ListenerIDKey).(string))
 	},
-	NewResponseData: func(_ *schema.ResourceData) ResponseData { return &ReadSidecarListenerAPIResponse{} },
+	NewResponseData:     func(_ *schema.ResourceData) ResponseData { return &ReadSidecarListenerAPIResponse{} },
+	RequestErrorHandler: &ReadIgnoreHttpNotFound{resName: "Sidecar listener"},
 }
 
 type ReadSidecarListenerAPIResponse struct {


### PR DESCRIPTION
## Description of the change

Add proper error handling for `404` issues during read operations. This is a Terraform best practice to get the provider to signal the necessity to recreate a resource in case it does not exist instead of erroring out.

This scenario explains a recurring issue some of our customers face:

1. User creates a resource in Terraform;
2. User removes the resource manually from the control plane, making the state out-of-sync;
3. User runs `terraform apply`;
4. Our provider returns an error during the read operation as the resource does not exist anymore and aborts Terraform execution.

With this fix, this is what happens:

1. User creates a resource in Terraform;
2. User removes the resource manually from the control plane, making the state out-of-sync;
3. User runs `terraform apply`;
4. Our provider signals that the resource needs to be recreated;
5. Terraform recreates the non-existing resource.

This change fixes the following resources that already use the abstractions provided in `cyral/resource.go` to centralize resource management:

```
cyral_integration_datadog
cyral_integration_elk
cyral_integration_hcvault
cyral_integration_idp_saml
cyral_integration_logging
cyral_integration_slack_alerts
cyral_integration_teams
cyral_repository
cyral_repository_access_gateway
cyral_repository_access_rules
cyral_repository_binding
cyral_repository_conf_auth
cyral_repository_network_access_policy
cyral_repository_user_account
cyral_role_sso_groups
cyral_sidecar_listener
```

The following resources should be addressed in a future PR as we also refactor them to use `cyral/resource.go`:

```
cyral_datalabel
cyral_repository_datamap
cyral_role
cyral_sidecar
```

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

```
make local/test
go test github.com/cyralinc/terraform-provider-cyral/... -v -race -timeout 20m
?       github.com/cyralinc/terraform-provider-cyral    [no test files]
=== RUN   TestNewClient_WhenTLSSkipVerifyIsEnabled_ThenInsecureSkipVerifyIsTrue
2023/08/02 23:08:55 [DEBUG] Init NewClient
2023/08/02 23:08:55 [DEBUG] TokenSource: &{0xc00013cd98 {0 0} <nil>}
2023/08/02 23:08:55 [DEBUG] End NewClient
--- PASS: TestNewClient_WhenTLSSkipVerifyIsEnabled_ThenInsecureSkipVerifyIsTrue (0.00s)
=== RUN   TestNewClient_WhenTLSSkipVerifyIsDisabled_ThenInsecureSkipVerifyIsFalse
2023/08/02 23:08:55 [DEBUG] Init NewClient
2023/08/02 23:08:55 [DEBUG] TokenSource: &{0xc00013cde0 {0 0} <nil>}
2023/08/02 23:08:55 [DEBUG] End NewClient
--- PASS: TestNewClient_WhenTLSSkipVerifyIsDisabled_ThenInsecureSkipVerifyIsFalse (0.00s)
=== RUN   TestNewClient_WhenClientIDIsEmpty_ThenThrowError
2023/08/02 23:08:55 [DEBUG] Init NewClient
--- PASS: TestNewClient_WhenClientIDIsEmpty_ThenThrowError (0.00s)
=== RUN   TestNewClient_WhenClientSecretIsEmpty_ThenThrowError
2023/08/02 23:08:55 [DEBUG] Init NewClient
--- PASS: TestNewClient_WhenClientSecretIsEmpty_ThenThrowError (0.00s)
=== RUN   TestNewClient_WhenControlPlaneIsEmpty_ThenThrowError
2023/08/02 23:08:55 [DEBUG] Init NewClient
--- PASS: TestNewClient_WhenControlPlaneIsEmpty_ThenThrowError (0.00s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/client     (cached)
=== RUN   TestAccDatalabelDataSource
=== PAUSE TestAccDatalabelDataSource
=== RUN   TestAccIntegrationIdPSAMLDataSource
=== PAUSE TestAccIntegrationIdPSAMLDataSource
=== RUN   TestAccLoggingIntegrationDataSource
=== PAUSE TestAccLoggingIntegrationDataSource
=== RUN   TestAccRepositoryDataSource
=== PAUSE TestAccRepositoryDataSource
=== RUN   TestAccRoleDataSource
=== PAUSE TestAccRoleDataSource
=== RUN   TestAccSAMLCertificateDataSource
=== PAUSE TestAccSAMLCertificateDataSource
=== RUN   TestAccSAMLConfigurationDataSource
=== PAUSE TestAccSAMLConfigurationDataSource
=== RUN   TestAccSidecarBoundPortsDataSource
=== PAUSE TestAccSidecarBoundPortsDataSource
=== RUN   TestAccSidecarCftTemplateDataSource
=== PAUSE TestAccSidecarCftTemplateDataSource
=== RUN   TestAccSidecarIDDataSource
=== PAUSE TestAccSidecarIDDataSource
=== RUN   TestAccSidecarInstanceIDsDataSource
=== PAUSE TestAccSidecarInstanceIDsDataSource
=== RUN   TestAccSidecarListenerDataSource
=== PAUSE TestAccSidecarListenerDataSource
=== RUN   TestIntegrationsData_GetValue_Default
--- PASS: TestIntegrationsData_GetValue_Default (0.00s)
=== RUN   TestIntegrationsData_GetValue_Splunk
--- PASS: TestIntegrationsData_GetValue_Splunk (0.00s)
=== RUN   TestAccProvider
2023/08/02 23:32:52 [DEBUG] Init dataSourceSidecarListener
2023/08/02 23:32:52 [DEBUG] End dataSourceSidecarListener
--- PASS: TestAccProvider (0.01s)
=== RUN   TestAccDatalabelResource
=== PAUSE TestAccDatalabelResource
=== RUN   TestAccDatadogIntegrationResource
=== PAUSE TestAccDatadogIntegrationResource
=== RUN   TestAccELKIntegrationResource
=== PAUSE TestAccELKIntegrationResource
=== RUN   TestAccHCVaultIntegrationResource
=== PAUSE TestAccHCVaultIntegrationResource
=== RUN   TestAccIntegrationIdPSAMLDraftResource
=== PAUSE TestAccIntegrationIdPSAMLDraftResource
=== RUN   TestAccIntegrationIdPSAMLResource
=== PAUSE TestAccIntegrationIdPSAMLResource
=== RUN   TestAccIdPIntegrationResource
=== PAUSE TestAccIdPIntegrationResource
=== RUN   TestAccLogsIntegrationResourceCloudWatch
=== PAUSE TestAccLogsIntegrationResourceCloudWatch
=== RUN   TestAccLogsIntegrationResourceDataDog
=== PAUSE TestAccLogsIntegrationResourceDataDog
=== RUN   TestAccLogsIntegrationResourceElk
=== PAUSE TestAccLogsIntegrationResourceElk
=== RUN   TestAccLogsIntegrationResourceElkEmptyEsCredentials
=== PAUSE TestAccLogsIntegrationResourceElkEmptyEsCredentials
=== RUN   TestAccLogsIntegrationResourceSplunk
=== PAUSE TestAccLogsIntegrationResourceSplunk
=== RUN   TestAccLogsIntegrationResourceSumologic
=== PAUSE TestAccLogsIntegrationResourceSumologic
=== RUN   TestAccLogsIntegrationResourceFluentbit
=== PAUSE TestAccLogsIntegrationResourceFluentbit
=== RUN   TestAccLogstashIntegrationResource
=== PAUSE TestAccLogstashIntegrationResource
=== RUN   TestAccLookerIntegrationResource
=== PAUSE TestAccLookerIntegrationResource
=== RUN   TestAccDuoMFAIntegrationResource
=== PAUSE TestAccDuoMFAIntegrationResource
=== RUN   TestAccPagerDutyIntegrationResource
=== PAUSE TestAccPagerDutyIntegrationResource
=== RUN   TestAccSlackAlertsIntegrationResource
=== PAUSE TestAccSlackAlertsIntegrationResource
=== RUN   TestAccSplunkIntegrationResource
=== PAUSE TestAccSplunkIntegrationResource
=== RUN   TestAccSumoLogicIntegrationResource
=== PAUSE TestAccSumoLogicIntegrationResource
=== RUN   TestAccMsTeamsIntegrationResource
=== PAUSE TestAccMsTeamsIntegrationResource
=== RUN   TestAccPolicyRuleResource
=== PAUSE TestAccPolicyRuleResource
=== RUN   TestPolicyRuleResourceUpgradeV0
--- PASS: TestPolicyRuleResourceUpgradeV0 (0.00s)
=== RUN   TestAccPolicyResource
=== PAUSE TestAccPolicyResource
=== RUN   TestAccRepositoryAccessGatewayResource
=== PAUSE TestAccRepositoryAccessGatewayResource
=== RUN   TestAccRepositoryAccessRulesResource
=== PAUSE TestAccRepositoryAccessRulesResource
=== RUN   TestAccRepositoryBindingResource
=== PAUSE TestAccRepositoryBindingResource
=== RUN   TestAccRepositoryConfAnalysisResource
=== PAUSE TestAccRepositoryConfAnalysisResource
=== RUN   TestRepositoryConfAnalysisResourceUpgradeV0
--- PASS: TestRepositoryConfAnalysisResourceUpgradeV0 (0.00s)
=== RUN   TestAccRepositoryConfAuthResource
=== PAUSE TestAccRepositoryConfAuthResource
=== RUN   TestRepositoryConfAuthResourceUpgradeV0
--- PASS: TestRepositoryConfAuthResourceUpgradeV0 (0.00s)
=== RUN   TestAccRepositoryDatamapResource
=== PAUSE TestAccRepositoryDatamapResource
=== RUN   TestAccRepositoryNetworkAccessPolicyResource
=== PAUSE TestAccRepositoryNetworkAccessPolicyResource
=== RUN   TestAccRepositoryResource
=== PAUSE TestAccRepositoryResource
=== RUN   TestAccRepositoryUserAccountResource
=== PAUSE TestAccRepositoryUserAccountResource
=== RUN   TestAccRoleSSOGroupsResource
=== PAUSE TestAccRoleSSOGroupsResource
=== RUN   TestRoleSSOGroupsResourceUpgradeV0
--- PASS: TestRoleSSOGroupsResourceUpgradeV0 (0.00s)
=== RUN   TestAccRoleResource
=== PAUSE TestAccRoleResource
=== RUN   TestAccSidecarCredentialsResource
=== PAUSE TestAccSidecarCredentialsResource
=== RUN   TestSidecarListenerResource
=== PAUSE TestSidecarListenerResource
=== RUN   TestAccSidecarResource
=== PAUSE TestAccSidecarResource
=== RUN   TestElementsMatch
--- PASS: TestElementsMatch (0.00s)
=== CONT  TestAccRepositoryAccessRulesResource
=== CONT  TestAccSlackAlertsIntegrationResource
=== CONT  TestAccRepositoryNetworkAccessPolicyResource
=== CONT  TestAccIntegrationIdPSAMLDataSource
=== CONT  TestAccPolicyRuleResource
=== CONT  TestAccPolicyResource
=== CONT  TestAccMsTeamsIntegrationResource
=== CONT  TestAccSplunkIntegrationResource
=== CONT  TestAccIntegrationIdPSAMLResource
=== CONT  TestAccSumoLogicIntegrationResource
--- PASS: TestAccSlackAlertsIntegrationResource (7.53s)
=== CONT  TestAccDuoMFAIntegrationResource
--- PASS: TestAccMsTeamsIntegrationResource (7.64s)
=== CONT  TestAccPagerDutyIntegrationResource
--- PASS: TestAccSplunkIntegrationResource (8.24s)
=== CONT  TestAccLogstashIntegrationResource
--- PASS: TestAccPolicyResource (8.24s)
=== CONT  TestAccELKIntegrationResource
=== CONT  TestAccLogsIntegrationResourceSumologic
--- PASS: TestAccSumoLogicIntegrationResource (8.43s)
=== CONT  TestAccHCVaultIntegrationResource
--- PASS: TestAccRepositoryAccessRulesResource (11.66s)
--- PASS: TestAccPagerDutyIntegrationResource (5.19s)
=== CONT  TestAccSidecarListenerDataSource
--- PASS: TestAccDuoMFAIntegrationResource (5.31s)
=== CONT  TestAccDatalabelResource
=== CONT  TestAccSidecarInstanceIDsDataSource
--- PASS: TestAccLogsIntegrationResourceSumologic (6.41s)
=== CONT  TestAccSidecarIDDataSource
--- PASS: TestAccELKIntegrationResource (6.71s)
--- PASS: TestAccPolicyRuleResource (18.57s)
=== CONT  TestAccLogsIntegrationResourceSplunk
=== CONT  TestAccSidecarCftTemplateDataSource
--- PASS: TestAccHCVaultIntegrationResource (7.22s)
=== CONT  TestAccDatadogIntegrationResource
--- PASS: TestAccLogstashIntegrationResource (11.89s)
--- PASS: TestAccRepositoryNetworkAccessPolicyResource (20.87s)
=== CONT  TestAccLookerIntegrationResource
=== CONT  TestAccSidecarBoundPortsDataSource
--- PASS: TestAccDatalabelResource (8.24s)
--- PASS: TestAccIntegrationIdPSAMLDataSource (22.31s)
=== CONT  TestAccLogsIntegrationResourceElkEmptyEsCredentials
=== CONT  TestAccRepositoryDataSource
--- PASS: TestAccSidecarIDDataSource (8.82s)
--- PASS: TestAccLogsIntegrationResourceSplunk (6.36s)
=== CONT  TestAccLogsIntegrationResourceDataDog
--- PASS: TestAccSidecarInstanceIDsDataSource (10.42s)
=== CONT  TestAccDatalabelDataSource
--- PASS: TestAccDatadogIntegrationResource (6.14s)
=== CONT  TestAccLogsIntegrationResourceCloudWatch
=== CONT  TestAccLogsIntegrationResourceElk
--- PASS: TestAccLookerIntegrationResource (5.82s)
=== CONT  TestAccIdPIntegrationResource
--- PASS: TestAccIntegrationIdPSAMLResource (27.74s)
=== CONT  TestAccSidecarResource
--- PASS: TestAccLogsIntegrationResourceElkEmptyEsCredentials (6.16s)
=== CONT  TestSidecarListenerResource
--- PASS: TestAccSidecarCftTemplateDataSource (10.48s)
--- PASS: TestAccSidecarListenerDataSource (16.97s)
=== CONT  TestAccRoleResource
=== CONT  TestAccIntegrationIdPSAMLDraftResource
--- PASS: TestAccLogsIntegrationResourceDataDog (5.00s)
=== CONT  TestAccSidecarCredentialsResource
--- PASS: TestAccLogsIntegrationResourceCloudWatch (6.69s)
--- PASS: TestAccSidecarBoundPortsDataSource (12.25s)
=== CONT  TestAccRepositoryConfAnalysisResource
--- PASS: TestAccLogsIntegrationResourceElk (6.69s)
=== CONT  TestAccRoleSSOGroupsResource
--- PASS: TestAccRepositoryDataSource (13.12s)
=== CONT  TestAccRepositoryConfAuthResource
--- PASS: TestAccSidecarCredentialsResource (7.83s)
=== CONT  TestAccLoggingIntegrationDataSource
=== CONT  TestAccRepositoryBindingResource
--- PASS: TestAccIntegrationIdPSAMLDraftResource (11.94s)
--- PASS: TestAccRepositoryConfAnalysisResource (9.15s)
=== CONT  TestAccLogsIntegrationResourceFluentbit
--- PASS: TestAccDatalabelDataSource (19.43s)
=== CONT  TestAccSAMLConfigurationDataSource
--- PASS: TestAccLogsIntegrationResourceFluentbit (6.55s)
=== CONT  TestAccRepositoryDatamapResource
--- PASS: TestAccLoggingIntegrationDataSource (10.84s)
=== CONT  TestAccRoleDataSource
=== CONT  TestAccRepositoryResource
--- PASS: TestAccRoleSSOGroupsResource (19.46s)
=== CONT  TestAccRepositoryUserAccountResource
--- PASS: TestAccRepositoryBindingResource (11.61s)
--- PASS: TestAccRepositoryConfAuthResource (18.18s)
=== CONT  TestAccSAMLCertificateDataSource
--- PASS: TestAccSAMLConfigurationDataSource (11.11s)
=== CONT  TestAccRepositoryAccessGatewayResource
--- PASS: TestAccRoleResource (29.70s)
--- PASS: TestAccSidecarResource (31.50s)
--- PASS: TestAccSAMLCertificateDataSource (5.32s)
--- PASS: TestAccRoleDataSource (10.99s)
--- PASS: TestSidecarListenerResource (33.91s)
--- PASS: TestAccRepositoryDatamapResource (22.38s)
--- PASS: TestAccIdPIntegrationResource (44.18s)
--- PASS: TestAccRepositoryAccessGatewayResource (16.54s)
--- PASS: TestAccRepositoryResource (19.81s)
--- PASS: TestAccRepositoryUserAccountResource (38.72s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral      92.579s
```
