### PR TITLE
Update docs to avoid errors during destroy commands

### DIFF
--- a/cyral/resource_cyral_repository_network_access_policy.go
+++ b/cyral/resource_cyral_repository_network_access_policy.go
@@ -149,7 +149,13 @@ func deleteRepositoryNetworkAccessPolicy() ResourceOperationConfig {
 
 func resourceRepositoryNetworkAccessPolicy() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Manages the network access policy of a repository. Network access policies are also known as the [Network Shield](https://cyral.com/docs/manage-repositories/network-shield/). This feature is supported for the following repository types:" + supportedTypesMarkdown(repositoryTypesNetworkShield()),
+		Description: "Manages the network access policy of a repository. Network access policies are" +
+			" also known as the [Network Shield](https://cyral.com/docs/manage-repositories/network-shield/)." +
+			" This feature is supported for the following repository types:" +
+			supportedTypesMarkdown(repositoryTypesNetworkShield()) +
+			"\n\n-> **Note** If you also use the resource `cyral_repository_conf_auth` for the same repository," +
+			" create a `depends_on` relationship from this resource to the `cyral_repository_conf_auth` to" +
+			" avoid errors when running `terraform destroy`.",
 		CreateContext: CreateResource(createRepositoryNetworkAccessPolicy(), readRepositoryNetworkAccessPolicy()),
 		ReadContext:   ReadResource(readRepositoryNetworkAccessPolicy()),
 		UpdateContext: UpdateResource(updateRepositoryNetworkAccessPolicy(), readRepositoryNetworkAccessPolicy()),

--- a/examples/resources/cyral_repository_network_access_policy/resource.tf
+++ b/examples/resources/cyral_repository_network_access_policy/resource.tf
@@ -1,23 +1,36 @@
 # Repository the policy refers to
 resource "cyral_repository" "my_sqlserver_repo" {
-    name = "my-sqlserver-repo"
-    type = "sqlserver"
-    host = "sqlserver.cyral.com"
+  name = "sqlserver-repo"
+  type = "sqlserver"
+
+  repo_node {
+    host = "sqlserver.mycompany.com"
     port = 1433
+  }
+}
+
+resource "cyral_repository_conf_auth" "conf_auth" {
+  repository_id     = cyral_repository.my_sqlserver_repo.id
+  allow_native_auth = true
+  client_tls = "enable"
+  repo_tls = "enable"
 }
 
 # Allow access from IPs 1.2.3.4 and 4.3.2.1 for Admin database
 # account, and from any IP address for accounts Engineer and
 # Analyst.
-resource "cyral_repository_network_access_policy" "my_sqlserver_repo_policy" {
-    repository_id = cyral_repository.my_sqlserver_repo.id
-    network_access_rule {
-        name = "rule1"
-        db_accounts = ["Admin"]
-        source_ips = ["1.2.3.4", "4.3.2.1"]
-    }
-    network_access_rule {
-        name = "rule2"
-        db_accounts = ["Engineer", "Analyst"]
-    }
+resource "cyral_repository_network_access_policy" "access_policy" {
+  depends_on = [cyral_repository_conf_auth.conf_auth]
+  repository_id = cyral_repository.my_sqlserver_repo.id
+
+  network_access_rule {
+    name = "rule1"
+    db_accounts = ["Admin"]
+    source_ips = ["1.2.3.4", "4.3.2.1"]
+  }
+
+  network_access_rule {
+    name = "rule2"
+    db_accounts = ["Engineer", "Analyst"]
+  }
 }


### PR DESCRIPTION
## Description of the change

Update `cyral_repository_network_access_policy` docs informing about a required `depends_on` relationship to `cyral_repository_conf_auth` that refers to the same repo to avoid errors in `terraform destroy` execution.

This is necessary due to a backend limitation that will be addressed in the future. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

NA
