### PR TITLE
ENG-12728: Add template parameters section to the rego_policy_instance docs

### DIFF
--- a/docs/resources/rego_policy_instance.md
+++ b/docs/resources/rego_policy_instance.md
@@ -15,7 +15,7 @@ resource "cyral_rego_policy_instance" "policy" {
   category = "SECURITY"
   description = "Some policy description."
   template_id = "rate-limit"
-  parameters = "{\"rateLimit\":7,\"labels\":[\"EMAIL\"],\"alertSeverity\":\"high\",\"block\":false}"
+  parameters = "{\"rateLimit\":7,\"labels\":[\"EMAIL\"],\"alertSeverity\":\"high\",\"block\":false,\"identities\":{\"included\":{\"groups\":[\"analysts\"]}},\"dbAccounts\":{\"included\":[\"admin\"]}}"
   enabled = true
   tags = ["tag1", "tag2"]
 }
@@ -64,6 +64,111 @@ resource "cyral_rego_policy_instance" "policy" {
   duration = "10s"
 }
 ```
+
+## Template Parameters
+
+All templates use parameters defined as JSON, below is a list of all the corresponding parameters for the predefined templates.
+
+-> You can also use the Cyral API `GET` `/v1/regopolicies/templates` to retrieve all existing templates and their corresponding parameters schema.
+
+### Data Firewall (data-firewall)
+
+- `dataSet` (String) Data Set.
+- `dataFilter` (String) Data filter that will be applied when anyone tries to read the specified data labels from the data set.
+- `tags` (Array) Tags.
+- `labels` (Array) Data Labels.
+- `excludedIdentities` (Object) Identities that will be excluded from this policy. See [identityList](#objects--identityList).
+
+### Data Masking (data-masking)
+
+- `maskType` (String) Mask Type (E.g.: `NULL_MASK`, `CONSTANT_MASK`, `MASK`).
+- `maskArguments` (Array) Mask Argument associated to the given Mask Type (E.g.: Replacement Value).
+- `tags` (Array) Tags.
+- `labels` (Array) Data Labels.
+- `identities` (Object) Identities associated to the policy. If empty, the policy will be associated to all identities. See [identities](#objects--identities).
+- `dbAccounts` (Object) Database Accounts associated to the policy. If empty, the policy will be associated to any database account. See [dbAccounts](#objects--dbAccounts).
+
+### Data Protection (data-protection)
+
+- `block` (Boolean) Policy action to block.
+- `monitorReads` (Boolean) Monitor read operations.
+- `monitorUpdates` (Boolean) Monitor update operations.
+- `monitorDeletes` (Boolean) Monitor delete operations.
+- `tags` (Array) Tags.
+- `labels` (Array) Data Labels.
+- `identities` (Object) Identities associated to the policy. If empty, the policy will be associated to all identities. See [identities](#objects--identities).
+- `dbAccounts` (Object) Database Accounts associated to the policy. If empty, the policy will be associated to any database account. See [dbAccounts](#objects--dbAccounts).
+- `alertSeverity` (String) Policy action to alert, using the respective severity. Allowed values are: `low`, `medium`, `high`.
+
+### Ephemeral Grant (EphemeralGrantPolicy)
+
+- `repoAccount` (String) Repository Account Name.
+- `repo` (String) Repository Name.
+- `allowedSensitiveAttributes` (Array) Allowed Sensitive Attributes.
+
+### Rate Limit (rate-limit)
+
+- `rateLimit` (Integer) Maximum number of rows that can be returned per hour. Note: the value must be an integer greater than zero.
+- `block` (Boolean) Policy action to enforce.
+- `tags` (Array) Tags.
+- `labels` (Array) Data Labels.
+- `identities` (Object) Identities associated to the policy. If empty, the policy will be associated to all identities. See [identities](#objects--identities).
+- `dbAccounts` (Object) Database Accounts associated to the policy. If empty, the policy will be associated to any database account. See [dbAccounts](#objects--dbAccounts).
+- `alertSeverity` (String) Policy action to alert, using the respective severity. Allowed values are: `low`, `medium`, `high`.
+
+### Read Limit (read-limit)
+
+- `rowLimit` (Integer) Maximum number of rows that can be read per query. Note: the value must be an integer greater than zero.
+- `block` (Boolean) Policy action to enforce.
+- `appliesToAllData` (Boolean) Whether the policy should apply to the entire repository data.
+- `tags` (Array) Tags.
+- `labels` (Array) Data Labels.
+- `identities` (Object) Identities associated to the policy. If empty, the policy will be associated to all identities. See [identities](#objects--identities).
+- `dbAccounts` (Object) Database Accounts associated to the policy. If empty, the policy will be associated to any database account. See [dbAccounts](#objects--dbAccounts).
+- `alertSeverity` (String) Policy action to alert, using the respective severity. Allowed values are: `low`, `medium`, `high`.
+
+### Repository Protection (repository-protection)
+
+- `rowLimit` (Integer) Maximum number of rows that can be modified per query. Note: the value must be an integer greater than zero.
+- `monitorUpdates` (Boolean) Monitor update operations.
+- `monitorDeletes` (Boolean) Monitor delete operations.
+- `identities` (Object) Identities associated to the policy. If empty, the policy will be associated to all identities. See [identities](#objects--identities).
+- `dbAccounts` (Object) Database Accounts associated to the policy. If empty, the policy will be associated to any database account. See [dbAccounts](#objects--dbAccounts).
+- `alertSeverity` (String) Policy action to alert, using the respective severity. Allowed values are: `low`, `medium`, `high`.
+
+### Service Account Abuse (service-account-abuse)
+
+- `block` (Boolean) Policy action to enforce.
+- `serviceAccounts` (Array) Service accounts for which end user attribution is always required.
+- `alertSeverity` (String) Policy action to alert, using the respective severity. Allowed values are: `low`, `medium`, `high`.
+
+### User Segmentation (user-segmentation)
+
+- `dataSet` (String) Data Set.
+- `dataFilter` (String) Data filter that will be applied when anyone tries to read the specified data labels from the data set.
+- `tags` (Array) Tags.
+- `labels` (Array) Data Labels.
+- `includedIdentities` (Object) Identities that cannot see restricted records. See [identityList](#objects--identityList).
+- `includedDbAccounts` (Array) Database accounts cannot see restricted records.
+
+<a id="parameter-objects"></a>
+
+### Objects
+
+<a id="objects--identities"></a>
+
+- `identities` (Object) Identities. See properties below:
+  - `included` (Object) Included Identities. See [identityList](#objects--identityList).
+  - `excluded` (Object) Excluded Identities. See [identityList](#objects--identityList).
+    <a id="objects--dbAccounts"></a>
+- `dbAccounts` (Object) Database Accounts. See properties below:
+  - `included` (Array) Included Database Accounts.
+  - `excluded` (Array) Excluded Database Accounts.
+    <a id="objects--identityList"></a>
+- `identityList` (Object) Identity List. See properties below:
+  - `userNames` (Array) Identity Emails.
+  - `emails` (Array) Identity Usernames.
+  - `groups` (Array) Identity Groups.
 
 <!-- schema generated by tfplugindocs -->
 

--- a/examples/resources/cyral_rego_policy_instance/resource.tf
+++ b/examples/resources/cyral_rego_policy_instance/resource.tf
@@ -4,7 +4,7 @@ resource "cyral_rego_policy_instance" "policy" {
   category = "SECURITY"
   description = "Some policy description."
   template_id = "rate-limit"
-  parameters = "{\"rateLimit\":7,\"labels\":[\"EMAIL\"],\"alertSeverity\":\"high\",\"block\":false}"
+  parameters = "{\"rateLimit\":7,\"labels\":[\"EMAIL\"],\"alertSeverity\":\"high\",\"block\":false,\"identities\":{\"included\":{\"groups\":[\"analysts\"]}},\"dbAccounts\":{\"included\":[\"admin\"]}}"
   enabled = true
   tags = ["tag1", "tag2"]
 }

--- a/templates/resources/rego_policy_instance.md.tmpl
+++ b/templates/resources/rego_policy_instance.md.tmpl
@@ -8,4 +8,106 @@
 
 {{ tffile "examples/resources/cyral_rego_policy_instance/resource.tf" }}
 
+## Template Parameters
+
+All templates use parameters defined as JSON, below is a list of all the corresponding parameters for the predefined templates.
+
+-> You can also use the Cyral API `GET` `/v1/regopolicies/templates` to retrieve all existing templates and their corresponding parameters schema.
+
+### Data Firewall (data-firewall)
+
+- `dataSet` (String) Data Set.
+- `dataFilter` (String) Data filter that will be applied when anyone tries to read the specified data labels from the data set.
+- `tags` (Array) Tags.
+- `labels` (Array) Data Labels.
+- `excludedIdentities` (Object) Identities that will be excluded from this policy. See [identityList](#objects--identityList).
+
+### Data Masking (data-masking)
+
+- `maskType` (String) Mask Type (E.g.: `NULL_MASK`, `CONSTANT_MASK`, `MASK`).
+- `maskArguments` (Array) Mask Argument associated to the given Mask Type (E.g.: Replacement Value).
+- `tags` (Array) Tags.
+- `labels` (Array) Data Labels.
+- `identities` (Object) Identities associated to the policy. If empty, the policy will be associated to all identities. See [identities](#objects--identities).
+- `dbAccounts` (Object) Database Accounts associated to the policy. If empty, the policy will be associated to any database account. See [dbAccounts](#objects--dbAccounts).
+
+### Data Protection (data-protection)
+
+- `block` (Boolean) Policy action to block.
+- `monitorReads` (Boolean) Monitor read operations.
+- `monitorUpdates` (Boolean) Monitor update operations.
+- `monitorDeletes` (Boolean) Monitor delete operations.
+- `tags` (Array) Tags.
+- `labels` (Array) Data Labels.
+- `identities` (Object) Identities associated to the policy. If empty, the policy will be associated to all identities. See [identities](#objects--identities).
+- `dbAccounts` (Object) Database Accounts associated to the policy. If empty, the policy will be associated to any database account. See [dbAccounts](#objects--dbAccounts).
+- `alertSeverity` (String) Policy action to alert, using the respective severity. Allowed values are: `low`, `medium`, `high`.
+
+### Ephemeral Grant (EphemeralGrantPolicy)
+
+- `repoAccount` (String) Repository Account Name.
+- `repo` (String) Repository Name.
+- `allowedSensitiveAttributes` (Array) Allowed Sensitive Attributes.
+
+### Rate Limit (rate-limit)
+
+- `rateLimit` (Integer) Maximum number of rows that can be returned per hour. Note: the value must be an integer greater than zero.
+- `block` (Boolean) Policy action to enforce.
+- `tags` (Array) Tags.
+- `labels` (Array) Data Labels.
+- `identities` (Object) Identities associated to the policy. If empty, the policy will be associated to all identities. See [identities](#objects--identities).
+- `dbAccounts` (Object) Database Accounts associated to the policy. If empty, the policy will be associated to any database account. See [dbAccounts](#objects--dbAccounts).
+- `alertSeverity` (String) Policy action to alert, using the respective severity. Allowed values are: `low`, `medium`, `high`.
+
+### Read Limit (read-limit)
+
+- `rowLimit` (Integer) Maximum number of rows that can be read per query. Note: the value must be an integer greater than zero.
+- `block` (Boolean) Policy action to enforce.
+- `appliesToAllData` (Boolean) Whether the policy should apply to the entire repository data.
+- `tags` (Array) Tags.
+- `labels` (Array) Data Labels.
+- `identities` (Object) Identities associated to the policy. If empty, the policy will be associated to all identities. See [identities](#objects--identities).
+- `dbAccounts` (Object) Database Accounts associated to the policy. If empty, the policy will be associated to any database account. See [dbAccounts](#objects--dbAccounts).
+- `alertSeverity` (String) Policy action to alert, using the respective severity. Allowed values are: `low`, `medium`, `high`.
+
+### Repository Protection (repository-protection)
+
+- `rowLimit` (Integer) Maximum number of rows that can be modified per query. Note: the value must be an integer greater than zero.
+- `monitorUpdates` (Boolean) Monitor update operations.
+- `monitorDeletes` (Boolean) Monitor delete operations.
+- `identities` (Object) Identities associated to the policy. If empty, the policy will be associated to all identities. See [identities](#objects--identities).
+- `dbAccounts` (Object) Database Accounts associated to the policy. If empty, the policy will be associated to any database account. See [dbAccounts](#objects--dbAccounts).
+- `alertSeverity` (String) Policy action to alert, using the respective severity. Allowed values are: `low`, `medium`, `high`.
+
+### Service Account Abuse (service-account-abuse)
+
+- `block` (Boolean) Policy action to enforce.
+- `serviceAccounts` (Array) Service accounts for which end user attribution is always required.
+- `alertSeverity` (String) Policy action to alert, using the respective severity. Allowed values are: `low`, `medium`, `high`.
+
+### User Segmentation (user-segmentation)
+
+- `dataSet` (String) Data Set.
+- `dataFilter` (String) Data filter that will be applied when anyone tries to read the specified data labels from the data set.
+- `tags` (Array) Tags.
+- `labels` (Array) Data Labels.
+- `includedIdentities` (Object) Identities that cannot see restricted records. See [identityList](#objects--identityList).
+- `includedDbAccounts` (Array) Database accounts cannot see restricted records.
+
+<a id="parameter-objects"></a>
+### Objects
+<a id="objects--identities"></a>
+- `identities` (Object) Identities. See properties below:
+  - `included` (Object) Included Identities. See [identityList](#objects--identityList).
+  - `excluded` (Object) Excluded Identities. See [identityList](#objects--identityList).
+<a id="objects--dbAccounts"></a>
+- `dbAccounts` (Object) Database Accounts. See properties below:
+  - `included` (Array) Included Database Accounts.
+  - `excluded` (Array) Excluded Database Accounts.
+<a id="objects--identityList"></a>
+- `identityList` (Object) Identity List. See properties below:
+  - `userNames` (Array) Identity Emails.
+  - `emails` (Array) Identity Usernames.
+  - `groups` (Array) Identity Groups.
+
 {{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
## Description of the change

[ENG-12728](https://cyralinc.atlassian.net/browse/ENG-12728): Add terraform examples on how to create rego policies for different templates

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Jira issue referenced in commit message and/or PR title

### Testing

Tested the documentation using the [Terraform Doc Preview](https://registry.terraform.io/tools/doc-preview) and also tested the terraform config examples.


[ENG-12728]: https://cyralinc.atlassian.net/browse/ENG-12728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ