### PR TITLE
Fix expected error message length for failing tests

### DIFF
--- a/cyral/internal/sidecar/instance/data_source_cyral_sidecar_instance_stats_test.go
+++ b/cyral/internal/sidecar/instance/data_source_cyral_sidecar_instance_stats_test.go
@@ -51,7 +51,7 @@ func accTestStepSidecarInstanceStatsDataSource_EmptyInstanceID(dataSourceName st
 }
 
 func accTestStepSidecarInstanceStatsDataSource_NoSidecarFoundForGivenID(dataSourceName string) resource.TestStep {
-	nonExistentSidecarID := "some-non-existent-sidecar-id"
+	nonExistentSidecarID := "id"
 	config := fmt.Sprintf(`
 	data "cyral_sidecar_instance_stats" "%s" {
 		sidecar_id = %q

--- a/cyral/internal/sidecar/instance/data_source_cyral_sidecar_instance_test.go
+++ b/cyral/internal/sidecar/instance/data_source_cyral_sidecar_instance_test.go
@@ -42,7 +42,7 @@ func accTestStepSidecarInstanceDataSource_EmptySidecarID(dataSourceName string) 
 }
 
 func accTestStepSidecarInstanceDataSource_NoSidecarFoundForGivenID(dataSourceName string) resource.TestStep {
-	nonExistentSidecarID := "some-non-existent-sidecar-id"
+	nonExistentSidecarID := "id"
 	config := fmt.Sprintf(`
 	data "cyral_sidecar_instance" "%s" {
 		sidecar_id = %q


### PR DESCRIPTION
## Description of the change

Fix expected error message length for failing tests (`TestAccSidecarInstanceStatsDataSource` and `TestAccSidecarInstanceDataSource`). Since the error message returned by the sidecar API was updated, the regex used in these terraform tests was not matching the error anymore due to a line break in the error message. This was fixed by shortening the sidecar id used so that the error message fits in a single line.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

Running automated tests, see result below:
```
go test github.com/cyralinc/terraform-provider-cyral/... -v -race -timeout 20m
?   	github.com/cyralinc/terraform-provider-cyral	[no test files]
?   	github.com/cyralinc/terraform-provider-cyral/cyral/core	[no test files]
?   	github.com/cyralinc/terraform-provider-cyral/cyral/core/types/operationtype	[no test files]
?   	github.com/cyralinc/terraform-provider-cyral/cyral/core/types/resourcetype	[no test files]
=== RUN   TestNewClient_WhenTLSSkipVerifyIsEnabled_ThenInsecureSkipVerifyIsTrue
--- PASS: TestNewClient_WhenTLSSkipVerifyIsEnabled_ThenInsecureSkipVerifyIsTrue (0.00s)
=== RUN   TestNewClient_WhenTLSSkipVerifyIsDisabled_ThenInsecureSkipVerifyIsFalse
--- PASS: TestNewClient_WhenTLSSkipVerifyIsDisabled_ThenInsecureSkipVerifyIsFalse (0.00s)
=== RUN   TestNewClient_WhenClientIDIsEmpty_ThenThrowError
--- PASS: TestNewClient_WhenClientIDIsEmpty_ThenThrowError (0.00s)
=== RUN   TestNewClient_WhenClientSecretIsEmpty_ThenThrowError
--- PASS: TestNewClient_WhenClientSecretIsEmpty_ThenThrowError (0.00s)
=== RUN   TestNewClient_WhenControlPlaneIsEmpty_ThenThrowError
--- PASS: TestNewClient_WhenControlPlaneIsEmpty_ThenThrowError (0.00s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/client	(cached)
=== RUN   TestAccDatalabelDataSource
=== PAUSE TestAccDatalabelDataSource
=== RUN   TestAccDatalabelResource
--- PASS: TestAccDatalabelResource (5.12s)
=== CONT  TestAccDatalabelDataSource
--- PASS: TestAccDatalabelDataSource (22.01s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/datalabel	(cached)
?   	github.com/cyralinc/terraform-provider-cyral/cyral/internal/datalabel/classificationrule	[no test files]
?   	github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/confextension	[no test files]
=== RUN   TestAccSidecarCftTemplateDataSource
=== PAUSE TestAccSidecarCftTemplateDataSource
=== RUN   TestAccSidecarInstanceIDsDataSource
=== PAUSE TestAccSidecarInstanceIDsDataSource
=== RUN   TestIntegrationsData_GetValue_Default
--- PASS: TestIntegrationsData_GetValue_Default (0.00s)
=== RUN   TestIntegrationsData_GetValue_Splunk
--- PASS: TestIntegrationsData_GetValue_Splunk (0.00s)
=== RUN   TestAccDatadogIntegrationResource
=== PAUSE TestAccDatadogIntegrationResource
=== RUN   TestAccELKIntegrationResource
=== PAUSE TestAccELKIntegrationResource
=== RUN   TestAccIdPIntegrationResource
=== PAUSE TestAccIdPIntegrationResource
=== RUN   TestAccLogstashIntegrationResource
=== PAUSE TestAccLogstashIntegrationResource
=== RUN   TestAccLookerIntegrationResource
=== PAUSE TestAccLookerIntegrationResource
=== RUN   TestAccSplunkIntegrationResource
=== PAUSE TestAccSplunkIntegrationResource
=== RUN   TestAccSumoLogicIntegrationResource
=== PAUSE TestAccSumoLogicIntegrationResource
=== CONT  TestAccSidecarCftTemplateDataSource
=== CONT  TestAccIdPIntegrationResource
=== CONT  TestAccLogstashIntegrationResource
=== CONT  TestAccSplunkIntegrationResource
=== CONT  TestAccSumoLogicIntegrationResource
=== CONT  TestAccDatadogIntegrationResource
=== CONT  TestAccLookerIntegrationResource
=== CONT  TestAccELKIntegrationResource
--- PASS: TestAccELKIntegrationResource (10.48s)
=== CONT  TestAccSidecarInstanceIDsDataSource
--- PASS: TestAccDatadogIntegrationResource (11.64s)
--- PASS: TestAccSplunkIntegrationResource (11.86s)
--- PASS: TestAccSumoLogicIntegrationResource (11.92s)
--- PASS: TestAccLookerIntegrationResource (11.93s)
--- PASS: TestAccLogstashIntegrationResource (19.85s)
--- PASS: TestAccSidecarCftTemplateDataSource (20.64s)
--- PASS: TestAccSidecarInstanceIDsDataSource (11.90s)
--- PASS: TestAccIdPIntegrationResource (47.63s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/deprecated	(cached)
=== RUN   TestIntegrationAWSIAMAuthN
=== PAUSE TestIntegrationAWSIAMAuthN
=== CONT  TestIntegrationAWSIAMAuthN
--- PASS: TestIntegrationAWSIAMAuthN (23.19s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/awsiam	(cached)
=== RUN   TestAccDuoMFAIntegrationResource
=== PAUSE TestAccDuoMFAIntegrationResource
=== CONT  TestAccDuoMFAIntegrationResource
--- PASS: TestAccDuoMFAIntegrationResource (11.11s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/confextension/mfaduo	(cached)
=== RUN   TestAccPagerDutyIntegrationResource
=== PAUSE TestAccPagerDutyIntegrationResource
=== CONT  TestAccPagerDutyIntegrationResource
--- PASS: TestAccPagerDutyIntegrationResource (10.77s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/confextension/pagerduty	(cached)
=== RUN   TestAccHCVaultIntegrationResource
=== PAUSE TestAccHCVaultIntegrationResource
=== CONT  TestAccHCVaultIntegrationResource
--- PASS: TestAccHCVaultIntegrationResource (10.27s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/hcvault	(cached)
=== RUN   TestAccIntegrationIdPSAMLDataSource
=== PAUSE TestAccIntegrationIdPSAMLDataSource
=== RUN   TestAccIntegrationIdPSAMLDraftResource
=== PAUSE TestAccIntegrationIdPSAMLDraftResource
=== RUN   TestAccIntegrationIdPSAMLResource
=== PAUSE TestAccIntegrationIdPSAMLResource
=== CONT  TestAccIntegrationIdPSAMLDataSource
=== CONT  TestAccIntegrationIdPSAMLDraftResource
=== CONT  TestAccIntegrationIdPSAMLResource
--- PASS: TestAccIntegrationIdPSAMLDraftResource (14.33s)
--- PASS: TestAccIntegrationIdPSAMLDataSource (26.66s)
--- PASS: TestAccIntegrationIdPSAMLResource (30.46s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/idpsaml	(cached)
=== RUN   TestAccLoggingIntegrationDataSource
=== PAUSE TestAccLoggingIntegrationDataSource
=== RUN   TestAccLogsIntegrationResourceCloudWatch
=== PAUSE TestAccLogsIntegrationResourceCloudWatch
=== RUN   TestAccLogsIntegrationResourceDataDog
=== PAUSE TestAccLogsIntegrationResourceDataDog
=== RUN   TestAccLogsIntegrationResourceElk
=== PAUSE TestAccLogsIntegrationResourceElk
=== RUN   TestAccLogsIntegrationResourceElkEmptyEsCredentials
=== PAUSE TestAccLogsIntegrationResourceElkEmptyEsCredentials
=== RUN   TestAccLogsIntegrationResourceSplunk
=== PAUSE TestAccLogsIntegrationResourceSplunk
=== RUN   TestAccLogsIntegrationResourceSumologic
=== PAUSE TestAccLogsIntegrationResourceSumologic
=== RUN   TestAccLogsIntegrationResourceFluentbit
=== PAUSE TestAccLogsIntegrationResourceFluentbit
=== CONT  TestAccLogsIntegrationResourceElkEmptyEsCredentials
=== CONT  TestAccLogsIntegrationResourceElk
=== CONT  TestAccLogsIntegrationResourceSplunk
=== CONT  TestAccLogsIntegrationResourceCloudWatch
=== CONT  TestAccLogsIntegrationResourceDataDog
=== CONT  TestAccLoggingIntegrationDataSource
=== CONT  TestAccLogsIntegrationResourceFluentbit
=== CONT  TestAccLogsIntegrationResourceSumologic
--- PASS: TestAccLogsIntegrationResourceDataDog (9.68s)
--- PASS: TestAccLogsIntegrationResourceFluentbit (10.47s)
--- PASS: TestAccLogsIntegrationResourceElk (11.07s)
--- PASS: TestAccLogsIntegrationResourceCloudWatch (11.14s)
--- PASS: TestAccLogsIntegrationResourceSplunk (11.93s)
--- PASS: TestAccLogsIntegrationResourceElkEmptyEsCredentials (11.93s)
--- PASS: TestAccLogsIntegrationResourceSumologic (11.93s)
--- PASS: TestAccLoggingIntegrationDataSource (13.80s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/logging	(cached)
=== RUN   TestAccSlackAlertsIntegrationResource
=== PAUSE TestAccSlackAlertsIntegrationResource
=== CONT  TestAccSlackAlertsIntegrationResource
--- PASS: TestAccSlackAlertsIntegrationResource (8.35s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/slack	(cached)
=== RUN   TestAccMsTeamsIntegrationResource
=== PAUSE TestAccMsTeamsIntegrationResource
=== CONT  TestAccMsTeamsIntegrationResource
--- PASS: TestAccMsTeamsIntegrationResource (8.24s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/teams	(cached)
=== RUN   TestAccPermissionDataSource
=== PAUSE TestAccPermissionDataSource
=== CONT  TestAccPermissionDataSource
--- PASS: TestAccPermissionDataSource (4.58s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/permission	(cached)
=== RUN   TestAccPolicyResource
=== PAUSE TestAccPolicyResource
=== CONT  TestAccPolicyResource
--- PASS: TestAccPolicyResource (7.19s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/policy	(cached)
=== RUN   TestAccPolicyRuleResource
=== PAUSE TestAccPolicyRuleResource
=== RUN   TestPolicyRuleResourceUpgradeV0
--- PASS: TestPolicyRuleResourceUpgradeV0 (0.00s)
=== CONT  TestAccPolicyRuleResource
--- PASS: TestAccPolicyRuleResource (17.74s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/policy/rule	(cached)
=== RUN   TestAccRegoPolicyInstanceResource
=== PAUSE TestAccRegoPolicyInstanceResource
=== CONT  TestAccRegoPolicyInstanceResource
--- PASS: TestAccRegoPolicyInstanceResource (7.77s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/regopolicy	(cached)
=== RUN   TestAccRepositoryDataSource
=== PAUSE TestAccRepositoryDataSource
=== RUN   TestAccRepositoryResource
=== PAUSE TestAccRepositoryResource
=== CONT  TestAccRepositoryDataSource
=== CONT  TestAccRepositoryResource
--- PASS: TestAccRepositoryDataSource (14.14s)
--- PASS: TestAccRepositoryResource (19.74s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository	(cached)
=== RUN   TestAccRepositoryAccessGatewayResource
=== PAUSE TestAccRepositoryAccessGatewayResource
=== CONT  TestAccRepositoryAccessGatewayResource
--- PASS: TestAccRepositoryAccessGatewayResource (19.04s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/accessgateway	(cached)
=== RUN   TestAccRepositoryAccessRulesResource
=== PAUSE TestAccRepositoryAccessRulesResource
=== CONT  TestAccRepositoryAccessRulesResource
--- PASS: TestAccRepositoryAccessRulesResource (14.05s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/accessrules	(cached)
=== RUN   TestAccRepositoryBindingResource
=== PAUSE TestAccRepositoryBindingResource
=== CONT  TestAccRepositoryBindingResource
--- PASS: TestAccRepositoryBindingResource (10.67s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/binding	(cached)
=== RUN   TestAccRepositoryConfAnalysisResource
=== PAUSE TestAccRepositoryConfAnalysisResource
=== RUN   TestRepositoryConfAnalysisResourceUpgradeV0
--- PASS: TestRepositoryConfAnalysisResourceUpgradeV0 (0.00s)
=== CONT  TestAccRepositoryConfAnalysisResource
--- PASS: TestAccRepositoryConfAnalysisResource (8.46s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/confanalysis	(cached)
=== RUN   TestAccRepositoryConfAuthResource
=== PAUSE TestAccRepositoryConfAuthResource
=== RUN   TestRepositoryConfAuthResourceUpgradeV0
--- PASS: TestRepositoryConfAuthResourceUpgradeV0 (0.00s)
=== CONT  TestAccRepositoryConfAuthResource
--- PASS: TestAccRepositoryConfAuthResource (15.61s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/confauth	(cached)
=== RUN   TestAccRepositoryDatamapResource
=== PAUSE TestAccRepositoryDatamapResource
=== CONT  TestAccRepositoryDatamapResource
--- PASS: TestAccRepositoryDatamapResource (21.58s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/datamap	(cached)
=== RUN   TestAccRepositoryNetworkAccessPolicyResource
=== PAUSE TestAccRepositoryNetworkAccessPolicyResource
=== CONT  TestAccRepositoryNetworkAccessPolicyResource
--- PASS: TestAccRepositoryNetworkAccessPolicyResource (21.95s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/network	(cached)
=== RUN   TestAccRepositoryUserAccountResource
=== PAUSE TestAccRepositoryUserAccountResource
=== CONT  TestAccRepositoryUserAccountResource
--- PASS: TestAccRepositoryUserAccountResource (43.92s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/useraccount	(cached)
=== RUN   TestAccRoleDataSource
=== PAUSE TestAccRoleDataSource
=== RUN   TestAccRoleSSOGroupsResource
=== PAUSE TestAccRoleSSOGroupsResource
=== RUN   TestRoleSSOGroupsResourceUpgradeV0
--- PASS: TestRoleSSOGroupsResourceUpgradeV0 (0.00s)
=== RUN   TestAccRoleResource
=== PAUSE TestAccRoleResource
=== CONT  TestAccRoleResource
=== CONT  TestAccRoleSSOGroupsResource
=== CONT  TestAccRoleDataSource
--- PASS: TestAccRoleDataSource (6.12s)
--- PASS: TestAccRoleSSOGroupsResource (12.36s)
--- PASS: TestAccRoleResource (18.59s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/role	(cached)
=== RUN   TestAccSAMLCertificateDataSource
=== PAUSE TestAccSAMLCertificateDataSource
=== CONT  TestAccSAMLCertificateDataSource
--- PASS: TestAccSAMLCertificateDataSource (4.63s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/samlcertificate	(cached)
=== RUN   TestAccSAMLConfigurationDataSource
=== PAUSE TestAccSAMLConfigurationDataSource
=== CONT  TestAccSAMLConfigurationDataSource
--- PASS: TestAccSAMLConfigurationDataSource (8.88s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/samlconfiguration	(cached)
=== RUN   TestAccServiceAccountResource
=== PAUSE TestAccServiceAccountResource
=== CONT  TestAccServiceAccountResource
--- PASS: TestAccServiceAccountResource (22.27s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/serviceaccount	(cached)
=== RUN   TestAccSidecarBoundPortsDataSource
=== PAUSE TestAccSidecarBoundPortsDataSource
=== RUN   TestAccSidecarIDDataSource
=== PAUSE TestAccSidecarIDDataSource
=== RUN   TestAccSidecarResource
=== PAUSE TestAccSidecarResource
=== CONT  TestAccSidecarIDDataSource
=== CONT  TestAccSidecarResource
=== CONT  TestAccSidecarBoundPortsDataSource
--- PASS: TestAccSidecarIDDataSource (6.87s)
--- PASS: TestAccSidecarBoundPortsDataSource (12.89s)
--- PASS: TestAccSidecarResource (25.17s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/sidecar	(cached)
=== RUN   TestAccSidecarCredentialsResource
=== PAUSE TestAccSidecarCredentialsResource
=== CONT  TestAccSidecarCredentialsResource
--- PASS: TestAccSidecarCredentialsResource (5.83s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/sidecar/credentials	(cached)
=== RUN   TestAccSidecarHealthDataSource
=== PAUSE TestAccSidecarHealthDataSource
=== CONT  TestAccSidecarHealthDataSource
--- PASS: TestAccSidecarHealthDataSource (6.06s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/sidecar/health	(cached)
=== RUN   TestAccSidecarInstanceStatsDataSource
=== PAUSE TestAccSidecarInstanceStatsDataSource
=== RUN   TestAccSidecarInstanceDataSource
=== PAUSE TestAccSidecarInstanceDataSource
=== CONT  TestAccSidecarInstanceStatsDataSource
=== CONT  TestAccSidecarInstanceDataSource
--- PASS: TestAccSidecarInstanceStatsDataSource (4.07s)
--- PASS: TestAccSidecarInstanceDataSource (6.55s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/sidecar/instance	7.155s
=== RUN   TestAccSidecarListenerDataSource
=== PAUSE TestAccSidecarListenerDataSource
=== RUN   TestSidecarListenerResource
=== PAUSE TestSidecarListenerResource
=== CONT  TestAccSidecarListenerDataSource
=== CONT  TestSidecarListenerResource
--- PASS: TestAccSidecarListenerDataSource (17.30s)
--- PASS: TestSidecarListenerResource (33.30s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/sidecar/listener	(cached)
testing: warning: no tests to run
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/sweep	(cached) [no tests to run]
=== RUN   TestAccSystemInfoDataSource
=== PAUSE TestAccSystemInfoDataSource
=== CONT  TestAccSystemInfoDataSource
--- PASS: TestAccSystemInfoDataSource (4.35s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/systeminfo	(cached)
=== RUN   TestAccAccessTokenSettingsResource
=== PAUSE TestAccAccessTokenSettingsResource
=== CONT  TestAccAccessTokenSettingsResource
--- PASS: TestAccAccessTokenSettingsResource (14.63s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/internal/tokensettings	(cached)
=== RUN   TestAccProvider
--- PASS: TestAccProvider (0.01s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/provider	(cached)
=== RUN   TestElementsMatch
--- PASS: TestElementsMatch (0.00s)
PASS
ok  	github.com/cyralinc/terraform-provider-cyral/cyral/utils	(cached)
```
