### PR TITLE
Fix terraform tests that were failing in the E2E tests report

### DIFF
--- a/cyral/resource_cyral_integration_logging_test.go
+++ b/cyral/resource_cyral_integration_logging_test.go
@@ -417,7 +417,7 @@ func setupLogsTest(integrationData LoggingIntegration) (string, resource.TestChe
 					},
 				),
 				resource.TestCheckResourceAttr(
-					integrationELKResourceName,
+					integrationLogsFullTerraformResourceName,
 					"fluent_bit.0.skip_validate",
 					fmt.Sprint(integrationData.FluentBit.SkipValidate),
 				),

--- a/cyral/resource_cyral_repository_conf_auth.go
+++ b/cyral/resource_cyral_repository_conf_auth.go
@@ -19,8 +19,15 @@ const (
 	defaultClientTLS = "disable"
 	defaultRepoTLS   = "disable"
 
-	defaultAuthType = "ACCESS_TOKEN"
+	accessTokenAuthType = "ACCESS_TOKEN"
+	awsIAMAuthType      = "AWS_IAM"
+	defaultAuthType     = accessTokenAuthType
 )
+
+var authTypes = []string{
+	accessTokenAuthType,
+	awsIAMAuthType,
+}
 
 type RepositoryConfAuthData struct {
 	RepoID           *string `json:"-"`
@@ -176,11 +183,6 @@ func DeleteConfAuthConfig() ResourceOperationConfig {
 	}
 }
 
-var authTypes = []string{
-	"ACCESS_TOKEN",
-	"AWS_IAM",
-}
-
 func repositoryConfAuthResourceSchemaV0() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
@@ -217,8 +219,9 @@ func repositoryConfAuthResourceSchemaV0() *schema.Resource {
 				Default:     defaultRepoTLS,
 			},
 			"auth_type": {
-				Description: "Authentication type for this repository. List of supported types: " +
-					supportedTypesMarkdown(authTypes),
+				Description: fmt.Sprintf("Authentication type for this repository. **Note**: `%s` is currently "+
+					"only supported by `%s` repo type. List of supported values: %s",
+					awsIAMAuthType, MongoDB, supportedTypesMarkdown(authTypes)),
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      defaultAuthType,

--- a/cyral/resource_cyral_repository_conf_auth_test.go
+++ b/cyral/resource_cyral_repository_conf_auth_test.go
@@ -17,9 +17,9 @@ func repositoryConfAuthDependencyConfig() string {
 	return formatBasicRepositoryIntoConfig(
 		basicRepositoryResName,
 		accTestName(repositoryConfAuthResourceName, "repository"),
-		"mysql",
-		"http://mysql.local/",
-		3306,
+		"mongodb",
+		"http://mongodb.local/",
+		27017,
 	)
 }
 
@@ -28,6 +28,7 @@ func initialRepositoryConfAuthConfig() RepositoryConfAuthData {
 		AllowNativeAuth: false,
 		ClientTLS:       "disable",
 		RepoTLS:         "enable",
+		AuthType:        "ACCESS_TOKEN",
 	}
 }
 
@@ -67,6 +68,7 @@ func repositoryConfAuthMinimalConfigTest(resName string) resource.TestStep {
 			RepositoryConfAuthData{
 				ClientTLS: defaultClientTLS,
 				RepoTLS:   defaultRepoTLS,
+				AuthType:  defaultAuthType,
 			},
 		),
 	}
@@ -74,7 +76,6 @@ func repositoryConfAuthMinimalConfigTest(resName string) resource.TestStep {
 
 func TestAccRepositoryConfAuthResource(t *testing.T) {
 	testMinimal := repositoryConfAuthMinimalConfigTest("main_test")
-
 	mainTest := setupRepositoryConfAuthTest("main_test", initialRepositoryConfAuthConfig())
 	mainTestUpdate1 := setupRepositoryConfAuthTest("main_test", update1RepositoryConfAuthConfig())
 	mainTestUpdate2 := setupRepositoryConfAuthTest("main_test", update2RepositoryConfAuthConfig())
@@ -83,11 +84,9 @@ func TestAccRepositoryConfAuthResource(t *testing.T) {
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			testMinimal,
-
 			mainTest,
 			mainTestUpdate1,
 			mainTestUpdate2,
-
 			{
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/docs/resources/repository_conf_auth.md
+++ b/docs/resources/repository_conf_auth.md
@@ -33,7 +33,7 @@ resource "cyral_repository_conf_auth" "some_resource_name" {
 ### Optional
 
 - `allow_native_auth` (Boolean) Should the communication allow native authentication?
-- `auth_type` (String) Authentication type for this repository. List of supported types:
+- `auth_type` (String) Authentication type for this repository. **Note**: `AWS_IAM` is currently only supported by `mongodb` repo type. List of supported values:
   - `ACCESS_TOKEN`
   - `AWS_IAM`
 - `client_tls` (String) Is the repo Client using TLS? Default is "disable".


### PR DESCRIPTION
## Description of the change

Fix terraform tests that were failing in the E2E tests report. The errors were all related to the tests, so these changes does not have impact on the resource's functionality.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

Tested by running automated tests with `make`. See test results below:

```bash
go test github.com/cyralinc/terraform-provider-cyral/... -v -race -timeout 20m
?   	github.com/cyralinc/terraform-provider-cyral	[no test files]
=== RUN   TestNewClient_WhenTLSSkipVerifyIsEnabled_ThenInsecureSkipVerifyIsTrue
2023/09/19 20:12:47 [DEBUG] Init NewClient
2023/09/19 20:12:47 [DEBUG] TokenSource: &{0xc00013cf00 {0 0} <nil> 0}
2023/09/19 20:12:47 [DEBUG] End NewClient
--- PASS: TestNewClient_WhenTLSSkipVerifyIsEnabled_ThenInsecureSkipVerifyIsTrue (0.00s)
=== RUN   TestNewClient_WhenTLSSkipVerifyIsDisabled_ThenInsecureSkipVerifyIsFalse
2023/09/19 20:12:47 [DEBUG] Init NewClient
2023/09/19 20:12:47 [DEBUG] TokenSource: &{0xc00013cf48 {0 0} <nil> 0}
2023/09/19 20:12:47 [DEBUG] End NewClient
--- PASS: TestNewClient_WhenTLSSkipVerifyIsDisabled_ThenInsecureSkipVerifyIsFalse (0.00s)
=== RUN   TestNewClient_WhenClientIDIsEmpty_ThenThrowError
2023/09/19 20:12:47 [DEBUG] Init NewClient
--- PASS: TestNewClient_WhenClientIDIsEmpty_ThenThrowError (0.00s)
=== RUN   TestNewClient_WhenClientSecretIsEmpty_ThenThrowError
2023/09/19 20:12:47 [DEBUG] Init NewClient
--- PASS: TestNewClient_WhenClientSecretIsEmpty_ThenThrowError (0.00s)
=== RUN   TestNewClient_WhenControlPlaneIsEmpty_ThenThrowError
2023/09/19 20:12:47 [DEBUG] Init NewClient
--- PASS: TestNewClient_WhenControlPlaneIsEmpty_ThenThrowError (0.00s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/client	(cached)
=== RUN   TestAccDatalabelDataSource
=== PAUSE TestAccDatalabelDataSource
=== RUN   TestAccIntegrationIdPSAMLDataSource
=== PAUSE TestAccIntegrationIdPSAMLDataSource
=== RUN   TestAccLoggingIntegrationDataSource
=== PAUSE TestAccLoggingIntegrationDataSource
=== RUN   TestAccRepositoryDataSource
=== PAUSE TestAccRepositoryDataSource
=== RUN   TestAccRoleDataSource
=== PAUSE TestAccRoleDataSource
=== RUN   TestAccSAMLCertificateDataSource
=== PAUSE TestAccSAMLCertificateDataSource
=== RUN   TestAccSAMLConfigurationDataSource
=== PAUSE TestAccSAMLConfigurationDataSource
=== RUN   TestAccSidecarBoundPortsDataSource
=== PAUSE TestAccSidecarBoundPortsDataSource
=== RUN   TestAccSidecarCftTemplateDataSource
=== PAUSE TestAccSidecarCftTemplateDataSource
=== RUN   TestAccSidecarIDDataSource
=== PAUSE TestAccSidecarIDDataSource
=== RUN   TestAccSidecarInstanceIDsDataSource
=== PAUSE TestAccSidecarInstanceIDsDataSource
=== RUN   TestAccSidecarListenerDataSource
=== PAUSE TestAccSidecarListenerDataSource
=== RUN   TestIntegrationsData_GetValue_Default
--- PASS: TestIntegrationsData_GetValue_Default (0.00s)
=== RUN   TestIntegrationsData_GetValue_Splunk
--- PASS: TestIntegrationsData_GetValue_Splunk (0.00s)
=== RUN   TestAccProvider
2023/09/21 17:28:06 [DEBUG] Init dataSourceSidecarListener
2023/09/21 17:28:06 [DEBUG] End dataSourceSidecarListener
--- PASS: TestAccProvider (0.01s)
=== RUN   TestAccDatalabelResource
=== PAUSE TestAccDatalabelResource
=== RUN   TestAccDatadogIntegrationResource
=== PAUSE TestAccDatadogIntegrationResource
=== RUN   TestAccELKIntegrationResource
=== PAUSE TestAccELKIntegrationResource
=== RUN   TestAccHCVaultIntegrationResource
=== PAUSE TestAccHCVaultIntegrationResource
=== RUN   TestAccIntegrationIdPSAMLDraftResource
=== PAUSE TestAccIntegrationIdPSAMLDraftResource
=== RUN   TestAccIntegrationIdPSAMLResource
=== PAUSE TestAccIntegrationIdPSAMLResource
=== RUN   TestAccIdPIntegrationResource
=== PAUSE TestAccIdPIntegrationResource
=== RUN   TestAccLogsIntegrationResourceCloudWatch
=== PAUSE TestAccLogsIntegrationResourceCloudWatch
=== RUN   TestAccLogsIntegrationResourceDataDog
=== PAUSE TestAccLogsIntegrationResourceDataDog
=== RUN   TestAccLogsIntegrationResourceElk
=== PAUSE TestAccLogsIntegrationResourceElk
=== RUN   TestAccLogsIntegrationResourceElkEmptyEsCredentials
=== PAUSE TestAccLogsIntegrationResourceElkEmptyEsCredentials
=== RUN   TestAccLogsIntegrationResourceSplunk
=== PAUSE TestAccLogsIntegrationResourceSplunk
=== RUN   TestAccLogsIntegrationResourceSumologic
=== PAUSE TestAccLogsIntegrationResourceSumologic
=== RUN   TestAccLogsIntegrationResourceFluentbit
=== PAUSE TestAccLogsIntegrationResourceFluentbit
=== RUN   TestAccLogstashIntegrationResource
=== PAUSE TestAccLogstashIntegrationResource
=== RUN   TestAccLookerIntegrationResource
=== PAUSE TestAccLookerIntegrationResource
=== RUN   TestAccDuoMFAIntegrationResource
=== PAUSE TestAccDuoMFAIntegrationResource
=== RUN   TestAccPagerDutyIntegrationResource
=== PAUSE TestAccPagerDutyIntegrationResource
=== RUN   TestAccSlackAlertsIntegrationResource
=== PAUSE TestAccSlackAlertsIntegrationResource
=== RUN   TestAccSplunkIntegrationResource
=== PAUSE TestAccSplunkIntegrationResource
=== RUN   TestAccSumoLogicIntegrationResource
=== PAUSE TestAccSumoLogicIntegrationResource
=== RUN   TestAccMsTeamsIntegrationResource
=== PAUSE TestAccMsTeamsIntegrationResource
=== RUN   TestAccPolicyRuleResource
=== PAUSE TestAccPolicyRuleResource
=== RUN   TestPolicyRuleResourceUpgradeV0
--- PASS: TestPolicyRuleResourceUpgradeV0 (0.00s)
=== RUN   TestAccPolicyResource
=== PAUSE TestAccPolicyResource
=== RUN   TestAccRegoPolicyInstanceResource
=== PAUSE TestAccRegoPolicyInstanceResource
=== RUN   TestAccRepositoryAccessGatewayResource
=== PAUSE TestAccRepositoryAccessGatewayResource
=== RUN   TestAccRepositoryAccessRulesResource
=== PAUSE TestAccRepositoryAccessRulesResource
=== RUN   TestAccRepositoryBindingResource
=== PAUSE TestAccRepositoryBindingResource
=== RUN   TestAccRepositoryConfAnalysisResource
=== PAUSE TestAccRepositoryConfAnalysisResource
=== RUN   TestRepositoryConfAnalysisResourceUpgradeV0
--- PASS: TestRepositoryConfAnalysisResourceUpgradeV0 (0.00s)
=== RUN   TestAccRepositoryConfAuthResource
=== PAUSE TestAccRepositoryConfAuthResource
=== RUN   TestRepositoryConfAuthResourceUpgradeV0
--- PASS: TestRepositoryConfAuthResourceUpgradeV0 (0.00s)
=== RUN   TestAccRepositoryDatamapResource
=== PAUSE TestAccRepositoryDatamapResource
=== RUN   TestAccRepositoryNetworkAccessPolicyResource
=== PAUSE TestAccRepositoryNetworkAccessPolicyResource
=== RUN   TestAccRepositoryResource
=== PAUSE TestAccRepositoryResource
=== RUN   TestAccRepositoryUserAccountResource
=== PAUSE TestAccRepositoryUserAccountResource
=== RUN   TestAccRoleSSOGroupsResource
=== PAUSE TestAccRoleSSOGroupsResource
=== RUN   TestRoleSSOGroupsResourceUpgradeV0
--- PASS: TestRoleSSOGroupsResourceUpgradeV0 (0.00s)
=== RUN   TestAccRoleResource
=== PAUSE TestAccRoleResource
=== RUN   TestAccSidecarCredentialsResource
=== PAUSE TestAccSidecarCredentialsResource
=== RUN   TestSidecarListenerResource
=== PAUSE TestSidecarListenerResource
=== RUN   TestAccSidecarResource
=== PAUSE TestAccSidecarResource
=== RUN   TestElementsMatch
--- PASS: TestElementsMatch (0.00s)
=== CONT  TestAccLoggingIntegrationDataSource
=== CONT  TestAccDatalabelResource
=== CONT  TestAccSidecarBoundPortsDataSource
=== CONT  TestAccSidecarResource
=== CONT  TestSidecarListenerResource
=== CONT  TestAccSidecarCredentialsResource
=== CONT  TestAccRoleResource
=== CONT  TestAccLookerIntegrationResource
--- PASS: TestAccSidecarCredentialsResource (8.45s)
=== CONT  TestAccRepositoryUserAccountResource
=== CONT  TestAccRepositoryResource
--- PASS: TestAccLookerIntegrationResource (9.80s)
=== CONT  TestAccRoleSSOGroupsResource
--- PASS: TestAccDatalabelResource (10.43s)
=== CONT  TestAccRepositoryDatamapResource
--- PASS: TestAccLoggingIntegrationDataSource (12.28s)
=== CONT  TestAccRepositoryConfAuthResource
--- PASS: TestAccSidecarBoundPortsDataSource (15.66s)
--- PASS: TestAccRoleResource (21.42s)
=== CONT  TestAccRepositoryNetworkAccessPolicyResource
--- PASS: TestAccRoleSSOGroupsResource (13.60s)
=== CONT  TestAccSAMLCertificateDataSource
=== CONT  TestAccRepositoryBindingResource
--- PASS: TestAccSAMLCertificateDataSource (4.35s)
=== CONT  TestAccRepositoryAccessRulesResource
--- PASS: TestAccSidecarResource (30.64s)
--- PASS: TestAccRepositoryResource (22.50s)
=== CONT  TestAccSAMLConfigurationDataSource
--- PASS: TestAccRepositoryConfAuthResource (17.43s)
=== CONT  TestAccRoleDataSource
--- PASS: TestAccRepositoryDatamapResource (23.56s)
=== CONT  TestAccRegoPolicyInstanceResource
--- PASS: TestAccRoleDataSource (7.33s)
=== CONT  TestAccRepositoryAccessGatewayResource
--- PASS: TestSidecarListenerResource (41.31s)
=== CONT  TestAccLogsIntegrationResourceCloudWatch
=== CONT  TestAccPolicyResource
--- PASS: TestAccRepositoryBindingResource (13.00s)
--- PASS: TestAccSAMLConfigurationDataSource (10.94s)
=== CONT  TestAccPolicyRuleResource
=== CONT  TestAccLogsIntegrationResourceFluentbit
--- PASS: TestAccRegoPolicyInstanceResource (11.82s)
--- PASS: TestAccRepositoryNetworkAccessPolicyResource (27.76s)
=== CONT  TestAccMsTeamsIntegrationResource
--- PASS: TestAccRepositoryAccessRulesResource (19.04s)
=== CONT  TestAccLogsIntegrationResourceSumologic
=== CONT  TestAccRepositoryConfAnalysisResource
--- PASS: TestAccPolicyResource (10.24s)
--- PASS: TestAccLogsIntegrationResourceCloudWatch (10.40s)
=== CONT  TestAccLogsIntegrationResourceSplunk
--- PASS: TestAccLogsIntegrationResourceFluentbit (12.07s)
=== CONT  TestAccLogsIntegrationResourceElk
--- PASS: TestAccMsTeamsIntegrationResource (10.98s)
=== CONT  TestAccSumoLogicIntegrationResource
=== CONT  TestAccLogsIntegrationResourceElkEmptyEsCredentials
--- PASS: TestAccLogsIntegrationResourceSumologic (14.75s)
--- PASS: TestAccLogsIntegrationResourceSplunk (14.80s)
=== CONT  TestAccSplunkIntegrationResource
--- PASS: TestAccRepositoryConfAnalysisResource (17.25s)
=== CONT  TestAccIntegrationIdPSAMLDataSource
--- PASS: TestAccRepositoryAccessGatewayResource (28.86s)
=== CONT  TestAccPagerDutyIntegrationResource
=== CONT  TestAccRepositoryDataSource
--- PASS: TestAccRepositoryUserAccountResource (62.92s)
--- PASS: TestAccLogsIntegrationResourceElk (12.43s)
=== CONT  TestAccIntegrationIdPSAMLDraftResource
=== CONT  TestAccDuoMFAIntegrationResource
--- PASS: TestAccSumoLogicIntegrationResource (14.40s)
--- PASS: TestAccPolicyRuleResource (32.50s)
=== CONT  TestAccLogsIntegrationResourceDataDog
--- PASS: TestAccLogsIntegrationResourceElkEmptyEsCredentials (13.75s)
=== CONT  TestAccIdPIntegrationResource
--- PASS: TestAccSplunkIntegrationResource (13.57s)
=== CONT  TestAccSlackAlertsIntegrationResource
--- PASS: TestAccPagerDutyIntegrationResource (13.37s)
=== CONT  TestAccDatalabelDataSource
--- PASS: TestAccLogsIntegrationResourceDataDog (11.54s)
=== CONT  TestAccLogstashIntegrationResource
--- PASS: TestAccDuoMFAIntegrationResource (13.93s)
=== CONT  TestAccSidecarListenerDataSource
--- PASS: TestAccIntegrationIdPSAMLDraftResource (21.37s)
=== CONT  TestAccDatadogIntegrationResource
--- PASS: TestAccSlackAlertsIntegrationResource (13.58s)
=== CONT  TestAccSidecarInstanceIDsDataSource
--- PASS: TestAccRepositoryDataSource (24.12s)
=== CONT  TestAccIntegrationIdPSAMLResource
--- PASS: TestAccIntegrationIdPSAMLDataSource (29.47s)
=== CONT  TestAccHCVaultIntegrationResource
--- PASS: TestAccSidecarInstanceIDsDataSource (11.43s)
=== CONT  TestAccSidecarCftTemplateDataSource
=== CONT  TestAccELKIntegrationResource
--- PASS: TestAccDatadogIntegrationResource (12.77s)
--- PASS: TestAccHCVaultIntegrationResource (12.77s)
=== CONT  TestAccSidecarIDDataSource
--- PASS: TestAccLogstashIntegrationResource (26.42s)
--- PASS: TestAccDatalabelDataSource (32.41s)
--- PASS: TestAccSidecarListenerDataSource (29.60s)
--- PASS: TestAccELKIntegrationResource (14.75s)
--- PASS: TestAccSidecarCftTemplateDataSource (16.35s)
--- PASS: TestAccSidecarIDDataSource (10.53s)
--- PASS: TestAccIntegrationIdPSAMLResource (29.37s)
--- PASS: TestAccIdPIntegrationResource (59.35s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral	138.333s
```
