### PR TITLE
Add `skip_validate` option to Fluent Bit logging integration resource.

### DIFF
--- a/cyral/model_integration_logging.go
+++ b/cyral/model_integration_logging.go
@@ -38,7 +38,8 @@ type SumoLogicConfig struct {
 }
 
 type FluentBitConfig struct {
-	Config string `json:"config"`
+	Config       string `json:"config"`
+	SkipValidate bool   `json:"skipValidate"`
 }
 
 type LoggingIntegration struct {
@@ -250,6 +251,11 @@ func getIntegrationLogsSchema() map[string]*schema.Schema {
 						Description: "Fluent Bit configuration, in 'classic mode' INI format. For more details, see: https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/classic-mode/configuration-file",
 						Required:    true,
 						Type:        schema.TypeString,
+					},
+					"skip_validate": {
+						Optional:    true,
+						Type:        schema.TypeBool,
+						Description: "Whether to validate the Fluent Bit config.",
 					},
 				},
 			},

--- a/cyral/resource_cyral_integration_logging.go
+++ b/cyral/resource_cyral_integration_logging.go
@@ -69,7 +69,8 @@ func getLoggingConfig(resource *LoggingIntegration) (string, []interface{}, erro
 		configType = FluentbitKey
 		configScheme = []interface{}{
 			map[string]interface{}{
-				"config": resource.FluentBit.Config,
+				"config":        resource.FluentBit.Config,
+				"skip_validate": resource.FluentBit.SkipValidate,
 			},
 		}
 	default:
@@ -160,7 +161,8 @@ func (integrationLogConfig *LoggingIntegration) ReadFromSchema(d *schema.Resourc
 		}
 	case FluentbitKey:
 		integrationLogConfig.FluentBit = &FluentBitConfig{
-			Config: m["config"].(string),
+			Config:       m["config"].(string),
+			SkipValidate: m["skip_validate"].(bool),
 		}
 	default:
 		return fmt.Errorf("unexpected config type [%s]", configType)

--- a/cyral/resource_cyral_integration_logging_test.go
+++ b/cyral/resource_cyral_integration_logging_test.go
@@ -401,17 +401,28 @@ func setupLogsTest(integrationData LoggingIntegration) (string, resource.TestChe
 		}...)
 
 	case integrationData.FluentBit != nil:
-		checkFuncs = append(checkFuncs, []resource.TestCheckFunc{
-			resource.TestCheckResourceAttrWith(integrationLogsFullTerraformResourceName, "fluent_bit.0.config", func(value string) error {
-
-				// string must contain the config.
-				// We don't check exact value as it may contain trailing characters
-				if strings.Contains(value, integrationData.FluentBit.Config) {
-					return nil
-				}
-				return fmt.Errorf("expected %v, got %v", integrationData.FluentBit.Config, value)
-			}),
-		}...)
+		checkFuncs = append(
+			checkFuncs,
+			[]resource.TestCheckFunc{
+				resource.TestCheckResourceAttrWith(
+					integrationLogsFullTerraformResourceName,
+					"fluent_bit.0.config",
+					func(value string) error {
+						// string must contain the config.
+						// We don't check exact value as it may contain trailing characters
+						if strings.Contains(value, integrationData.FluentBit.Config) {
+							return nil
+						}
+						return fmt.Errorf("expected %v, got %v", integrationData.FluentBit.Config, value)
+					},
+				),
+				resource.TestCheckResourceAttr(
+					integrationELKResourceName,
+					"fluent_bit.0.skip_validate",
+					fmt.Sprint(integrationData.FluentBit.SkipValidate),
+				),
+			}...,
+		)
 	}
 
 	testFunction := resource.ComposeTestCheckFunc(checkFuncs...)
@@ -472,10 +483,12 @@ func formatLogsIntegrationDataIntoConfig(data LoggingIntegration, resName string
 		// fluentbit use INI format, so we need a proper way to handle this
 		config = fmt.Sprintf(`
 		fluent_bit {
+			skip_validate = %t
 			config = <<-EOF
 %s
 			EOF
-		}`, data.FluentBit.Config)
+		}`, data.FluentBit.SkipValidate, data.FluentBit.Config,
+		)
 	default:
 		return "", fmt.Errorf("Error in parsing config in test, %v", data)
 	}

--- a/docs/data-sources/integration_logging.md
+++ b/docs/data-sources/integration_logging.md
@@ -89,6 +89,7 @@ Read-Only:
 Read-Only:
 
 - `config` (String)
+- `skip_validate` (Boolean)
 
 <a id="nestedobjatt--integrations--splunk"></a>
 

--- a/docs/resources/integration_logging.md
+++ b/docs/resources/integration_logging.md
@@ -168,6 +168,10 @@ Required:
 
 - `config` (String) Fluent Bit configuration, in 'classic mode' INI format. For more details, see: https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/classic-mode/configuration-file
 
+Optional:
+
+- `skip_validate` (Boolean) Whether to validate the Fluent Bit config.
+
 <a id="nestedblock--splunk"></a>
 
 ### Nested Schema for `splunk`


### PR DESCRIPTION
## Description of the change

Fluent Bit's config parsing Go library has proven to be occasionally buggy with regard to validation, so this option allows users to completely bypass config validation primarily in those cases. Note that while this will allow invalid configurations to be saved to the Control Plane, there is no guarantee that such configs will actually work with Fluent Bit. This does not skip the sidecar's Fluent Bit from validating the configuration, and that Fluent Bit's internal parser may still fail during parsing. In that case, logs will just be written to the sidecar's stdout/stderr instead of being shipped to any (mis)configured destinations.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

Ran the tests via make. They seem a bit flaky but I saw the tests that I added pass.
