### PR TITLE
Add missing mongodb flavor configuration

### DIFF
--- a/cyral/internal/repository/data_source_cyral_repository.go
+++ b/cyral/internal/repository/data_source_cyral_repository.go
@@ -179,12 +179,17 @@ func DataSourceRepository() *schema.Resource {
 										Computed:    true,
 									},
 									RepoMongoDBServerTypeKey: {
-										Description: "Type of the MongoDB server. Allowed values: " + utils.SupportedValuesAsMarkdown(mongoServerTypes()),
+										Description: "Type of the MongoDB server.",
 										Type:        schema.TypeString,
 										Computed:    true,
 									},
 									RepoMongoDBSRVRecordName: {
-										Description: "Name of a DNS SRV record which contains cluster topology details",
+										Description: "Name of a DNS SRV record which contains cluster topology details.",
+										Type:        schema.TypeString,
+										Optional:    true,
+									},
+									RepoMongoDBFlavorKey: {
+										Description: "The flavor of the MongoDB deployment.",
 										Type:        schema.TypeString,
 										Optional:    true,
 									},

--- a/cyral/internal/repository/resource_cyral_repository_test.go
+++ b/cyral/internal/repository/resource_cyral_repository_test.go
@@ -280,6 +280,7 @@ func repoAsConfig(repo repository.RepoInfo, resName string) string {
 		replicaSet := "null"
 		serverType := "null"
 		srvRecordName := "null"
+		flavor := "null"
 		if repo.MongoDBSettings.ReplicaSetName != "" {
 			replicaSet = fmt.Sprintf(`"%s"`, repo.MongoDBSettings.ReplicaSetName)
 		}
@@ -289,15 +290,20 @@ func repoAsConfig(repo repository.RepoInfo, resName string) string {
 		if repo.MongoDBSettings.SRVRecordName != "" {
 			srvRecordName = fmt.Sprintf(`"%s"`, repo.MongoDBSettings.SRVRecordName)
 		}
+		if repo.MongoDBSettings.Flavor != "" {
+			flavor = fmt.Sprintf(`"%s"`, repo.MongoDBSettings.Flavor)
+		}
 		config += fmt.Sprintf(`
 		mongodb_settings {
 			replica_set_name = %s
 			server_type = %s
 			srv_record_name = %s
+			flavor = %s
 		}`,
 			replicaSet,
 			serverType,
 			srvRecordName,
+			flavor,
 		)
 	}
 

--- a/docs/data-sources/repository.md
+++ b/docs/data-sources/repository.md
@@ -127,6 +127,7 @@ Read-Only:
 
 Read-Only:
 
+- `flavor` (String)
 - `replica_set_name` (String)
 - `server_type` (String)
 - `srv_record_name` (String)


### PR DESCRIPTION
## Description of the change

The [PR](503) that added support for the `flavor` attribute in `cyral_repository.mongodb_settings` missed the respective data source.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

```
go test github.com/cyralinc/terraform-provider-cyral/... -v -race -timeout 20m
?       github.com/cyralinc/terraform-provider-cyral    [no test files]
?       github.com/cyralinc/terraform-provider-cyral/cyral/core [no test files]
?       github.com/cyralinc/terraform-provider-cyral/cyral/core/types/operationtype     [no test files]
?       github.com/cyralinc/terraform-provider-cyral/cyral/core/types/resourcetype      [no test files]
=== RUN   TestNewClient_WhenTLSSkipVerifyIsEnabled_ThenInsecureSkipVerifyIsTrue
--- PASS: TestNewClient_WhenTLSSkipVerifyIsEnabled_ThenInsecureSkipVerifyIsTrue (0.00s)
=== RUN   TestNewClient_WhenTLSSkipVerifyIsDisabled_ThenInsecureSkipVerifyIsFalse
--- PASS: TestNewClient_WhenTLSSkipVerifyIsDisabled_ThenInsecureSkipVerifyIsFalse (0.00s)
=== RUN   TestNewClient_WhenClientIDIsEmpty_ThenThrowError
--- PASS: TestNewClient_WhenClientIDIsEmpty_ThenThrowError (0.00s)
=== RUN   TestNewClient_WhenClientSecretIsEmpty_ThenThrowError
--- PASS: TestNewClient_WhenClientSecretIsEmpty_ThenThrowError (0.00s)
=== RUN   TestNewClient_WhenControlPlaneIsEmpty_ThenThrowError
--- PASS: TestNewClient_WhenControlPlaneIsEmpty_ThenThrowError (0.00s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/client       (cached)
?       github.com/cyralinc/terraform-provider-cyral/cyral/internal/datalabel/classificationrule        [no test files]
=== RUN   TestAccDatalabelDataSource
=== PAUSE TestAccDatalabelDataSource
=== RUN   TestAccDatalabelResource
--- PASS: TestAccDatalabelResource (3.97s)
=== CONT  TestAccDatalabelDataSource
--- PASS: TestAccDatalabelDataSource (20.67s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/datalabel   (cached)
?       github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/confextension   [no test files]
=== RUN   TestAccSidecarInstanceIDsDataSource
=== PAUSE TestAccSidecarInstanceIDsDataSource
=== RUN   TestIntegrationsData_GetValue_Default
--- PASS: TestIntegrationsData_GetValue_Default (0.00s)
=== RUN   TestIntegrationsData_GetValue_Splunk
--- PASS: TestIntegrationsData_GetValue_Splunk (0.00s)
=== RUN   TestAccDatadogIntegrationResource
=== PAUSE TestAccDatadogIntegrationResource
=== RUN   TestAccELKIntegrationResource
=== PAUSE TestAccELKIntegrationResource
=== RUN   TestAccIdPIntegrationResource
=== PAUSE TestAccIdPIntegrationResource
=== RUN   TestAccLogstashIntegrationResource
=== PAUSE TestAccLogstashIntegrationResource
=== RUN   TestAccLookerIntegrationResource
=== PAUSE TestAccLookerIntegrationResource
=== RUN   TestAccSplunkIntegrationResource
=== PAUSE TestAccSplunkIntegrationResource
=== RUN   TestAccSumoLogicIntegrationResource
=== PAUSE TestAccSumoLogicIntegrationResource
=== CONT  TestAccSidecarInstanceIDsDataSource
=== CONT  TestAccSplunkIntegrationResource
=== CONT  TestAccELKIntegrationResource
=== CONT  TestAccLookerIntegrationResource
=== CONT  TestAccSumoLogicIntegrationResource
=== CONT  TestAccIdPIntegrationResource
=== CONT  TestAccLogstashIntegrationResource
=== CONT  TestAccDatadogIntegrationResource
--- PASS: TestAccSumoLogicIntegrationResource (7.03s)
--- PASS: TestAccSplunkIntegrationResource (7.36s)
--- PASS: TestAccDatadogIntegrationResource (7.48s)
--- PASS: TestAccLookerIntegrationResource (7.65s)
--- PASS: TestAccELKIntegrationResource (8.11s)
--- PASS: TestAccSidecarInstanceIDsDataSource (9.36s)
--- PASS: TestAccLogstashIntegrationResource (14.74s)
--- PASS: TestAccIdPIntegrationResource (51.14s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/deprecated  (cached)
=== RUN   TestIntegrationAWSIAMAuthN
=== PAUSE TestIntegrationAWSIAMAuthN
=== CONT  TestIntegrationAWSIAMAuthN
--- PASS: TestIntegrationAWSIAMAuthN (17.77s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/awsiam  (cached)
=== RUN   TestAccDuoMFAIntegrationResource
=== PAUSE TestAccDuoMFAIntegrationResource
=== CONT  TestAccDuoMFAIntegrationResource
--- PASS: TestAccDuoMFAIntegrationResource (8.32s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/confextension/mfaduo    (cached)
=== RUN   TestAccPagerDutyIntegrationResource
=== PAUSE TestAccPagerDutyIntegrationResource
=== CONT  TestAccPagerDutyIntegrationResource
--- PASS: TestAccPagerDutyIntegrationResource (9.16s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/confextension/pagerduty (cached)
=== RUN   TestAccHCVaultIntegrationResource
=== PAUSE TestAccHCVaultIntegrationResource
=== CONT  TestAccHCVaultIntegrationResource
--- PASS: TestAccHCVaultIntegrationResource (8.01s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/hcvault (cached)
=== RUN   TestAccIntegrationIdPSAMLDataSource
=== PAUSE TestAccIntegrationIdPSAMLDataSource
=== RUN   TestAccIntegrationIdPSAMLDraftResource
=== PAUSE TestAccIntegrationIdPSAMLDraftResource
=== RUN   TestAccIntegrationIdPSAMLResource
=== PAUSE TestAccIntegrationIdPSAMLResource
=== CONT  TestAccIntegrationIdPSAMLDraftResource
=== CONT  TestAccIntegrationIdPSAMLResource
=== CONT  TestAccIntegrationIdPSAMLDataSource
--- PASS: TestAccIntegrationIdPSAMLDraftResource (12.79s)
--- PASS: TestAccIntegrationIdPSAMLDataSource (29.01s)
--- PASS: TestAccIntegrationIdPSAMLResource (34.40s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/idpsaml (cached)
=== RUN   TestAccLoggingIntegrationDataSource
=== PAUSE TestAccLoggingIntegrationDataSource
=== RUN   TestAccLogsIntegrationResourceCloudWatch
=== PAUSE TestAccLogsIntegrationResourceCloudWatch
=== RUN   TestAccLogsIntegrationResourceDataDog
=== PAUSE TestAccLogsIntegrationResourceDataDog
=== RUN   TestAccLogsIntegrationResourceElk
=== PAUSE TestAccLogsIntegrationResourceElk
=== RUN   TestAccLogsIntegrationResourceElkEmptyEsCredentials
=== PAUSE TestAccLogsIntegrationResourceElkEmptyEsCredentials
=== RUN   TestAccLogsIntegrationResourceSplunk
=== PAUSE TestAccLogsIntegrationResourceSplunk
=== RUN   TestAccLogsIntegrationResourceSumologic
=== PAUSE TestAccLogsIntegrationResourceSumologic
=== RUN   TestAccLogsIntegrationResourceFluentbit
=== PAUSE TestAccLogsIntegrationResourceFluentbit
=== CONT  TestAccLogsIntegrationResourceDataDog
=== CONT  TestAccLogsIntegrationResourceElk
=== CONT  TestAccLogsIntegrationResourceCloudWatch
=== CONT  TestAccLogsIntegrationResourceSumologic
=== CONT  TestAccLogsIntegrationResourceSplunk
=== CONT  TestAccLogsIntegrationResourceFluentbit
=== CONT  TestAccLoggingIntegrationDataSource
=== CONT  TestAccLogsIntegrationResourceElkEmptyEsCredentials
--- PASS: TestAccLogsIntegrationResourceFluentbit (10.83s)
--- PASS: TestAccLogsIntegrationResourceElk (10.92s)
--- PASS: TestAccLogsIntegrationResourceDataDog (11.02s)
--- PASS: TestAccLogsIntegrationResourceElkEmptyEsCredentials (11.04s)
--- PASS: TestAccLogsIntegrationResourceSplunk (11.11s)
--- PASS: TestAccLogsIntegrationResourceSumologic (11.75s)
--- PASS: TestAccLogsIntegrationResourceCloudWatch (11.77s)
--- PASS: TestAccLoggingIntegrationDataSource (13.20s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/logging (cached)
=== RUN   TestAccSlackAlertsIntegrationResource
=== PAUSE TestAccSlackAlertsIntegrationResource
=== CONT  TestAccSlackAlertsIntegrationResource
--- PASS: TestAccSlackAlertsIntegrationResource (9.43s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/slack   (cached)
=== RUN   TestAccMsTeamsIntegrationResource
=== PAUSE TestAccMsTeamsIntegrationResource
=== CONT  TestAccMsTeamsIntegrationResource
--- PASS: TestAccMsTeamsIntegrationResource (6.01s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/teams   (cached)
=== RUN   TestAccPermissionDataSource
=== PAUSE TestAccPermissionDataSource
=== CONT  TestAccPermissionDataSource
--- PASS: TestAccPermissionDataSource (4.95s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/permission  (cached)
=== RUN   TestAccPolicyResource
=== PAUSE TestAccPolicyResource
=== CONT  TestAccPolicyResource
--- PASS: TestAccPolicyResource (6.34s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/policy      (cached)
=== RUN   TestAccPolicyRuleResource
=== PAUSE TestAccPolicyRuleResource
=== RUN   TestPolicyRuleResourceUpgradeV0
--- PASS: TestPolicyRuleResourceUpgradeV0 (0.00s)
=== CONT  TestAccPolicyRuleResource
--- PASS: TestAccPolicyRuleResource (16.79s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/policy/rule (cached)
=== RUN   TestAccRegoPolicyInstanceResource
=== PAUSE TestAccRegoPolicyInstanceResource
=== CONT  TestAccRegoPolicyInstanceResource
--- PASS: TestAccRegoPolicyInstanceResource (8.54s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/regopolicy  (cached)
=== RUN   TestAccRepositoryDataSource
=== PAUSE TestAccRepositoryDataSource
=== RUN   TestAccRepositoryResource
=== PAUSE TestAccRepositoryResource
=== CONT  TestAccRepositoryResource
=== CONT  TestAccRepositoryDataSource
--- PASS: TestAccRepositoryDataSource (11.13s)
--- PASS: TestAccRepositoryResource (16.01s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository  18.085s
=== RUN   TestAccRepositoryAccessGatewayResource
=== PAUSE TestAccRepositoryAccessGatewayResource
=== CONT  TestAccRepositoryAccessGatewayResource
--- PASS: TestAccRepositoryAccessGatewayResource (19.08s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/accessgateway    (cached)
=== RUN   TestAccRepositoryAccessRulesResource
=== PAUSE TestAccRepositoryAccessRulesResource
=== CONT  TestAccRepositoryAccessRulesResource
--- PASS: TestAccRepositoryAccessRulesResource (11.93s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/accessrules      (cached)
=== RUN   TestAccRepositoryBindingResource
=== PAUSE TestAccRepositoryBindingResource
=== CONT  TestAccRepositoryBindingResource
--- PASS: TestAccRepositoryBindingResource (10.59s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/binding  (cached)
=== RUN   TestAccRepositoryConfAnalysisResource
=== PAUSE TestAccRepositoryConfAnalysisResource
=== RUN   TestRepositoryConfAnalysisResourceUpgradeV0
--- PASS: TestRepositoryConfAnalysisResourceUpgradeV0 (0.00s)
=== CONT  TestAccRepositoryConfAnalysisResource
--- PASS: TestAccRepositoryConfAnalysisResource (7.54s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/confanalysis     (cached)
=== RUN   TestAccRepositoryConfAuthResource
=== PAUSE TestAccRepositoryConfAuthResource
=== RUN   TestRepositoryConfAuthResourceUpgradeV0
--- PASS: TestRepositoryConfAuthResourceUpgradeV0 (0.00s)
=== CONT  TestAccRepositoryConfAuthResource
--- PASS: TestAccRepositoryConfAuthResource (13.33s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/confauth (cached)
=== RUN   TestAccRepositoryDatamapResource
=== PAUSE TestAccRepositoryDatamapResource
=== CONT  TestAccRepositoryDatamapResource
--- PASS: TestAccRepositoryDatamapResource (18.28s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/datamap  (cached)
=== RUN   TestAccRepositoryNetworkAccessPolicyResource
=== PAUSE TestAccRepositoryNetworkAccessPolicyResource
=== CONT  TestAccRepositoryNetworkAccessPolicyResource
--- PASS: TestAccRepositoryNetworkAccessPolicyResource (17.98s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/network  (cached)
=== RUN   TestAccRepositoryUserAccountResource
=== PAUSE TestAccRepositoryUserAccountResource
=== CONT  TestAccRepositoryUserAccountResource
--- PASS: TestAccRepositoryUserAccountResource (35.54s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/useraccount      (cached)
=== RUN   TestAccRoleDataSource
=== PAUSE TestAccRoleDataSource
=== RUN   TestAccRoleSSOGroupsResource
=== PAUSE TestAccRoleSSOGroupsResource
=== RUN   TestRoleSSOGroupsResourceUpgradeV0
--- PASS: TestRoleSSOGroupsResourceUpgradeV0 (0.00s)
=== RUN   TestAccRoleResource
=== PAUSE TestAccRoleResource
=== CONT  TestAccRoleDataSource
=== CONT  TestAccRoleResource
=== CONT  TestAccRoleSSOGroupsResource
--- PASS: TestAccRoleDataSource (11.36s)
--- PASS: TestAccRoleSSOGroupsResource (15.28s)
--- PASS: TestAccRoleResource (21.09s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/role        (cached)
=== RUN   TestAccSAMLCertificateDataSource
=== PAUSE TestAccSAMLCertificateDataSource
=== CONT  TestAccSAMLCertificateDataSource
--- PASS: TestAccSAMLCertificateDataSource (5.28s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/samlcertificate     (cached)
=== RUN   TestAccSAMLConfigurationDataSource
=== PAUSE TestAccSAMLConfigurationDataSource
=== CONT  TestAccSAMLConfigurationDataSource
--- PASS: TestAccSAMLConfigurationDataSource (9.66s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/samlconfiguration   (cached)
=== RUN   TestAccServiceAccountResource
=== PAUSE TestAccServiceAccountResource
=== CONT  TestAccServiceAccountResource
--- PASS: TestAccServiceAccountResource (19.66s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/serviceaccount      (cached)
=== RUN   TestAccSidecarBoundPortsDataSource
=== PAUSE TestAccSidecarBoundPortsDataSource
=== RUN   TestAccSidecarIDDataSource
=== PAUSE TestAccSidecarIDDataSource
=== RUN   TestAccSidecarResource
=== PAUSE TestAccSidecarResource
=== CONT  TestAccSidecarBoundPortsDataSource
=== CONT  TestAccSidecarResource
=== CONT  TestAccSidecarIDDataSource
--- PASS: TestAccSidecarIDDataSource (6.90s)
--- PASS: TestAccSidecarBoundPortsDataSource (12.18s)
--- PASS: TestAccSidecarResource (21.22s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/sidecar     (cached)
=== RUN   TestAccSidecarCredentialsResource
=== PAUSE TestAccSidecarCredentialsResource
=== CONT  TestAccSidecarCredentialsResource
--- PASS: TestAccSidecarCredentialsResource (6.21s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/sidecar/credentials (cached)
=== RUN   TestAccSidecarHealthDataSource
=== PAUSE TestAccSidecarHealthDataSource
=== CONT  TestAccSidecarHealthDataSource
--- PASS: TestAccSidecarHealthDataSource (7.41s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/sidecar/health      (cached)
=== RUN   TestAccSidecarInstanceStatsDataSource
=== PAUSE TestAccSidecarInstanceStatsDataSource
=== RUN   TestAccSidecarInstanceDataSource
=== PAUSE TestAccSidecarInstanceDataSource
=== CONT  TestAccSidecarInstanceDataSource
=== CONT  TestAccSidecarInstanceStatsDataSource
--- PASS: TestAccSidecarInstanceStatsDataSource (5.50s)
--- PASS: TestAccSidecarInstanceDataSource (6.04s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/sidecar/instance    (cached)
=== RUN   TestAccSidecarListenerDataSource
=== PAUSE TestAccSidecarListenerDataSource
=== RUN   TestSidecarListenerResource
=== PAUSE TestSidecarListenerResource
=== CONT  TestSidecarListenerResource
=== CONT  TestAccSidecarListenerDataSource
--- PASS: TestAccSidecarListenerDataSource (13.44s)
--- PASS: TestSidecarListenerResource (27.44s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/sidecar/listener    (cached)
testing: warning: no tests to run
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/sweep       (cached) [no tests to run]
=== RUN   TestAccSystemInfoDataSource
=== PAUSE TestAccSystemInfoDataSource
=== CONT  TestAccSystemInfoDataSource
--- PASS: TestAccSystemInfoDataSource (3.62s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/systeminfo  (cached)
=== RUN   TestAccAccessTokenSettingsResource
=== PAUSE TestAccAccessTokenSettingsResource
=== CONT  TestAccAccessTokenSettingsResource
--- PASS: TestAccAccessTokenSettingsResource (11.87s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/tokensettings       (cached)
=== RUN   TestAccProvider
--- PASS: TestAccProvider (0.01s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/provider     (cached)
=== RUN   TestElementsMatch
--- PASS: TestElementsMatch (0.00s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/utils        (cached)
```