### PR TITLE
Fix role name in RDS IAM required permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 4.9.2 (February 28, 2024)
+
+It is safe to use this version with all `v4` control planes as long
+as the new incompatible features are not used. These features require
+a minimum version of the control plane and are detailed below.
+
+The minimum control plane version required for full compatibility
+with all the features in this release is `v4.12.0`.
+
+See the list of incompatible attributes, data sources and resources
+with previous `v4` control planes in the [`v4.9.0`](#490-january-31-2024)
+release documentation.
+
+### Documentation:
+
+- Fix role name in RDS IAM required permissions ([#513](https://github.com/cyralinc/terraform-provider-cyral/pull/513))
+
 ## 4.9.1 (February 14, 2024)
 
 It is safe to use this version with all `v4` control planes as long

--- a/docs/guides/iam_auth_rds_pg.md
+++ b/docs/guides/iam_auth_rds_pg.md
@@ -4,13 +4,13 @@ page_title: "Authentication from sidecar to RDS using an AWS IAM role"
 
 -> **Note** This guide assumes you have an RDS PG instance that is
 reachable from the subnets the sidecar will be deployed to. Make
-sure you create the user in the database that corresponds to the role
-created in this example and grant the `rds_iam` permission as shown
-in the following command:
+sure you create the user in the database that corresponds to the name of
+the role created in this example and grant the `rds_iam` permission as
+shown in the following command:
 
 ```
-CREATE USER "arn:aws:iam::YOUR_AWS_ACCOUNT_NUM:role/my-sidecar_rds_access_role";
-GRANT rds_iam TO "arn:aws:iam::YOUR_AWS_ACCOUNT_NUM:role/my-sidecar_rds_access_role";
+CREATE USER "my-sidecar_rds_access_role";
+GRANT rds_iam TO "my-sidecar_rds_access_role";
 ```
 
 Use this guide to create the minimum required configuration in both Cyral

--- a/templates/guides/iam_auth_rds_pg.md.tmpl
+++ b/templates/guides/iam_auth_rds_pg.md.tmpl
@@ -4,13 +4,13 @@ page_title: "Authentication from sidecar to RDS using an AWS IAM role"
 
 -> **Note** This guide assumes you have an RDS PG instance that is
 reachable from the subnets the sidecar will be deployed to. Make
-sure you create the user in the database that corresponds to the role
-created in this example and grant the `rds_iam` permission as shown
-in the following command:
+sure you create the user in the database that corresponds to the name of
+the role created in this example and grant the `rds_iam` permission as
+shown in the following command:
 
 ```
-CREATE USER "arn:aws:iam::YOUR_AWS_ACCOUNT_NUM:role/my-sidecar_rds_access_role";
-GRANT rds_iam TO "arn:aws:iam::YOUR_AWS_ACCOUNT_NUM:role/my-sidecar_rds_access_role";
+CREATE USER "my-sidecar_rds_access_role";
+GRANT rds_iam TO "my-sidecar_rds_access_role";
 ```
 
 Use this guide to create the minimum required configuration in both Cyral


### PR DESCRIPTION
## Description of the change

The current version of the docs points to the `arn` as the user name that must be created on the RDS instance, but this approach does not work. The role `name` must be used instead.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

The issue was found during tests with the actual guide, so the fix was required to get it running.