### PR TITLE
ENG-12334: Add data label tags field to the policy resource

### DIFF
--- a/cyral/model_policy.go
+++ b/cyral/model_policy.go
@@ -5,20 +5,21 @@ import (
 )
 
 type Policy struct {
-	Meta *PolicyMetadata `json:"meta" yaml:"meta"`
-	Data []string        `json:"data,omitempty" yaml:"data,omitempty,flow"`
+	Meta *PolicyMetadata `json:"meta"`
+	Data []string        `json:"data,omitempty"`
+	Tags []string        `json:"tags,omitempty"`
 }
 
 type PolicyMetadata struct {
-	ID          string    `json:"id" yaml:"id"`
-	Name        string    `json:"name" yaml:"name"`
-	Version     string    `json:"version" yaml:"version"`
-	Created     time.Time `json:"created" yaml:"created"`
-	LastUpdated time.Time `json:"lastUpdated" yaml:"lastUpdated"`
-	Type        string    `json:"type" yaml:"type"`
-	Tags        []string  `json:"tags" yaml:"tags"`
-	Enabled     bool      `json:"enabled" yaml:"enabled"`
-	Description string    `json:"description" yaml:"description"`
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Version     string    `json:"version"`
+	Created     time.Time `json:"created"`
+	LastUpdated time.Time `json:"lastUpdated"`
+	Type        string    `json:"type"`
+	Tags        []string  `json:"tags"`
+	Enabled     bool      `json:"enabled"`
+	Description string    `json:"description"`
 }
 
 type PolicyListResponse struct {

--- a/cyral/resource_cyral_integration_logging_test.go
+++ b/cyral/resource_cyral_integration_logging_test.go
@@ -79,7 +79,7 @@ var initialLogsConfigSumologic LoggingIntegration = LoggingIntegration{
 	ReceiveAuditLogs: true,
 	LoggingIntegrationConfig: LoggingIntegrationConfig{
 		SumoLogic: &SumoLogicConfig{
-			Address: "http://www.hostname.com.br",
+			Address: "https://www.hostname.com.br/path",
 		},
 	},
 }
@@ -162,7 +162,7 @@ var updatedLogsConfigSumologic LoggingIntegration = LoggingIntegration{
 	ReceiveAuditLogs: true,
 	LoggingIntegrationConfig: LoggingIntegrationConfig{
 		SumoLogic: &SumoLogicConfig{
-			Address: "http://www.hostnameupdated.com.br",
+			Address: "https://www.hostnameupdated.com.br/path",
 		},
 	},
 }

--- a/cyral/resource_cyral_integration_sumo_logic_test.go
+++ b/cyral/resource_cyral_integration_sumo_logic_test.go
@@ -13,12 +13,12 @@ const (
 
 var initialSumoLogicConfig SumoLogicIntegration = SumoLogicIntegration{
 	Name:    accTestName(integrationSumoLogicResourceName, "sumo-logic"),
-	Address: "sumologic.local/initial",
+	Address: "https://sumologic.local/initial",
 }
 
 var updatedSumoLogicConfig SumoLogicIntegration = SumoLogicIntegration{
 	Name:    accTestName(integrationSumoLogicResourceName, "sumo-logic-updated"),
-	Address: "sumologic.local/updated",
+	Address: "https://sumologic.local/updated",
 }
 
 func TestAccSumoLogicIntegrationResource(t *testing.T) {

--- a/cyral/resource_cyral_policy.go
+++ b/cyral/resource_cyral_policy.go
@@ -14,8 +14,9 @@ import (
 
 func resourcePolicy() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manages [policies](https://cyral.com/docs/reference/policy). See also: [Policy Rule](./policy_rule.md)." +
-			" For more information, see the [Policy Guide](https://cyral.com/docs/policy/overview).",
+		Description: "Manages [policies](https://cyral.com/docs/reference/policy). See also: " +
+			"[Policy Rule](./policy_rule.md). For more information, see the " +
+			"[Policy Guide](https://cyral.com/docs/policy/overview).",
 		CreateContext: resourcePolicyCreate,
 		ReadContext:   resourcePolicyRead,
 		UpdateContext: resourcePolicyUpdate,
@@ -27,9 +28,11 @@ func resourcePolicy() *schema.Resource {
 				Computed:    true,
 			},
 			"data": {
-				Description: "List that specify which data fields a policy manages. Each field is represented by the LABEL you established for it in your data map. The actual location of that data (the names of fields, columns, or databases that hold it) is listed in the data map.",
-				Type:        schema.TypeList,
-				Optional:    true,
+				Description: "List that specify which data fields a policy manages. Each field is represented by the LABEL " +
+					"you established for it in your data map. The actual location of that data (the names of fields, columns, " +
+					"or databases that hold it) is listed in the data map.",
+				Type:     schema.TypeList,
+				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
@@ -56,10 +59,21 @@ func resourcePolicy() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
+			"data_label_tags": {
+				Description: "List of tags that represent sets of data labels (established in your data map) that " +
+					"are used to specify the collections of data labels that the policy manages. For more information, " +
+					"see [The tags block of a policy](https://cyral.com/docs/policy/policy-structure#the-tags-block-of-a-policy)",
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"tags": {
-				Description: "Tags that can be used to organize and/or classify your policies (ex: `[your_tag1, your_tag2]`).",
-				Type:        schema.TypeList,
-				Optional:    true,
+				Description: "Metadata tags that can be used to organize and/or classify your policies " +
+					"(ex: `[your_tag1, your_tag2]`).",
+				Type:     schema.TypeList,
+				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
@@ -121,7 +135,7 @@ func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, m interface
 
 	response := Policy{}
 	if err := json.Unmarshal(body, &response); err != nil {
-		return createError(fmt.Sprintf("Unable to unmarshall JSON"), fmt.Sprintf("%v", err))
+		return createError("Unable to unmarshall JSON", fmt.Sprintf("%v", err))
 	}
 	log.Printf("[DEBUG] Response body (unmarshalled): %#v", response)
 
@@ -131,6 +145,7 @@ func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, m interface
 	d.Set("enabled", response.Meta.Enabled)
 	d.Set("last_updated", response.Meta.LastUpdated.String())
 	d.Set("name", response.Meta.Name)
+	d.Set("data_label_tags", response.Tags)
 	d.Set("tags", response.Meta.Tags)
 	d.Set("type", response.Meta.Type)
 	d.Set("version", response.Meta.Version)
@@ -185,12 +200,14 @@ func getStrListFromSchemaField(d *schema.ResourceData, field string) []string {
 
 func getPolicyInfoFromResource(d *schema.ResourceData) Policy {
 	data := getStrListFromSchemaField(d, "data")
-	tags := getStrListFromSchemaField(d, "tags")
+	dataLabelTags := getStrListFromSchemaField(d, "data_label_tags")
+	metadataTags := getStrListFromSchemaField(d, "tags")
 
 	policy := Policy{
 		Data: data,
+		Tags: dataLabelTags,
 		Meta: &PolicyMetadata{
-			Tags: tags,
+			Tags: metadataTags,
 		},
 	}
 

--- a/cyral/resource_cyral_policy.go
+++ b/cyral/resource_cyral_policy.go
@@ -37,7 +37,7 @@ func resourcePolicy() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"data_tags": {
+			"data_label_tags": {
 				Description: "List of tags that represent sets of data labels (established in your data map) that " +
 					"are used to specify the collections of data labels that the policy manages. For more information, " +
 					"see [The tags block of a policy](https://cyral.com/docs/policy/policy-structure#the-tags-block-of-a-policy)",
@@ -153,7 +153,7 @@ func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, m interface
 
 	d.Set("created", response.Meta.Created.String())
 	d.Set("data", response.Data)
-	d.Set("data_tags", response.Tags)
+	d.Set("data_label_tags", response.Tags)
 	d.Set("description", response.Meta.Description)
 	d.Set("enabled", response.Meta.Enabled)
 	d.Set("last_updated", response.Meta.LastUpdated.String())
@@ -219,7 +219,7 @@ func getStrListFromSchemaField(d *schema.ResourceData, field string) []string {
 
 func getPolicyInfoFromResource(d *schema.ResourceData) Policy {
 	data := getStrListFromSchemaField(d, "data")
-	dataTags := getStrListFromSchemaField(d, "data_tags")
+	dataTags := getStrListFromSchemaField(d, "data_label_tags")
 	metadataTags := getStrListFromSchemaField(d, "metadata_tags")
 	if len(metadataTags) == 0 {
 		metadataTags = getStrListFromSchemaField(d, "tags")

--- a/cyral/resource_cyral_policy.go
+++ b/cyral/resource_cyral_policy.go
@@ -37,6 +37,16 @@ func resourcePolicy() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"data_tags": {
+				Description: "List of tags that represent sets of data labels (established in your data map) that " +
+					"are used to specify the collections of data labels that the policy manages. For more information, " +
+					"see [The tags block of a policy](https://cyral.com/docs/policy/policy-structure#the-tags-block-of-a-policy)",
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"description": {
 				Description: "String that describes the policy (ex: `your_policy_description`).",
 				Type:        schema.TypeString,
@@ -58,16 +68,6 @@ func resourcePolicy() *schema.Resource {
 				Description: "Policy name that will be used internally in Control Plane (ex: `your_policy_name`).",
 				Type:        schema.TypeString,
 				Required:    true,
-			},
-			"data_label_tags": {
-				Description: "List of tags that represent sets of data labels (established in your data map) that " +
-					"are used to specify the collections of data labels that the policy manages. For more information, " +
-					"see [The tags block of a policy](https://cyral.com/docs/policy/policy-structure#the-tags-block-of-a-policy)",
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
 			},
 			"tags": {
 				Deprecated: "Use `metadata_tags` instead. This will be removed in the next major version of the provider.",
@@ -153,11 +153,11 @@ func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, m interface
 
 	d.Set("created", response.Meta.Created.String())
 	d.Set("data", response.Data)
+	d.Set("data_tags", response.Tags)
 	d.Set("description", response.Meta.Description)
 	d.Set("enabled", response.Meta.Enabled)
 	d.Set("last_updated", response.Meta.LastUpdated.String())
 	d.Set("name", response.Meta.Name)
-	d.Set("data_label_tags", response.Tags)
 	d.Set("type", response.Meta.Type)
 	d.Set("version", response.Meta.Version)
 	// Once the `tags` field is removed, this conditional logic should also be
@@ -219,7 +219,7 @@ func getStrListFromSchemaField(d *schema.ResourceData, field string) []string {
 
 func getPolicyInfoFromResource(d *schema.ResourceData) Policy {
 	data := getStrListFromSchemaField(d, "data")
-	dataLabelTags := getStrListFromSchemaField(d, "data_label_tags")
+	dataTags := getStrListFromSchemaField(d, "data_tags")
 	metadataTags := getStrListFromSchemaField(d, "metadata_tags")
 	if len(metadataTags) == 0 {
 		metadataTags = getStrListFromSchemaField(d, "tags")
@@ -227,7 +227,7 @@ func getPolicyInfoFromResource(d *schema.ResourceData) Policy {
 
 	policy := Policy{
 		Data: data,
-		Tags: dataLabelTags,
+		Tags: dataTags,
 		Meta: &PolicyMetadata{
 			Tags: metadataTags,
 		},

--- a/cyral/resource_cyral_policy_test.go
+++ b/cyral/resource_cyral_policy_test.go
@@ -82,11 +82,11 @@ func setupPolicyTest(integrationData Policy) (string, resource.TestCheckFunc) {
 			integrationData.Data[0],
 		),
 		resource.TestCheckResourceAttr(
-			"cyral_policy.policy_test", "data_tags.#",
+			"cyral_policy.policy_test", "data_label_tags.#",
 			fmt.Sprintf("%d", len(integrationData.Tags)),
 		),
 		resource.TestCheckResourceAttr(
-			"cyral_policy.policy_test", "data_tags.0",
+			"cyral_policy.policy_test", "data_label_tags.0",
 			integrationData.Tags[0],
 		),
 		resource.TestCheckResourceAttr(
@@ -109,7 +109,7 @@ func formatPolicyTestConfigIntoConfig(data Policy) string {
 		description = "%s"
 		enabled = %t
 		data = %s
-		data_tags = %s
+		data_label_tags = %s
 		metadata_tags = %s
 	}`,
 		data.Meta.Name,

--- a/cyral/resource_cyral_policy_test.go
+++ b/cyral/resource_cyral_policy_test.go
@@ -19,7 +19,7 @@ var initialPolicyConfig = Policy{
 		Tags:        []string{"tag"},
 	},
 	Data: []string{"data"},
-	Tags: []string{"DATA_LABEL_TAG_TEST"},
+	Tags: []string{"DATA_TAG_TEST"},
 }
 
 var updatedPolicyConfig = Policy{
@@ -30,7 +30,7 @@ var updatedPolicyConfig = Policy{
 		Tags:        []string{"tag-updated"},
 	},
 	Data: []string{"data-updated"},
-	Tags: []string{"DATA_LABEL_TAG_TEST_UPDATED"},
+	Tags: []string{"DATA_TAG_TEST_UPDATED"},
 }
 
 func TestAccPolicyResource(t *testing.T) {
@@ -82,11 +82,11 @@ func setupPolicyTest(integrationData Policy) (string, resource.TestCheckFunc) {
 			integrationData.Data[0],
 		),
 		resource.TestCheckResourceAttr(
-			"cyral_policy.policy_test", "data_label_tags.#",
+			"cyral_policy.policy_test", "data_tags.#",
 			fmt.Sprintf("%d", len(integrationData.Tags)),
 		),
 		resource.TestCheckResourceAttr(
-			"cyral_policy.policy_test", "data_label_tags.0",
+			"cyral_policy.policy_test", "data_tags.0",
 			integrationData.Tags[0],
 		),
 		resource.TestCheckResourceAttr(
@@ -109,7 +109,7 @@ func formatPolicyTestConfigIntoConfig(data Policy) string {
 		description = "%s"
 		enabled = %t
 		data = %s
-		data_label_tags = %s
+		data_tags = %s
 		metadata_tags = %s
 	}`,
 		data.Meta.Name,

--- a/cyral/resource_cyral_policy_test.go
+++ b/cyral/resource_cyral_policy_test.go
@@ -11,14 +11,6 @@ const (
 	policyResourceName = "policy"
 )
 
-type PolicyTestConfig struct {
-	Data        []string
-	Description string
-	Enabled     bool
-	Name        string
-	Tags        []string
-}
-
 var initialPolicyConfig = Policy{
 	Meta: &PolicyMetadata{
 		Name:        accTestName(policyResourceName, "test"),

--- a/cyral/resource_cyral_policy_test.go
+++ b/cyral/resource_cyral_policy_test.go
@@ -90,11 +90,11 @@ func setupPolicyTest(integrationData Policy) (string, resource.TestCheckFunc) {
 			integrationData.Tags[0],
 		),
 		resource.TestCheckResourceAttr(
-			"cyral_policy.policy_test", "tags.#",
+			"cyral_policy.policy_test", "metadata_tags.#",
 			fmt.Sprintf("%d", len(integrationData.Meta.Tags)),
 		),
 		resource.TestCheckResourceAttr(
-			"cyral_policy.policy_test", "tags.0",
+			"cyral_policy.policy_test", "metadata_tags.0",
 			integrationData.Meta.Tags[0],
 		),
 	)
@@ -110,7 +110,7 @@ func formatPolicyTestConfigIntoConfig(data Policy) string {
 		enabled = %t
 		data = %s
 		data_label_tags = %s
-		tags = %s
+		metadata_tags = %s
 	}`,
 		data.Meta.Name,
 		data.Meta.Description,

--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -37,7 +37,8 @@ resource "cyral_policy" "some_resource_name" {
 - `data_label_tags` (List of String) List of tags that represent sets of data labels (established in your data map) that are used to specify the collections of data labels that the policy manages. For more information, see [The tags block of a policy](https://cyral.com/docs/policy/policy-structure#the-tags-block-of-a-policy)
 - `description` (String) String that describes the policy (ex: `your_policy_description`).
 - `enabled` (Boolean) Boolean that causes a policy to be enabled or disabled.
-- `tags` (List of String) Metadata tags that can be used to organize and/or classify your policies (ex: `[your_tag1, your_tag2]`).
+- `metadata_tags` (List of String) Metadata tags that can be used to organize and/or classify your policies (ex: `[your_tag1, your_tag2]`).
+- `tags` (List of String, Deprecated) Metadata tags that can be used to organize and/or classify your policies (ex: `[your_tag1, your_tag2]`).
 
 ### Read-Only
 

--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -14,10 +14,11 @@ Manages [policies](https://cyral.com/docs/reference/policy). See also: [Policy R
 
 ```terraform
 resource "cyral_policy" "some_resource_name" {
-  data = [""]
+  name = ""
   description = ""
   enabled = true
-  name = ""
+  data = [""]
+  data_label_tags = [""]
   tags = [""]
 }
 ```
@@ -33,9 +34,10 @@ resource "cyral_policy" "some_resource_name" {
 ### Optional
 
 - `data` (List of String) List that specify which data fields a policy manages. Each field is represented by the LABEL you established for it in your data map. The actual location of that data (the names of fields, columns, or databases that hold it) is listed in the data map.
+- `data_label_tags` (List of String) List of tags that represent sets of data labels (established in your data map) that are used to specify the collections of data labels that the policy manages. For more information, see [The tags block of a policy](https://cyral.com/docs/policy/policy-structure#the-tags-block-of-a-policy)
 - `description` (String) String that describes the policy (ex: `your_policy_description`).
 - `enabled` (Boolean) Boolean that causes a policy to be enabled or disabled.
-- `tags` (List of String) Tags that can be used to organize and/or classify your policies (ex: `[your_tag1, your_tag2]`).
+- `tags` (List of String) Metadata tags that can be used to organize and/or classify your policies (ex: `[your_tag1, your_tag2]`).
 
 ### Read-Only
 

--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -18,7 +18,7 @@ resource "cyral_policy" "some_resource_name" {
   description = ""
   enabled = true
   data = [""]
-  data_label_tags = [""]
+  data_tags = [""]
   tags = [""]
 }
 ```
@@ -34,7 +34,7 @@ resource "cyral_policy" "some_resource_name" {
 ### Optional
 
 - `data` (List of String) List that specify which data fields a policy manages. Each field is represented by the LABEL you established for it in your data map. The actual location of that data (the names of fields, columns, or databases that hold it) is listed in the data map.
-- `data_label_tags` (List of String) List of tags that represent sets of data labels (established in your data map) that are used to specify the collections of data labels that the policy manages. For more information, see [The tags block of a policy](https://cyral.com/docs/policy/policy-structure#the-tags-block-of-a-policy)
+- `data_tags` (List of String) List of tags that represent sets of data labels (established in your data map) that are used to specify the collections of data labels that the policy manages. For more information, see [The tags block of a policy](https://cyral.com/docs/policy/policy-structure#the-tags-block-of-a-policy)
 - `description` (String) String that describes the policy (ex: `your_policy_description`).
 - `enabled` (Boolean) Boolean that causes a policy to be enabled or disabled.
 - `metadata_tags` (List of String) Metadata tags that can be used to organize and/or classify your policies (ex: `[your_tag1, your_tag2]`).

--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -18,7 +18,7 @@ resource "cyral_policy" "some_resource_name" {
   description = ""
   enabled = true
   data = [""]
-  data_tags = [""]
+  data_label_tags = [""]
   tags = [""]
 }
 ```
@@ -34,7 +34,7 @@ resource "cyral_policy" "some_resource_name" {
 ### Optional
 
 - `data` (List of String) List that specify which data fields a policy manages. Each field is represented by the LABEL you established for it in your data map. The actual location of that data (the names of fields, columns, or databases that hold it) is listed in the data map.
-- `data_tags` (List of String) List of tags that represent sets of data labels (established in your data map) that are used to specify the collections of data labels that the policy manages. For more information, see [The tags block of a policy](https://cyral.com/docs/policy/policy-structure#the-tags-block-of-a-policy)
+- `data_label_tags` (List of String) List of tags that represent sets of data labels (established in your data map) that are used to specify the collections of data labels that the policy manages. For more information, see [The tags block of a policy](https://cyral.com/docs/policy/policy-structure#the-tags-block-of-a-policy)
 - `description` (String) String that describes the policy (ex: `your_policy_description`).
 - `enabled` (Boolean) Boolean that causes a policy to be enabled or disabled.
 - `metadata_tags` (List of String) Metadata tags that can be used to organize and/or classify your policies (ex: `[your_tag1, your_tag2]`).

--- a/examples/resources/cyral_policy/resource.tf
+++ b/examples/resources/cyral_policy/resource.tf
@@ -1,7 +1,8 @@
 resource "cyral_policy" "some_resource_name" {
-  data = [""]
+  name = ""
   description = ""
   enabled = true
-  name = ""
+  data = [""]
+  data_label_tags = [""]
   tags = [""]
 }

--- a/examples/resources/cyral_policy/resource.tf
+++ b/examples/resources/cyral_policy/resource.tf
@@ -3,6 +3,6 @@ resource "cyral_policy" "some_resource_name" {
   description = ""
   enabled = true
   data = [""]
-  data_tags = [""]
+  data_label_tags = [""]
   tags = [""]
 }

--- a/examples/resources/cyral_policy/resource.tf
+++ b/examples/resources/cyral_policy/resource.tf
@@ -3,6 +3,6 @@ resource "cyral_policy" "some_resource_name" {
   description = ""
   enabled = true
   data = [""]
-  data_label_tags = [""]
+  data_tags = [""]
   tags = [""]
 }


### PR DESCRIPTION
## Description of the change

The current policy resource ([cyral_policy](https://github.com/cyralinc/terraform-provider-cyral/blob/main/cyral/resource_cyral_policy.go)) does not have a field for [data label tags](https://cyral.com/docs/v4.7/policy/policy-structure/#the-tags-block-of-a-policy) - it only has a `tags` field that refers to the policy metadata tags. That said, this PR adds a field for data label tags to the `cyral_policy` resource. This PR also fixes the sumologic tests that were failing after an update in the API that validates the sumologic address.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Jira issue referenced in commit message and/or PR title

### Testing

Tested by running automated tests and performing E2E manual tests. Automated tests result:
```log
go test github.com/cyralinc/terraform-provider-cyral/... -v -race -timeout 20m
?       github.com/cyralinc/terraform-provider-cyral    [no test files]
=== RUN   TestNewClient_WhenTLSSkipVerifyIsEnabled_ThenInsecureSkipVerifyIsTrue
2023/08/08 17:18:42 [DEBUG] Init NewClient
2023/08/08 17:18:42 [DEBUG] TokenSource: &{0xc0000a6d98 {0 0} <nil>}
2023/08/08 17:18:42 [DEBUG] End NewClient
--- PASS: TestNewClient_WhenTLSSkipVerifyIsEnabled_ThenInsecureSkipVerifyIsTrue (0.00s)
=== RUN   TestNewClient_WhenTLSSkipVerifyIsDisabled_ThenInsecureSkipVerifyIsFalse
2023/08/08 17:18:42 [DEBUG] Init NewClient
2023/08/08 17:18:42 [DEBUG] TokenSource: &{0xc0000a6de0 {0 0} <nil>}
2023/08/08 17:18:42 [DEBUG] End NewClient
--- PASS: TestNewClient_WhenTLSSkipVerifyIsDisabled_ThenInsecureSkipVerifyIsFalse (0.00s)
=== RUN   TestNewClient_WhenClientIDIsEmpty_ThenThrowError
2023/08/08 17:18:42 [DEBUG] Init NewClient
--- PASS: TestNewClient_WhenClientIDIsEmpty_ThenThrowError (0.00s)
=== RUN   TestNewClient_WhenClientSecretIsEmpty_ThenThrowError
2023/08/08 17:18:42 [DEBUG] Init NewClient
--- PASS: TestNewClient_WhenClientSecretIsEmpty_ThenThrowError (0.00s)
=== RUN   TestNewClient_WhenControlPlaneIsEmpty_ThenThrowError
2023/08/08 17:18:42 [DEBUG] Init NewClient
--- PASS: TestNewClient_WhenControlPlaneIsEmpty_ThenThrowError (0.00s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/client     (cached)
=== RUN   TestAccDatalabelDataSource
=== PAUSE TestAccDatalabelDataSource
=== RUN   TestAccIntegrationIdPSAMLDataSource
=== PAUSE TestAccIntegrationIdPSAMLDataSource
=== RUN   TestAccLoggingIntegrationDataSource
=== PAUSE TestAccLoggingIntegrationDataSource
=== RUN   TestAccRepositoryDataSource
=== PAUSE TestAccRepositoryDataSource
=== RUN   TestAccRoleDataSource
=== PAUSE TestAccRoleDataSource
=== RUN   TestAccSAMLCertificateDataSource
=== PAUSE TestAccSAMLCertificateDataSource
=== RUN   TestAccSAMLConfigurationDataSource
=== PAUSE TestAccSAMLConfigurationDataSource
=== RUN   TestAccSidecarBoundPortsDataSource
=== PAUSE TestAccSidecarBoundPortsDataSource
=== RUN   TestAccSidecarCftTemplateDataSource
=== PAUSE TestAccSidecarCftTemplateDataSource
=== RUN   TestAccSidecarIDDataSource
=== PAUSE TestAccSidecarIDDataSource
=== RUN   TestAccSidecarInstanceIDsDataSource
=== PAUSE TestAccSidecarInstanceIDsDataSource
=== RUN   TestAccSidecarListenerDataSource
=== PAUSE TestAccSidecarListenerDataSource
=== RUN   TestIntegrationsData_GetValue_Default
--- PASS: TestIntegrationsData_GetValue_Default (0.00s)
=== RUN   TestIntegrationsData_GetValue_Splunk
--- PASS: TestIntegrationsData_GetValue_Splunk (0.00s)
=== RUN   TestAccProvider
2023/08/08 19:13:41 [DEBUG] Init dataSourceSidecarListener
2023/08/08 19:13:41 [DEBUG] End dataSourceSidecarListener
--- PASS: TestAccProvider (0.01s)
=== RUN   TestAccDatalabelResource
=== PAUSE TestAccDatalabelResource
=== RUN   TestAccDatadogIntegrationResource
=== PAUSE TestAccDatadogIntegrationResource
=== RUN   TestAccELKIntegrationResource
=== PAUSE TestAccELKIntegrationResource
=== RUN   TestAccHCVaultIntegrationResource
=== PAUSE TestAccHCVaultIntegrationResource
=== RUN   TestAccIntegrationIdPSAMLDraftResource
=== PAUSE TestAccIntegrationIdPSAMLDraftResource
=== RUN   TestAccIntegrationIdPSAMLResource
=== PAUSE TestAccIntegrationIdPSAMLResource
=== RUN   TestAccIdPIntegrationResource
=== PAUSE TestAccIdPIntegrationResource
=== RUN   TestAccLogsIntegrationResourceCloudWatch
=== PAUSE TestAccLogsIntegrationResourceCloudWatch
=== RUN   TestAccLogsIntegrationResourceDataDog
=== PAUSE TestAccLogsIntegrationResourceDataDog
=== RUN   TestAccLogsIntegrationResourceElk
=== PAUSE TestAccLogsIntegrationResourceElk
=== RUN   TestAccLogsIntegrationResourceElkEmptyEsCredentials
=== PAUSE TestAccLogsIntegrationResourceElkEmptyEsCredentials
=== RUN   TestAccLogsIntegrationResourceSplunk
=== PAUSE TestAccLogsIntegrationResourceSplunk
=== RUN   TestAccLogsIntegrationResourceSumologic
=== PAUSE TestAccLogsIntegrationResourceSumologic
=== RUN   TestAccLogsIntegrationResourceFluentbit
=== PAUSE TestAccLogsIntegrationResourceFluentbit
=== RUN   TestAccLogstashIntegrationResource
=== PAUSE TestAccLogstashIntegrationResource
=== RUN   TestAccLookerIntegrationResource
=== PAUSE TestAccLookerIntegrationResource
=== RUN   TestAccDuoMFAIntegrationResource
=== PAUSE TestAccDuoMFAIntegrationResource
=== RUN   TestAccPagerDutyIntegrationResource
=== PAUSE TestAccPagerDutyIntegrationResource
=== RUN   TestAccSlackAlertsIntegrationResource
=== PAUSE TestAccSlackAlertsIntegrationResource
=== RUN   TestAccSplunkIntegrationResource
=== PAUSE TestAccSplunkIntegrationResource
=== RUN   TestAccSumoLogicIntegrationResource
=== PAUSE TestAccSumoLogicIntegrationResource
=== RUN   TestAccMsTeamsIntegrationResource
=== PAUSE TestAccMsTeamsIntegrationResource
=== RUN   TestAccPolicyRuleResource
=== PAUSE TestAccPolicyRuleResource
=== RUN   TestPolicyRuleResourceUpgradeV0
--- PASS: TestPolicyRuleResourceUpgradeV0 (0.00s)
=== RUN   TestAccPolicyResource
=== PAUSE TestAccPolicyResource
=== RUN   TestAccRepositoryAccessGatewayResource
=== PAUSE TestAccRepositoryAccessGatewayResource
=== RUN   TestAccRepositoryAccessRulesResource
=== PAUSE TestAccRepositoryAccessRulesResource
=== RUN   TestAccRepositoryBindingResource
=== PAUSE TestAccRepositoryBindingResource
=== RUN   TestAccRepositoryConfAnalysisResource
=== PAUSE TestAccRepositoryConfAnalysisResource
=== RUN   TestRepositoryConfAnalysisResourceUpgradeV0
--- PASS: TestRepositoryConfAnalysisResourceUpgradeV0 (0.00s)
=== RUN   TestAccRepositoryConfAuthResource
=== PAUSE TestAccRepositoryConfAuthResource
=== RUN   TestRepositoryConfAuthResourceUpgradeV0
--- PASS: TestRepositoryConfAuthResourceUpgradeV0 (0.00s)
=== RUN   TestAccRepositoryDatamapResource
=== PAUSE TestAccRepositoryDatamapResource
=== RUN   TestAccRepositoryNetworkAccessPolicyResource
=== PAUSE TestAccRepositoryNetworkAccessPolicyResource
=== RUN   TestAccRepositoryResource
=== PAUSE TestAccRepositoryResource
=== RUN   TestAccRepositoryUserAccountResource
=== PAUSE TestAccRepositoryUserAccountResource
=== RUN   TestAccRoleSSOGroupsResource
=== PAUSE TestAccRoleSSOGroupsResource
=== RUN   TestRoleSSOGroupsResourceUpgradeV0
--- PASS: TestRoleSSOGroupsResourceUpgradeV0 (0.00s)
=== RUN   TestAccRoleResource
=== PAUSE TestAccRoleResource
=== RUN   TestAccSidecarCredentialsResource
=== PAUSE TestAccSidecarCredentialsResource
=== RUN   TestSidecarListenerResource
=== PAUSE TestSidecarListenerResource
=== RUN   TestAccSidecarResource
=== PAUSE TestAccSidecarResource
=== RUN   TestElementsMatch
--- PASS: TestElementsMatch (0.00s)
=== CONT  TestAccIntegrationIdPSAMLDataSource
=== CONT  TestAccLogsIntegrationResourceSumologic
=== CONT  TestAccRepositoryBindingResource
=== CONT  TestAccSidecarResource
=== CONT  TestSidecarListenerResource
=== CONT  TestAccSidecarCredentialsResource
=== CONT  TestAccRoleResource
=== CONT  TestAccRepositoryUserAccountResource
--- PASS: TestAccSidecarCredentialsResource (8.09s)
=== CONT  TestAccRepositoryResource
=== CONT  TestAccRepositoryNetworkAccessPolicyResource
--- PASS: TestAccLogsIntegrationResourceSumologic (8.65s)
=== CONT  TestAccRoleSSOGroupsResource
--- PASS: TestAccRepositoryBindingResource (12.13s)
=== CONT  TestAccRepositoryConfAuthResource
--- PASS: TestAccIntegrationIdPSAMLDataSource (18.09s)
=== CONT  TestAccRepositoryConfAnalysisResource
--- PASS: TestAccRoleResource (22.13s)
=== CONT  TestAccRepositoryDatamapResource
--- PASS: TestAccRoleSSOGroupsResource (13.30s)
--- PASS: TestAccRepositoryResource (20.24s)
=== CONT  TestAccDatadogIntegrationResource
--- PASS: TestAccSidecarResource (29.09s)
=== CONT  TestAccLogsIntegrationResourceFluentbit
--- PASS: TestAccRepositoryNetworkAccessPolicyResource (21.92s)
=== CONT  TestAccLogsIntegrationResourceElkEmptyEsCredentials
--- PASS: TestAccRepositoryConfAnalysisResource (8.50s)
=== CONT  TestAccLogsIntegrationResourceSplunk
--- PASS: TestAccRepositoryConfAuthResource (15.07s)
=== CONT  TestAccLogsIntegrationResourceElk
--- PASS: TestSidecarListenerResource (34.23s)
=== CONT  TestAccLogsIntegrationResourceDataDog
=== CONT  TestAccLogsIntegrationResourceCloudWatch
--- PASS: TestAccDatadogIntegrationResource (6.92s)
--- PASS: TestAccLogsIntegrationResourceFluentbit (6.23s)
=== CONT  TestAccIntegrationIdPSAMLResource
=== CONT  TestAccIdPIntegrationResource
--- PASS: TestAccLogsIntegrationResourceSplunk (9.09s)
=== CONT  TestAccHCVaultIntegrationResource
--- PASS: TestAccLogsIntegrationResourceElkEmptyEsCredentials (9.37s)
--- PASS: TestAccLogsIntegrationResourceElk (9.45s)
=== CONT  TestAccELKIntegrationResource
--- PASS: TestAccLogsIntegrationResourceDataDog (8.52s)
=== CONT  TestAccIntegrationIdPSAMLDraftResource
--- PASS: TestAccLogsIntegrationResourceCloudWatch (9.37s)
=== CONT  TestAccSplunkIntegrationResource
--- PASS: TestAccHCVaultIntegrationResource (8.11s)
=== CONT  TestAccRepositoryAccessGatewayResource
--- PASS: TestAccRepositoryDatamapResource (23.44s)
=== CONT  TestAccPolicyResource
--- PASS: TestAccRepositoryUserAccountResource (49.70s)
=== CONT  TestAccRepositoryAccessRulesResource
--- PASS: TestAccELKIntegrationResource (8.04s)
=== CONT  TestAccPolicyRuleResource
--- PASS: TestAccSplunkIntegrationResource (8.23s)
=== CONT  TestAccSumoLogicIntegrationResource
--- PASS: TestAccIntegrationIdPSAMLDraftResource (12.08s)
=== CONT  TestAccSidecarBoundPortsDataSource
--- PASS: TestAccPolicyResource (7.88s)
=== CONT  TestAccSidecarListenerDataSource
=== CONT  TestAccRoleDataSource
--- PASS: TestAccIntegrationIdPSAMLResource (23.07s)
--- PASS: TestAccSumoLogicIntegrationResource (7.96s)
=== CONT  TestAccSidecarInstanceIDsDataSource
--- PASS: TestAccRoleDataSource (5.67s)
=== CONT  TestAccDatalabelResource
--- PASS: TestAccRepositoryAccessRulesResource (15.21s)
=== CONT  TestAccSAMLCertificateDataSource
--- PASS: TestAccSidecarInstanceIDsDataSource (7.38s)
=== CONT  TestAccSidecarCftTemplateDataSource
=== CONT  TestAccSAMLConfigurationDataSource
--- PASS: TestAccSidecarBoundPortsDataSource (14.14s)
=== CONT  TestAccSidecarIDDataSource
--- PASS: TestAccSAMLCertificateDataSource (4.65s)
--- PASS: TestAccRepositoryAccessGatewayResource (21.72s)
=== CONT  TestAccRepositoryDataSource
--- PASS: TestAccPolicyRuleResource (21.07s)
=== CONT  TestAccLoggingIntegrationDataSource
=== CONT  TestAccSlackAlertsIntegrationResource
--- PASS: TestAccDatalabelResource (8.76s)
--- PASS: TestAccSidecarListenerDataSource (18.80s)
=== CONT  TestAccDatalabelDataSource
--- PASS: TestAccSidecarIDDataSource (6.76s)
=== CONT  TestAccPagerDutyIntegrationResource
=== CONT  TestAccMsTeamsIntegrationResource
--- PASS: TestAccSAMLConfigurationDataSource (9.44s)
=== CONT  TestAccLookerIntegrationResource
--- PASS: TestAccSlackAlertsIntegrationResource (6.76s)
--- PASS: TestAccSidecarCftTemplateDataSource (11.65s)
=== CONT  TestAccDuoMFAIntegrationResource
--- PASS: TestAccIdPIntegrationResource (41.87s)
=== CONT  TestAccLogstashIntegrationResource
--- PASS: TestAccLoggingIntegrationDataSource (10.90s)
--- PASS: TestAccPagerDutyIntegrationResource (8.39s)
--- PASS: TestAccRepositoryDataSource (15.40s)
--- PASS: TestAccMsTeamsIntegrationResource (7.69s)
--- PASS: TestAccLookerIntegrationResource (7.85s)
--- PASS: TestAccDuoMFAIntegrationResource (8.37s)
--- PASS: TestAccLogstashIntegrationResource (13.69s)
--- PASS: TestAccDatalabelDataSource (20.13s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral      96.073s
```
