### PR TITLE
Removing the `helm` and `cloudFormation` sidecar deployment types

### DIFF
--- a/cyral/data_source_cyral_sidecar_bound_ports_test.go
+++ b/cyral/data_source_cyral_sidecar_bound_ports_test.go
@@ -16,7 +16,7 @@ func dsourceSidecarBoundPortsSampleSidecarConfig() string {
 	return formatBasicSidecarIntoConfig(
 		basicSidecarResName,
 		accTestName(sidecarBoundPortsDataSourceName, "sidecar"),
-		"cloudFormation", "",
+		"cft-ec2", "",
 	)
 }
 

--- a/cyral/data_source_cyral_sidecar_cft_template.go
+++ b/cyral/data_source_cyral_sidecar_cft_template.go
@@ -12,14 +12,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-const CloudFormationDeploymentMethod = "cloudFormation"
+const CloudFormationDeploymentMethod = "cft-ec2"
 
 func dataSourceSidecarCftTemplate() *schema.Resource {
 	return &schema.Resource{
 		DeprecationMessage: "This data source was deprecated. It will be removed in the next major version of " +
 			"the provider.",
 		Description: "Retrieves the CloudFormation deployment template for a given sidecar. This data source only " +
-			"supports sidecars with `cloudFormation` deployment method. For Terraform template, use our " +
+			"supports sidecars with `cft-ec2` deployment method. For Terraform template, use our " +
 			"`terraform-cyral-sidecar-aws` module.",
 		Read: getSidecarCftTemplate,
 		Schema: map[string]*schema.Schema{
@@ -63,7 +63,7 @@ func dataSourceSidecarCftTemplate() *schema.Resource {
 						},
 					},
 				},
-				Description: "AWS parameters for `cloudFormation` deployment method.",
+				Description: "AWS parameters for `cft-ec2` deployment method.",
 			},
 			"template": {
 				Type:        schema.TypeString,

--- a/cyral/data_source_cyral_sidecar_cft_template_test.go
+++ b/cyral/data_source_cyral_sidecar_cft_template_test.go
@@ -33,7 +33,7 @@ func setupSidecarCftTemplateTest() (string, resource.TestCheckFunc) {
 	configuration += formatBasicSidecarIntoConfig(
 		basicSidecarResName,
 		accTestName(sidecarCftTemplateDataSourceName, "sidecar"),
-		"cloudFormation", "",
+		"cft-ec2", "",
 	)
 	configuration += formatELKIntegrationDataIntoConfig(
 		ELKIntegration{

--- a/cyral/data_source_cyral_sidecar_id_test.go
+++ b/cyral/data_source_cyral_sidecar_id_test.go
@@ -63,7 +63,7 @@ func testAccSidecarIDConfig_ExistentSidecar() string {
 	config += formatBasicSidecarIntoConfig(
 		basicSidecarResName,
 		accTestName(sidecarIDDataSourceName, "sidecar"),
-		"cloudFormation", "",
+		"cft-ec2", "",
 	)
 	config += fmt.Sprintf(
 		`

--- a/cyral/data_source_cyral_sidecar_instance_ids_test.go
+++ b/cyral/data_source_cyral_sidecar_instance_ids_test.go
@@ -69,7 +69,7 @@ func testAccSidecarInstanceIDsConfig_NoSidecarInstances() string {
 	config += formatBasicSidecarIntoConfig(
 		basicSidecarResName,
 		accTestName(sidecarInstanceIDsDataSourceName, "sidecar"),
-		"cloudFormation", "",
+		"cft-ec2", "",
 	)
 
 	config += fmt.Sprintf(

--- a/cyral/resource_cyral_sidecar.go
+++ b/cyral/resource_cyral_sidecar.go
@@ -84,12 +84,12 @@ func resourceSidecar() *schema.Resource {
 				Required:    true,
 			},
 			"deployment_method": {
-				Description: "Deployment method that will be used by this sidecar (valid values: `docker`, `cloudFormation`, `terraform`, `helm`, `helm3`, `automated`, `custom`, `terraformGKE`, `linux`, and `singleContainer`).",
+				Description: "Deployment method that will be used by this sidecar (valid values: `docker`, `cft-ec2`, `terraform`, `helm3`, `automated`, `custom`, `terraformGKE`, `linux`, and `singleContainer`).",
 				Type:        schema.TypeString,
 				Required:    true,
 				ValidateFunc: validation.StringInSlice(
 					[]string{
-						"docker", "cloudFormation", "terraform", "helm", "helm3",
+						"docker", "cft-ec2", "terraform", "helm3",
 						"automated", "custom", "terraformGKE", "singleContainer",
 						"linux",
 					}, false,

--- a/cyral/resource_cyral_sidecar_test.go
+++ b/cyral/resource_cyral_sidecar_test.go
@@ -24,7 +24,7 @@ func getTestCBS() CertificateBundleSecrets {
 var cloudFormationSidecarConfig = SidecarData{
 	Name:                     accTestName(sidecarResourceName, "cft"),
 	Labels:                   []string{"test1"},
-	SidecarProperties:        NewSidecarProperties("cloudFormation", "foo", ""),
+	SidecarProperties:        NewSidecarProperties("cft-ec2", "foo", ""),
 	UserEndpoint:             "some.cft.user.endpoint",
 	CertificateBundleSecrets: getTestCBS(),
 }
@@ -38,10 +38,10 @@ var dockerSidecarConfig = SidecarData{
 }
 
 var helmSidecarConfig = SidecarData{
-	Name:                     accTestName(sidecarResourceName, "helm"),
+	Name:                     accTestName(sidecarResourceName, "helm3"),
 	Labels:                   []string{"test3"},
-	SidecarProperties:        NewSidecarProperties("helm", "baz", ""),
-	UserEndpoint:             "some.helm.user.endpoint",
+	SidecarProperties:        NewSidecarProperties("helm3", "baz", ""),
+	UserEndpoint:             "some.helm3.user.endpoint",
 	CertificateBundleSecrets: getTestCBS(),
 }
 

--- a/docs/data-sources/sidecar_cft_template.md
+++ b/docs/data-sources/sidecar_cft_template.md
@@ -24,7 +24,7 @@ data "cyral_sidecar_cft_template" "some_data_source_name" {
 
 ### Required
 
-- `aws_configuration` (Block Set, Min: 1) AWS parameters for `cloudFormation` deployment method. (see [below for nested schema](#nestedblock--aws_configuration))
+- `aws_configuration` (Block Set, Min: 1) AWS parameters for `cft-ec2` deployment method. (see [below for nested schema](#nestedblock--aws_configuration))
 - `sidecar_id` (String) ID of the sidecar which the template will be generated.
 
 ### Optional

--- a/docs/resources/sidecar.md
+++ b/docs/resources/sidecar.md
@@ -28,7 +28,7 @@ resource "cyral_sidecar" "some_resource_name" {
 
 ### Required
 
-- `deployment_method` (String) Deployment method that will be used by this sidecar (valid values: `docker`, `cloudFormation`, `terraform`, `helm`, `helm3`, `automated`, `custom`, `terraformGKE`, `linux`, and `singleContainer`).
+- `deployment_method` (String) Deployment method that will be used by this sidecar (valid values: `docker`, `cft-ec2`, `terraform`, `helm3`, `automated`, `custom`, `terraformGKE`, `linux`, and `singleContainer`).
 - `name` (String) Sidecar name that will be used internally in Control Plane (ex: `your_sidecar_name`).
 
 ### Optional


### PR DESCRIPTION
## Description of the change

> Removing the `helm` deployment type and changing `cloudFormation` to `cft-ec2` to be in line with what is currently used when using the UI.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

> Ran `make` locally and the changed tests passed
