### PR TITLE
Fix test for cyral_sidecar_instance_stats data source

### DIFF
--- a/cyral/data_source_cyral_sidecar_instance_stats_test.go
+++ b/cyral/data_source_cyral_sidecar_instance_stats_test.go
@@ -66,7 +66,7 @@ func accTestStepSidecarInstanceStatsDataSource_NoInstanceFoundForGivenID(dataSou
 	// deployed.
 	config := formatBasicSidecarIntoConfig(
 		basicSidecarResName,
-		accTestName("data-sidecar-instance", "sidecar"),
+		accTestName("data-sidecar-instance-stats", "sidecar"),
 		"cft-ec2",
 		"",
 	)


### PR DESCRIPTION
## Description of the change

Fix test for `cyral_sidecar_instance_stats` data source so that it works running in parallel with other tests.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

Before this fix:
```
Step #4 - "E2E":     data_source_cyral_sidecar_instance_stats_test.go:19: Step 4/4, expected an error with pattern, no match on: Error running apply: exit status 1
Step #4 - "E2E":         
Step #4 - "E2E":         Error: Unable to create sidecar
Step #4 - "E2E":         
Step #4 - "E2E":           with cyral_sidecar.test_sidecar,
Step #4 - "E2E":           on terraform_plugin_test.tf line 2, in resource "cyral_sidecar" "test_sidecar":
Step #4 - "E2E":            2: 	resource "cyral_sidecar" "test_sidecar" {
Step #4 - "E2E":         
Step #4 - "E2E":         error executing POST request; status code: 500; body: "{\"Message\":\"Failed
Step #4 - "E2E":         to register sidecar: rpc error: code = AlreadyExists desc = error creating
Step #4 - "E2E":         sidecar: rpc error: code = AlreadyExists desc = sidecar with name
Step #4 - "E2E":         `tfprov-acc-data-sidecar-instance-sidecar` already exists\"}\n"
```

After this fix:
```
=== RUN   TestAccSidecarInstanceStatsDataSource
=== PAUSE TestAccSidecarInstanceStatsDataSource
=== CONT  TestAccSidecarInstanceStatsDataSource
--- PASS: TestAccSidecarInstanceStatsDataSource (7.66s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral	8.266s
```