### PR TITLE
ENG-12179: Add classification rule field to data label resource

### DIFF
--- a/cyral/data_source_cyral_sidecar_cft_template.go
+++ b/cyral/data_source_cyral_sidecar_cft_template.go
@@ -16,6 +16,8 @@ const CloudFormationDeploymentMethod = "cloudFormation"
 
 func dataSourceSidecarCftTemplate() *schema.Resource {
 	return &schema.Resource{
+		DeprecationMessage: "This data source was deprecated. It will be removed in the next major version of " +
+			"the provider.",
 		Description: "Retrieves the CloudFormation deployment template for a given sidecar. This data source only " +
 			"supports sidecars with `cloudFormation` deployment method. For Terraform template, use our " +
 			"`terraform-cyral-sidecar-aws` module.",

--- a/cyral/model_datalabel.go
+++ b/cyral/model_datalabel.go
@@ -1,17 +1,36 @@
 package cyral
 
 const (
-	dataLabelTypeUnknown    = "UNKNOWN"
+	typeUnknown    = "UNKNOWN"
+	statusEnabled  = "ENABLED"
+	statusDisabled = "DISABLED"
+	// Data label type
 	dataLabelTypePredefined = "PREDEFINED"
 	dataLabelTypeCustom     = "CUSTOM"
-	defaultDataLabelType    = dataLabelTypeUnknown
+	defaultDataLabelType    = typeUnknown
+	// Classification rule type
+	classificationRuleTypeRego = "REGO"
 )
 
 func dataLabelTypes() []string {
 	return []string{
-		dataLabelTypeUnknown,
+		typeUnknown,
 		dataLabelTypePredefined,
 		dataLabelTypeCustom,
+	}
+}
+
+func classificationRuleTypes() []string {
+	return []string{
+		typeUnknown,
+		classificationRuleTypeRego,
+	}
+}
+
+func classificationRuleStatus() []string {
+	return []string{
+		statusEnabled,
+		statusDisabled,
 	}
 }
 

--- a/cyral/resource_cyral_datalabel.go
+++ b/cyral/resource_cyral_datalabel.go
@@ -53,6 +53,7 @@ func resourceDatalabel() *schema.Resource {
 							Description: "Type of the classification rule. Valid values are: `UNKNOWN` and `REGO`.",
 							Type:        schema.TypeString,
 							Optional:    true,
+							Default:     "UNKNOWN",
 						},
 						"rule_code": {
 							Description: "Actual code of the classification rule. For example, this attribute may contain " +
@@ -64,6 +65,7 @@ func resourceDatalabel() *schema.Resource {
 							Description: "Status of the classification rule. Valid values are: `ENABLED` and  `DISABLED`.",
 							Type:        schema.TypeString,
 							Optional:    true,
+							Default:     "ENABLED",
 						},
 					},
 				},

--- a/cyral/resource_cyral_datalabel.go
+++ b/cyral/resource_cyral_datalabel.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/cyralinc/terraform-provider-cyral/client"
 )
@@ -52,9 +53,10 @@ func resourceDatalabel() *schema.Resource {
 						"rule_type": {
 							Description: "Type of the classification rule. Valid values are: `UNKNOWN` and `REGO`. Defaults " +
 								"to `UNKNOWN`.",
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  "UNKNOWN",
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "UNKNOWN",
+							ValidateFunc: validation.StringInSlice(classificationRuleTypes(), false),
 						},
 						"rule_code": {
 							Description: "Actual code of the classification rule. For example, this attribute may contain " +
@@ -65,9 +67,10 @@ func resourceDatalabel() *schema.Resource {
 						"rule_status": {
 							Description: "Status of the classification rule. Valid values are: `ENABLED` and  `DISABLED`. " +
 								"Defaults to `ENABLED`.",
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  "ENABLED",
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "ENABLED",
+							ValidateFunc: validation.StringInSlice(classificationRuleStatus(), false),
 						},
 					},
 				},

--- a/cyral/resource_cyral_datalabel.go
+++ b/cyral/resource_cyral_datalabel.go
@@ -13,19 +13,6 @@ import (
 	"github.com/cyralinc/terraform-provider-cyral/client"
 )
 
-func writeDataLabelToResourceSchema(label DataLabel, d *schema.ResourceData) error {
-	if err := d.Set("description", label.Description); err != nil {
-		return err
-	}
-
-	tagIfaces := label.TagsAsInterface()
-	if err := d.Set("tags", tagIfaces); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func resourceDatalabel() *schema.Resource {
 	return &schema.Resource{
 		Description:   "Manages data labels. Data labels are part of the Cyral [Data Map](https://cyral.com/docs/policy/datamap).",
@@ -53,12 +40,40 @@ func resourceDatalabel() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"classification_rule": {
+				Description: "Classification rules are used by the " +
+					"[Automatic Data Map](https://cyral.com/docs/policy/automatic-datamap) feature to automatically map " +
+					"data locations to labels. Currently, only `PREDEFINED` labels have classification rules.",
+				Optional: true,
+				Type:     schema.TypeSet,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"rule_type": {
+							Description: "Type of the classification rule. Valid values are: `UNKNOWN` and `REGO`.",
+							Type:        schema.TypeString,
+							Optional:    true,
+						},
+						"rule_code": {
+							Description: "Actual code of the classification rule. For example, this attribute may contain " +
+								"REGO code for `REGO`-type classification rules.",
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"rule_status": {
+							Description: "Status of the classification rule. Valid values are: `ENABLED` and  `DISABLED`.",
+							Type:        schema.TypeString,
+							Optional:    true,
+						},
+					},
+				},
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: func(
 				ctx context.Context,
 				d *schema.ResourceData,
-				m interface{},
+				m any,
 			) ([]*schema.ResourceData, error) {
 				d.Set("name", d.Id())
 				return []*schema.ResourceData{d}, nil
@@ -67,7 +82,7 @@ func resourceDatalabel() *schema.Resource {
 	}
 }
 
-func resourceDatalabelCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceDatalabelCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	log.Printf("[DEBUG] Init resourceDatalabelCreate")
 	c := m.(*client.Client)
 
@@ -88,7 +103,7 @@ func resourceDatalabelCreate(ctx context.Context, d *schema.ResourceData, m inte
 	return resourceDatalabelRead(ctx, d, m)
 }
 
-func resourceDatalabelRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceDatalabelRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	log.Printf("[DEBUG] Init resourceDatalabelRead")
 	c := m.(*client.Client)
 
@@ -115,7 +130,7 @@ func resourceDatalabelRead(ctx context.Context, d *schema.ResourceData, m interf
 	return diag.Diagnostics{}
 }
 
-func resourceDatalabelUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceDatalabelUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	log.Printf("[DEBUG] Init resourceDatalabelUpdate")
 	c := m.(*client.Client)
 
@@ -134,7 +149,7 @@ func resourceDatalabelUpdate(ctx context.Context, d *schema.ResourceData, m inte
 	return resourceDatalabelRead(ctx, d, m)
 }
 
-func resourceDatalabelDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceDatalabelDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	log.Printf("[DEBUG] Init resourceDatalabelDelete")
 	c := m.(*client.Client)
 
@@ -153,15 +168,45 @@ func resourceDatalabelDelete(ctx context.Context, d *schema.ResourceData, m inte
 
 func getDataLabelFromResource(d *schema.ResourceData) DataLabel {
 	var tags []string
-	tagIfaces := d.Get("tags").([]interface{})
+	tagIfaces := d.Get("tags").([]any)
 	for _, tagIface := range tagIfaces {
 		tags = append(tags, tagIface.(string))
 	}
 
-	return DataLabel{
-		Name:        d.Get("name").(string),
-		Type:        dataLabelTypeCustom,
-		Description: d.Get("description").(string),
-		Tags:        tags,
+	var classificationRule *DataLabelClassificationRule
+	classificationRuleList := d.Get("classification_rule").(*schema.Set).List()
+	if len(classificationRuleList) > 0 {
+		classificationRuleMap := classificationRuleList[0].(map[string]any)
+		classificationRule = &DataLabelClassificationRule{
+			RuleType:   classificationRuleMap["rule_type"].(string),
+			RuleCode:   classificationRuleMap["rule_code"].(string),
+			RuleStatus: classificationRuleMap["rule_status"].(string),
+		}
 	}
+
+	return DataLabel{
+		Name:               d.Get("name").(string),
+		Type:               dataLabelTypeCustom,
+		Description:        d.Get("description").(string),
+		Tags:               tags,
+		ClassificationRule: classificationRule,
+	}
+}
+
+func writeDataLabelToResourceSchema(label DataLabel, d *schema.ResourceData) error {
+	if err := d.Set("description", label.Description); err != nil {
+		return fmt.Errorf("error setting 'description' field: %w", err)
+	}
+
+	tagIfaces := label.TagsAsInterface()
+	if err := d.Set("tags", tagIfaces); err != nil {
+		return fmt.Errorf("error setting 'tags' field: %w", err)
+	}
+
+	classificationRule := label.ClassificationRuleAsInterface()
+	if err := d.Set("classification_rule", classificationRule); err != nil {
+		return fmt.Errorf("error setting 'classification_rule' field: %w", err)
+	}
+
+	return nil
 }

--- a/cyral/resource_cyral_datalabel.go
+++ b/cyral/resource_cyral_datalabel.go
@@ -43,17 +43,18 @@ func resourceDatalabel() *schema.Resource {
 			"classification_rule": {
 				Description: "Classification rules are used by the " +
 					"[Automatic Data Map](https://cyral.com/docs/policy/automatic-datamap) feature to automatically map " +
-					"data locations to labels. Currently, only `PREDEFINED` labels have classification rules.",
+					"data locations to labels.",
 				Optional: true,
 				Type:     schema.TypeSet,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"rule_type": {
-							Description: "Type of the classification rule. Valid values are: `UNKNOWN` and `REGO`.",
-							Type:        schema.TypeString,
-							Optional:    true,
-							Default:     "UNKNOWN",
+							Description: "Type of the classification rule. Valid values are: `UNKNOWN` and `REGO`. Defaults " +
+								"to `UNKNOWN`.",
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "UNKNOWN",
 						},
 						"rule_code": {
 							Description: "Actual code of the classification rule. For example, this attribute may contain " +
@@ -62,10 +63,11 @@ func resourceDatalabel() *schema.Resource {
 							Optional: true,
 						},
 						"rule_status": {
-							Description: "Status of the classification rule. Valid values are: `ENABLED` and  `DISABLED`.",
-							Type:        schema.TypeString,
-							Optional:    true,
-							Default:     "ENABLED",
+							Description: "Status of the classification rule. Valid values are: `ENABLED` and  `DISABLED`. " +
+								"Defaults to `ENABLED`.",
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "ENABLED",
 						},
 					},
 				},

--- a/cyral/resource_cyral_datalabel_test.go
+++ b/cyral/resource_cyral_datalabel_test.go
@@ -97,23 +97,30 @@ func datalabelConfigResourceFullName(resName string) string {
 }
 
 func formatDataLabelIntoConfig(resName string, dataLabel *DataLabel) string {
+	var classificationRuleConfig string
+	if dataLabel.ClassificationRule != nil {
+		classificationRuleConfig = fmt.Sprintf(`
+		classification_rule {
+			rule_type = "%s"
+			rule_code = "%s"
+			rule_status = "%s"
+		}`,
+			dataLabel.ClassificationRule.RuleType,
+			dataLabel.ClassificationRule.RuleCode,
+			dataLabel.ClassificationRule.RuleStatus,
+		)
+	}
 	return fmt.Sprintf(`
 	resource "cyral_datalabel" "%s" {
 		name  = "%s"
 		description = "%s"
 		tags = %s
-		classification_rule {
-			rule_type = "%s"
-			rule_code = "%s"
-			rule_status = "%s"
-		}
+		%s
 	}`,
 		resName,
 		dataLabel.Name,
 		dataLabel.Description,
 		listToStr(dataLabel.Tags),
-		dataLabel.ClassificationRule.RuleType,
-		dataLabel.ClassificationRule.RuleCode,
-		dataLabel.ClassificationRule.RuleStatus,
+		classificationRuleConfig,
 	)
 }

--- a/cyral/resource_cyral_datalabel_test.go
+++ b/cyral/resource_cyral_datalabel_test.go
@@ -16,6 +16,11 @@ func initialDataLabelConfig() *DataLabel {
 		Name:        accTestName(datalabelResourceName, "label1"),
 		Description: "label1-description",
 		Tags:        []string{"tag1", "tag2"},
+		ClassificationRule: &DataLabelClassificationRule{
+			RuleType:   "UNKNOWN",
+			RuleCode:   "",
+			RuleStatus: "ENABLED",
+		},
 	}
 }
 
@@ -24,6 +29,11 @@ func updatedDataLabelConfig() *DataLabel {
 		Name:        accTestName(datalabelResourceName, "label2"),
 		Description: "label2-description",
 		Tags:        []string{"tag1", "tag2"},
+		ClassificationRule: &DataLabelClassificationRule{
+			RuleType:   "REGO",
+			RuleCode:   "int main() {cout << 'Hello World' << endl; return 0;}",
+			RuleStatus: "DISABLED",
+		},
 	}
 }
 
@@ -59,12 +69,24 @@ func setupDatalabelTest(t *testing.T, resName string, dataLabel *DataLabel) (str
 	resourceFullName := datalabelConfigResourceFullName(resName)
 
 	testFunction := resource.ComposeTestCheckFunc(
-		resource.TestCheckResourceAttr(resourceFullName,
-			"name", dataLabel.Name),
-		resource.TestCheckResourceAttr(resourceFullName,
-			"description", dataLabel.Description),
-		resource.TestCheckResourceAttr(resourceFullName,
-			"tags.#", "2"),
+		resource.TestCheckResourceAttr(resourceFullName, "name", dataLabel.Name),
+		resource.TestCheckResourceAttr(resourceFullName, "description", dataLabel.Description),
+		resource.TestCheckResourceAttr(resourceFullName, "tags.#", "2"),
+		resource.TestCheckResourceAttr(
+			resourceFullName,
+			"classification_rule.0.rule_type",
+			dataLabel.ClassificationRule.RuleType,
+		),
+		resource.TestCheckResourceAttr(
+			resourceFullName,
+			"classification_rule.0.rule_code",
+			dataLabel.ClassificationRule.RuleCode,
+		),
+		resource.TestCheckResourceAttr(
+			resourceFullName,
+			"classification_rule.0.rule_status",
+			dataLabel.ClassificationRule.RuleStatus,
+		),
 	)
 
 	return configuration, testFunction
@@ -80,6 +102,18 @@ func formatDataLabelIntoConfig(resName string, dataLabel *DataLabel) string {
 		name  = "%s"
 		description = "%s"
 		tags = %s
-	}`, resName, dataLabel.Name, dataLabel.Description,
-		listToStr(dataLabel.Tags))
+		classification_rule {
+			rule_type = "%s"
+			rule_code = "%s"
+			rule_status = "%s"
+		}
+	}`,
+		resName,
+		dataLabel.Name,
+		dataLabel.Description,
+		listToStr(dataLabel.Tags),
+		dataLabel.ClassificationRule.RuleType,
+		dataLabel.ClassificationRule.RuleCode,
+		dataLabel.ClassificationRule.RuleStatus,
+	)
 }

--- a/docs/data-sources/sidecar_cft_template.md
+++ b/docs/data-sources/sidecar_cft_template.md
@@ -1,6 +1,6 @@
 # cyral_sidecar_cft_template (Data Source)
 
-Retrieves the CloudFormation deployment template for a given sidecar. This data source only supports sidecars with `cloudFormation` deployment method. For Terraform template, use our `terraform-cyral-sidecar-aws` module.
+~> **DEPRECATED** This data source was deprecated. It will be removed in the next major version of the provider.
 
 ## Example Usage
 

--- a/docs/resources/datalabel.md
+++ b/docs/resources/datalabel.md
@@ -17,6 +17,11 @@ resource "cyral_datalabel" "NAME" {
   name        = "NAME"
   description = "Customer name"
   tags        = ["PII", "SENSITIVE"]
+  classification_rule {
+    rule_type = "REGO"
+    rule_code = "some-rego-code"
+    rule_status = "ENABLED"
+  }
 }
 ```
 

--- a/docs/resources/datalabel.md
+++ b/docs/resources/datalabel.md
@@ -30,9 +30,20 @@ resource "cyral_datalabel" "NAME" {
 
 ### Optional
 
+- `classification_rule` (Block Set, Max: 1) Classification rules are used by the [Automatic Data Map](https://cyral.com/docs/policy/automatic-datamap) feature to automatically map data locations to labels. (see [below for nested schema](#nestedblock--classification_rule))
 - `description` (String) Description of the data label.
 - `tags` (List of String) Tags that can be used to categorize data labels.
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--classification_rule"></a>
+
+### Nested Schema for `classification_rule`
+
+Optional:
+
+- `rule_code` (String) Actual code of the classification rule. For example, this attribute may contain REGO code for `REGO`-type classification rules.
+- `rule_status` (String) Status of the classification rule. Valid values are: `ENABLED` and `DISABLED`. Defaults to `ENABLED`.
+- `rule_type` (String) Type of the classification rule. Valid values are: `UNKNOWN` and `REGO`. Defaults to `UNKNOWN`.

--- a/examples/resources/cyral_datalabel/resource.tf
+++ b/examples/resources/cyral_datalabel/resource.tf
@@ -2,4 +2,9 @@ resource "cyral_datalabel" "NAME" {
   name        = "NAME"
   description = "Customer name"
   tags        = ["PII", "SENSITIVE"]
+  classification_rule {
+    rule_type = "REGO"
+    rule_code = "some-rego-code"
+    rule_status = "ENABLED"
+  }
 }


### PR DESCRIPTION
## Description of the change

This PR contains the following changes:
- Adds `classification_rule` field to data label resource
- Deprecates `cyral_sidecar_cft_template` data source since it is no longer valid for new sidecars

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Jira issue referenced in commit message and/or PR title

### Testing

Automated tests and manual E2E tests. See automated tests result below:
```log
go test github.com/cyralinc/terraform-provider-cyral/... -v -race -timeout 20m
?       github.com/cyralinc/terraform-provider-cyral    [no test files]
=== RUN   TestNewClient_WhenTLSSkipVerifyIsEnabled_ThenInsecureSkipVerifyIsTrue
2023/08/08 17:18:42 [DEBUG] Init NewClient
2023/08/08 17:18:42 [DEBUG] TokenSource: &{0xc0000a6d98 {0 0} <nil>}
2023/08/08 17:18:42 [DEBUG] End NewClient
--- PASS: TestNewClient_WhenTLSSkipVerifyIsEnabled_ThenInsecureSkipVerifyIsTrue (0.00s)
=== RUN   TestNewClient_WhenTLSSkipVerifyIsDisabled_ThenInsecureSkipVerifyIsFalse
2023/08/08 17:18:42 [DEBUG] Init NewClient
2023/08/08 17:18:42 [DEBUG] TokenSource: &{0xc0000a6de0 {0 0} <nil>}
2023/08/08 17:18:42 [DEBUG] End NewClient
--- PASS: TestNewClient_WhenTLSSkipVerifyIsDisabled_ThenInsecureSkipVerifyIsFalse (0.00s)
=== RUN   TestNewClient_WhenClientIDIsEmpty_ThenThrowError
2023/08/08 17:18:42 [DEBUG] Init NewClient
--- PASS: TestNewClient_WhenClientIDIsEmpty_ThenThrowError (0.00s)
=== RUN   TestNewClient_WhenClientSecretIsEmpty_ThenThrowError
2023/08/08 17:18:42 [DEBUG] Init NewClient
--- PASS: TestNewClient_WhenClientSecretIsEmpty_ThenThrowError (0.00s)
=== RUN   TestNewClient_WhenControlPlaneIsEmpty_ThenThrowError
2023/08/08 17:18:42 [DEBUG] Init NewClient
--- PASS: TestNewClient_WhenControlPlaneIsEmpty_ThenThrowError (0.00s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/client     (cached)
=== RUN   TestAccDatalabelDataSource
=== PAUSE TestAccDatalabelDataSource
=== RUN   TestAccIntegrationIdPSAMLDataSource
=== PAUSE TestAccIntegrationIdPSAMLDataSource
=== RUN   TestAccLoggingIntegrationDataSource
=== PAUSE TestAccLoggingIntegrationDataSource
=== RUN   TestAccRepositoryDataSource
=== PAUSE TestAccRepositoryDataSource
=== RUN   TestAccRoleDataSource
=== PAUSE TestAccRoleDataSource
=== RUN   TestAccSAMLCertificateDataSource
=== PAUSE TestAccSAMLCertificateDataSource
=== RUN   TestAccSAMLConfigurationDataSource
=== PAUSE TestAccSAMLConfigurationDataSource
=== RUN   TestAccSidecarBoundPortsDataSource
=== PAUSE TestAccSidecarBoundPortsDataSource
=== RUN   TestAccSidecarCftTemplateDataSource
=== PAUSE TestAccSidecarCftTemplateDataSource
=== RUN   TestAccSidecarIDDataSource
=== PAUSE TestAccSidecarIDDataSource
=== RUN   TestAccSidecarInstanceIDsDataSource
=== PAUSE TestAccSidecarInstanceIDsDataSource
=== RUN   TestAccSidecarListenerDataSource
=== PAUSE TestAccSidecarListenerDataSource
=== RUN   TestIntegrationsData_GetValue_Default
--- PASS: TestIntegrationsData_GetValue_Default (0.00s)
=== RUN   TestIntegrationsData_GetValue_Splunk
--- PASS: TestIntegrationsData_GetValue_Splunk (0.00s)
=== RUN   TestAccProvider
2023/08/10 20:24:32 [DEBUG] Init dataSourceSidecarListener
2023/08/10 20:24:32 [DEBUG] End dataSourceSidecarListener
--- PASS: TestAccProvider (0.01s)
=== RUN   TestAccDatalabelResource
=== PAUSE TestAccDatalabelResource
=== RUN   TestAccDatadogIntegrationResource
=== PAUSE TestAccDatadogIntegrationResource
=== RUN   TestAccELKIntegrationResource
=== PAUSE TestAccELKIntegrationResource
=== RUN   TestAccHCVaultIntegrationResource
=== PAUSE TestAccHCVaultIntegrationResource
=== RUN   TestAccIntegrationIdPSAMLDraftResource
=== PAUSE TestAccIntegrationIdPSAMLDraftResource
=== RUN   TestAccIntegrationIdPSAMLResource
=== PAUSE TestAccIntegrationIdPSAMLResource
=== RUN   TestAccIdPIntegrationResource
=== PAUSE TestAccIdPIntegrationResource
=== RUN   TestAccLogsIntegrationResourceCloudWatch
=== PAUSE TestAccLogsIntegrationResourceCloudWatch
=== RUN   TestAccLogsIntegrationResourceDataDog
=== PAUSE TestAccLogsIntegrationResourceDataDog
=== RUN   TestAccLogsIntegrationResourceElk
=== PAUSE TestAccLogsIntegrationResourceElk
=== RUN   TestAccLogsIntegrationResourceElkEmptyEsCredentials
=== PAUSE TestAccLogsIntegrationResourceElkEmptyEsCredentials
=== RUN   TestAccLogsIntegrationResourceSplunk
=== PAUSE TestAccLogsIntegrationResourceSplunk
=== RUN   TestAccLogsIntegrationResourceSumologic
=== PAUSE TestAccLogsIntegrationResourceSumologic
=== RUN   TestAccLogsIntegrationResourceFluentbit
=== PAUSE TestAccLogsIntegrationResourceFluentbit
=== RUN   TestAccLogstashIntegrationResource
=== PAUSE TestAccLogstashIntegrationResource
=== RUN   TestAccLookerIntegrationResource
=== PAUSE TestAccLookerIntegrationResource
=== RUN   TestAccDuoMFAIntegrationResource
=== PAUSE TestAccDuoMFAIntegrationResource
=== RUN   TestAccPagerDutyIntegrationResource
=== PAUSE TestAccPagerDutyIntegrationResource
=== RUN   TestAccSlackAlertsIntegrationResource
=== PAUSE TestAccSlackAlertsIntegrationResource
=== RUN   TestAccSplunkIntegrationResource
=== PAUSE TestAccSplunkIntegrationResource
=== RUN   TestAccSumoLogicIntegrationResource
=== PAUSE TestAccSumoLogicIntegrationResource
=== RUN   TestAccMsTeamsIntegrationResource
=== PAUSE TestAccMsTeamsIntegrationResource
=== RUN   TestAccPolicyRuleResource
=== PAUSE TestAccPolicyRuleResource
=== RUN   TestPolicyRuleResourceUpgradeV0
--- PASS: TestPolicyRuleResourceUpgradeV0 (0.00s)
=== RUN   TestAccPolicyResource
=== PAUSE TestAccPolicyResource
=== RUN   TestAccRepositoryAccessGatewayResource
=== PAUSE TestAccRepositoryAccessGatewayResource
=== RUN   TestAccRepositoryAccessRulesResource
=== PAUSE TestAccRepositoryAccessRulesResource
=== RUN   TestAccRepositoryBindingResource
=== PAUSE TestAccRepositoryBindingResource
=== RUN   TestAccRepositoryConfAnalysisResource
=== PAUSE TestAccRepositoryConfAnalysisResource
=== RUN   TestRepositoryConfAnalysisResourceUpgradeV0
--- PASS: TestRepositoryConfAnalysisResourceUpgradeV0 (0.00s)
=== RUN   TestAccRepositoryConfAuthResource
=== PAUSE TestAccRepositoryConfAuthResource
=== RUN   TestRepositoryConfAuthResourceUpgradeV0
--- PASS: TestRepositoryConfAuthResourceUpgradeV0 (0.00s)
=== RUN   TestAccRepositoryDatamapResource
=== PAUSE TestAccRepositoryDatamapResource
=== RUN   TestAccRepositoryNetworkAccessPolicyResource
=== PAUSE TestAccRepositoryNetworkAccessPolicyResource
=== RUN   TestAccRepositoryResource
=== PAUSE TestAccRepositoryResource
=== RUN   TestAccRepositoryUserAccountResource
=== PAUSE TestAccRepositoryUserAccountResource
=== RUN   TestAccRoleSSOGroupsResource
=== PAUSE TestAccRoleSSOGroupsResource
=== RUN   TestRoleSSOGroupsResourceUpgradeV0
--- PASS: TestRoleSSOGroupsResourceUpgradeV0 (0.00s)
=== RUN   TestAccRoleResource
=== PAUSE TestAccRoleResource
=== RUN   TestAccSidecarCredentialsResource
=== PAUSE TestAccSidecarCredentialsResource
=== RUN   TestSidecarListenerResource
=== PAUSE TestSidecarListenerResource
=== RUN   TestAccSidecarResource
=== PAUSE TestAccSidecarResource
=== RUN   TestElementsMatch
--- PASS: TestElementsMatch (0.00s)
=== CONT  TestAccDatalabelDataSource
=== CONT  TestSidecarListenerResource
=== CONT  TestAccDatalabelResource
=== CONT  TestAccLogsIntegrationResourceFluentbit
=== CONT  TestAccLogstashIntegrationResource
=== CONT  TestAccLogsIntegrationResourceSumologic
=== CONT  TestAccSAMLConfigurationDataSource
=== CONT  TestAccSidecarResource
=== CONT  TestAccLogsIntegrationResourceElkEmptyEsCredentials
--- PASS: TestAccLogsIntegrationResourceFluentbit (6.63s)
=== CONT  TestAccLogsIntegrationResourceSplunk
--- PASS: TestAccLogsIntegrationResourceSumologic (7.73s)
--- PASS: TestAccDatalabelResource (7.98s)
=== CONT  TestAccLogsIntegrationResourceDataDog
=== CONT  TestAccLogsIntegrationResourceElk
--- PASS: TestAccSAMLConfigurationDataSource (8.80s)
--- PASS: TestAccLogstashIntegrationResource (12.74s)
=== CONT  TestAccLogsIntegrationResourceCloudWatch
--- PASS: TestAccLogsIntegrationResourceElkEmptyEsCredentials (7.10s)
=== CONT  TestAccIntegrationIdPSAMLResource
--- PASS: TestAccLogsIntegrationResourceDataDog (5.90s)
=== CONT  TestAccIdPIntegrationResource
=== CONT  TestAccIntegrationIdPSAMLDraftResource
--- PASS: TestAccLogsIntegrationResourceSplunk (6.99s)
--- PASS: TestAccLogsIntegrationResourceElk (7.59s)
=== CONT  TestAccELKIntegrationResource
--- PASS: TestAccDatalabelDataSource (20.45s)
=== CONT  TestAccHCVaultIntegrationResource
=== CONT  TestAccRepositoryAccessGatewayResource
--- PASS: TestAccLogsIntegrationResourceCloudWatch (8.30s)
=== CONT  TestAccSidecarCredentialsResource
--- PASS: TestAccELKIntegrationResource (6.96s)
--- PASS: TestAccIntegrationIdPSAMLDraftResource (10.95s)
=== CONT  TestAccRoleResource
=== CONT  TestAccRoleSSOGroupsResource
--- PASS: TestAccHCVaultIntegrationResource (7.43s)
=== CONT  TestAccRepositoryUserAccountResource
--- PASS: TestAccSidecarResource (29.28s)
=== CONT  TestAccRepositoryResource
--- PASS: TestAccSidecarCredentialsResource (7.06s)
--- PASS: TestSidecarListenerResource (34.89s)
=== CONT  TestAccDatadogIntegrationResource
--- PASS: TestAccIntegrationIdPSAMLResource (23.15s)
=== CONT  TestAccRepositoryConfAuthResource
=== CONT  TestAccSidecarInstanceIDsDataSource
--- PASS: TestAccRepositoryAccessGatewayResource (20.68s)
=== CONT  TestAccRepositoryBindingResource
--- PASS: TestAccDatadogIntegrationResource (8.41s)
--- PASS: TestAccRoleSSOGroupsResource (15.53s)
=== CONT  TestAccRepositoryConfAnalysisResource
=== CONT  TestAccSidecarListenerDataSource
--- PASS: TestAccRoleResource (22.40s)
=== CONT  TestAccSidecarIDDataSource
--- PASS: TestAccSidecarInstanceIDsDataSource (8.03s)
--- PASS: TestAccRepositoryConfAnalysisResource (10.15s)
=== CONT  TestAccSidecarBoundPortsDataSource
=== CONT  TestAccSidecarCftTemplateDataSource
--- PASS: TestAccRepositoryResource (23.34s)
--- PASS: TestAccRepositoryBindingResource (11.68s)
=== CONT  TestAccRepositoryNetworkAccessPolicyResource
=== CONT  TestAccDuoMFAIntegrationResource
--- PASS: TestAccRepositoryConfAuthResource (18.49s)
=== CONT  TestAccSlackAlertsIntegrationResource
--- PASS: TestAccSidecarIDDataSource (6.97s)
--- PASS: TestAccIdPIntegrationResource (43.08s)
=== CONT  TestAccRoleDataSource
--- PASS: TestAccRoleDataSource (6.99s)
=== CONT  TestAccLookerIntegrationResource
--- PASS: TestAccSlackAlertsIntegrationResource (8.21s)
=== CONT  TestAccPolicyRuleResource
=== CONT  TestAccPolicyResource
--- PASS: TestAccDuoMFAIntegrationResource (9.58s)
--- PASS: TestAccSidecarCftTemplateDataSource (12.86s)
=== CONT  TestAccMsTeamsIntegrationResource
=== CONT  TestAccRepositoryDatamapResource
--- PASS: TestAccSidecarListenerDataSource (20.55s)
--- PASS: TestAccSidecarBoundPortsDataSource (15.67s)
=== CONT  TestAccPagerDutyIntegrationResource
=== CONT  TestAccLoggingIntegrationDataSource
--- PASS: TestAccLookerIntegrationResource (8.94s)
=== CONT  TestAccSumoLogicIntegrationResource
--- PASS: TestAccPolicyResource (9.86s)
--- PASS: TestAccMsTeamsIntegrationResource (8.79s)
=== CONT  TestAccSAMLCertificateDataSource
--- PASS: TestAccPagerDutyIntegrationResource (9.34s)
=== CONT  TestAccIntegrationIdPSAMLDataSource
=== CONT  TestAccSplunkIntegrationResource
--- PASS: TestAccSAMLCertificateDataSource (4.80s)
--- PASS: TestAccRepositoryNetworkAccessPolicyResource (27.01s)
=== CONT  TestAccRepositoryDataSource
--- PASS: TestAccSumoLogicIntegrationResource (8.81s)
=== CONT  TestAccRepositoryAccessRulesResource
--- PASS: TestAccRepositoryUserAccountResource (55.02s)
--- PASS: TestAccLoggingIntegrationDataSource (12.94s)
--- PASS: TestAccPolicyRuleResource (23.44s)
--- PASS: TestAccSplunkIntegrationResource (8.86s)
--- PASS: TestAccRepositoryDatamapResource (26.55s)
--- PASS: TestAccIntegrationIdPSAMLDataSource (17.16s)
--- PASS: TestAccRepositoryDataSource (15.40s)
--- PASS: TestAccRepositoryAccessRulesResource (15.21s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral      99.524s
```
