### PR TITLE
Ignore regex analysis for 404 status code

### DIFF
--- a/cyral/core/error_handlers.go
+++ b/cyral/core/error_handlers.go
@@ -27,6 +27,14 @@ func (h *IgnoreNotFoundByMessage) HandleError(
 ) error {
 	tflog.Debug(ctx, "==> Init HandleError core.IgnoreNotFoundByMessage")
 
+	// If this is a 404 already, then we don't need to actually match the error message
+	httpError, _ := err.(*client.HttpError)
+	if httpError.StatusCode == http.StatusNotFound {
+		tflog.Debug(ctx, "===> Ignoring regex matching as the status code is already 404")
+		r.SetId("")
+		return nil
+	}
+
 	matched, regexpError := regexp.MatchString(
 		h.MessageMatches,
 		err.Error(),


### PR DESCRIPTION
## Description of the change

Ignore regex error analysis for not found errors when the status code is already `404`.

This makes the TF provider compatible with APIs that had the status code properly fixed in case of resources not found and also for those old APIs that returned `50x` statuses.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

Manually tested the code forcing a `404` error in an old API that would normally return a `500`. Also made sure it works properly when returning an actual `500`.

The results of the acceptance tests are as follows:

```
terraform-provider-cyral % make local/test                                                
go test github.com/cyralinc/terraform-provider-cyral/... -v -race -timeout 20m
?       github.com/cyralinc/terraform-provider-cyral    [no test files]
?       github.com/cyralinc/terraform-provider-cyral/cyral/core [no test files]
?       github.com/cyralinc/terraform-provider-cyral/cyral/core/types/operationtype     [no test files]
?       github.com/cyralinc/terraform-provider-cyral/cyral/core/types/resourcetype      [no test files]
?       github.com/cyralinc/terraform-provider-cyral/cyral/internal/datalabel/classificationrule        [no test files]
?       github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/confextension   [no test files]
=== RUN   TestNewClient_WhenTLSSkipVerifyIsEnabled_ThenInsecureSkipVerifyIsTrue
--- PASS: TestNewClient_WhenTLSSkipVerifyIsEnabled_ThenInsecureSkipVerifyIsTrue (0.00s)
=== RUN   TestNewClient_WhenTLSSkipVerifyIsDisabled_ThenInsecureSkipVerifyIsFalse
--- PASS: TestNewClient_WhenTLSSkipVerifyIsDisabled_ThenInsecureSkipVerifyIsFalse (0.00s)
=== RUN   TestNewClient_WhenClientIDIsEmpty_ThenThrowError
--- PASS: TestNewClient_WhenClientIDIsEmpty_ThenThrowError (0.00s)
=== RUN   TestNewClient_WhenClientSecretIsEmpty_ThenThrowError
--- PASS: TestNewClient_WhenClientSecretIsEmpty_ThenThrowError (0.00s)
=== RUN   TestNewClient_WhenControlPlaneIsEmpty_ThenThrowError
--- PASS: TestNewClient_WhenControlPlaneIsEmpty_ThenThrowError (0.00s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/client       1.265s
=== RUN   TestAccDatalabelDataSource
=== PAUSE TestAccDatalabelDataSource
=== RUN   TestAccDatalabelResource
--- PASS: TestAccDatalabelResource (5.70s)
=== CONT  TestAccDatalabelDataSource
--- PASS: TestAccDatalabelDataSource (22.87s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/datalabel   31.929s
=== RUN   TestAccSAMLConfigurationDataSource
=== PAUSE TestAccSAMLConfigurationDataSource
=== RUN   TestAccSidecarInstanceIDsDataSource
=== PAUSE TestAccSidecarInstanceIDsDataSource
=== RUN   TestIntegrationsData_GetValue_Default
--- PASS: TestIntegrationsData_GetValue_Default (0.00s)
=== RUN   TestIntegrationsData_GetValue_Splunk
--- PASS: TestIntegrationsData_GetValue_Splunk (0.00s)
=== RUN   TestAccDatadogIntegrationResource
=== PAUSE TestAccDatadogIntegrationResource
=== RUN   TestAccELKIntegrationResource
=== PAUSE TestAccELKIntegrationResource
=== RUN   TestAccIdPIntegrationResource
=== PAUSE TestAccIdPIntegrationResource
=== RUN   TestAccLogstashIntegrationResource
=== PAUSE TestAccLogstashIntegrationResource
=== RUN   TestAccLookerIntegrationResource
=== PAUSE TestAccLookerIntegrationResource
=== RUN   TestAccSplunkIntegrationResource
=== PAUSE TestAccSplunkIntegrationResource
=== RUN   TestAccSumoLogicIntegrationResource
=== PAUSE TestAccSumoLogicIntegrationResource
=== CONT  TestAccSAMLConfigurationDataSource
=== CONT  TestAccLogstashIntegrationResource
=== CONT  TestAccSplunkIntegrationResource
=== CONT  TestAccSumoLogicIntegrationResource
=== CONT  TestAccLookerIntegrationResource
=== CONT  TestAccELKIntegrationResource
=== CONT  TestAccIdPIntegrationResource
=== CONT  TestAccDatadogIntegrationResource
=== CONT  TestAccSidecarInstanceIDsDataSource
--- PASS: TestAccDatadogIntegrationResource (12.88s)
--- PASS: TestAccSumoLogicIntegrationResource (13.18s)
--- PASS: TestAccELKIntegrationResource (13.19s)
--- PASS: TestAccSplunkIntegrationResource (14.27s)
--- PASS: TestAccLookerIntegrationResource (14.38s)
--- PASS: TestAccSidecarInstanceIDsDataSource (14.41s)
--- PASS: TestAccSAMLConfigurationDataSource (14.74s)
--- PASS: TestAccLogstashIntegrationResource (19.77s)
--- PASS: TestAccIdPIntegrationResource (44.08s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/deprecated  45.878s
=== RUN   TestIntegrationAWSIAMAuthN
=== PAUSE TestIntegrationAWSIAMAuthN
=== CONT  TestIntegrationAWSIAMAuthN
--- PASS: TestIntegrationAWSIAMAuthN (20.13s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/awsiam  21.535s
=== RUN   TestAccDuoMFAIntegrationResource
=== PAUSE TestAccDuoMFAIntegrationResource
=== CONT  TestAccDuoMFAIntegrationResource
--- PASS: TestAccDuoMFAIntegrationResource (10.84s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/confextension/mfaduo    13.035s
=== RUN   TestAccPagerDutyIntegrationResource
=== PAUSE TestAccPagerDutyIntegrationResource
=== CONT  TestAccPagerDutyIntegrationResource
--- PASS: TestAccPagerDutyIntegrationResource (10.48s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/confextension/pagerduty 13.086s
=== RUN   TestAccHCVaultIntegrationResource
=== PAUSE TestAccHCVaultIntegrationResource
=== CONT  TestAccHCVaultIntegrationResource
--- PASS: TestAccHCVaultIntegrationResource (11.35s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/hcvault 14.332s
=== RUN   TestAccIntegrationIdPSAMLDataSource
=== PAUSE TestAccIntegrationIdPSAMLDataSource
=== RUN   TestAccIntegrationIdPSAMLResource
=== PAUSE TestAccIntegrationIdPSAMLResource
=== CONT  TestAccIntegrationIdPSAMLResource
=== CONT  TestAccIntegrationIdPSAMLDataSource
--- PASS: TestAccIntegrationIdPSAMLDataSource (27.24s)
--- PASS: TestAccIntegrationIdPSAMLResource (27.91s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/idpsaml 31.280s
=== RUN   TestAccIntegrationIdPSAMLDraftResource
=== PAUSE TestAccIntegrationIdPSAMLDraftResource
=== CONT  TestAccIntegrationIdPSAMLDraftResource
--- PASS: TestAccIntegrationIdPSAMLDraftResource (14.62s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/idpsaml/draft   17.573s
=== RUN   TestAccLoggingIntegrationDataSource
=== PAUSE TestAccLoggingIntegrationDataSource
=== RUN   TestAccLogsIntegrationResourceCloudWatch
=== PAUSE TestAccLogsIntegrationResourceCloudWatch
=== RUN   TestAccLogsIntegrationResourceDataDog
=== PAUSE TestAccLogsIntegrationResourceDataDog
=== RUN   TestAccLogsIntegrationResourceElk
=== PAUSE TestAccLogsIntegrationResourceElk
=== RUN   TestAccLogsIntegrationResourceElkEmptyEsCredentials
=== PAUSE TestAccLogsIntegrationResourceElkEmptyEsCredentials
=== RUN   TestAccLogsIntegrationResourceSplunk
=== PAUSE TestAccLogsIntegrationResourceSplunk
=== RUN   TestAccLogsIntegrationResourceSumologic
=== PAUSE TestAccLogsIntegrationResourceSumologic
=== RUN   TestAccLogsIntegrationResourceFluentbit
=== PAUSE TestAccLogsIntegrationResourceFluentbit
=== CONT  TestAccLoggingIntegrationDataSource
=== CONT  TestAccLogsIntegrationResourceElk
=== CONT  TestAccLogsIntegrationResourceSplunk
=== CONT  TestAccLogsIntegrationResourceDataDog
=== CONT  TestAccLogsIntegrationResourceFluentbit
=== CONT  TestAccLogsIntegrationResourceElkEmptyEsCredentials
=== CONT  TestAccLogsIntegrationResourceCloudWatch
=== CONT  TestAccLogsIntegrationResourceSumologic
--- PASS: TestAccLogsIntegrationResourceDataDog (12.16s)
--- PASS: TestAccLogsIntegrationResourceSumologic (13.83s)
--- PASS: TestAccLogsIntegrationResourceFluentbit (14.10s)
--- PASS: TestAccLogsIntegrationResourceElk (14.17s)
--- PASS: TestAccLogsIntegrationResourceCloudWatch (15.04s)
--- PASS: TestAccLogsIntegrationResourceElkEmptyEsCredentials (15.04s)
--- PASS: TestAccLogsIntegrationResourceSplunk (15.11s)
--- PASS: TestAccLoggingIntegrationDataSource (18.01s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/logging 21.100s
=== RUN   TestAccSlackAlertsIntegrationResource
=== PAUSE TestAccSlackAlertsIntegrationResource
=== CONT  TestAccSlackAlertsIntegrationResource
--- PASS: TestAccSlackAlertsIntegrationResource (9.14s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/slack   10.653s
=== RUN   TestAccMsTeamsIntegrationResource
=== PAUSE TestAccMsTeamsIntegrationResource
=== CONT  TestAccMsTeamsIntegrationResource
--- PASS: TestAccMsTeamsIntegrationResource (8.82s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/teams   10.564s
=== RUN   TestAccPermissionDataSource
=== PAUSE TestAccPermissionDataSource
=== CONT  TestAccPermissionDataSource
--- PASS: TestAccPermissionDataSource (4.22s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/permission  5.635s
=== RUN   TestAccPolicyResource
=== PAUSE TestAccPolicyResource
=== CONT  TestAccPolicyResource
--- PASS: TestAccPolicyResource (7.95s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/policy      9.379s
=== RUN   TestAccPolicyRuleResource
=== PAUSE TestAccPolicyRuleResource
=== RUN   TestPolicyRuleResourceUpgradeV0
--- PASS: TestPolicyRuleResourceUpgradeV0 (0.00s)
=== CONT  TestAccPolicyRuleResource
--- PASS: TestAccPolicyRuleResource (18.32s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/policy/rule 19.754s
=== RUN   TestAccRegoPolicyInstanceResource
=== PAUSE TestAccRegoPolicyInstanceResource
=== CONT  TestAccRegoPolicyInstanceResource
--- PASS: TestAccRegoPolicyInstanceResource (7.19s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/regopolicy  8.622s
=== RUN   TestAccRepositoryDataSource
=== PAUSE TestAccRepositoryDataSource
=== RUN   TestAccRepositoryResource
=== PAUSE TestAccRepositoryResource
=== CONT  TestAccRepositoryResource
=== CONT  TestAccRepositoryDataSource
--- PASS: TestAccRepositoryDataSource (14.23s)
--- PASS: TestAccRepositoryResource (19.67s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository  21.223s
=== RUN   TestAccRepositoryAccessGatewayResource
=== PAUSE TestAccRepositoryAccessGatewayResource
=== CONT  TestAccRepositoryAccessGatewayResource
--- PASS: TestAccRepositoryAccessGatewayResource (24.22s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/accessgateway    25.662s
=== RUN   TestAccRepositoryAccessRulesResource
=== PAUSE TestAccRepositoryAccessRulesResource
=== CONT  TestAccRepositoryAccessRulesResource
--- PASS: TestAccRepositoryAccessRulesResource (15.27s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/accessrules      17.090s
=== RUN   TestAccRepositoryBindingResource
=== PAUSE TestAccRepositoryBindingResource
=== CONT  TestAccRepositoryBindingResource
--- PASS: TestAccRepositoryBindingResource (12.92s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/binding  14.342s
=== RUN   TestAccRepositoryConfAnalysisResource
=== PAUSE TestAccRepositoryConfAnalysisResource
=== RUN   TestRepositoryConfAnalysisResourceUpgradeV0
--- PASS: TestRepositoryConfAnalysisResourceUpgradeV0 (0.00s)
=== CONT  TestAccRepositoryConfAnalysisResource
--- PASS: TestAccRepositoryConfAnalysisResource (9.39s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/confanalysis     10.825s
=== RUN   TestAccRepositoryConfAuthResource
=== PAUSE TestAccRepositoryConfAuthResource
=== RUN   TestRepositoryConfAuthResourceUpgradeV0
--- PASS: TestRepositoryConfAuthResourceUpgradeV0 (0.00s)
=== CONT  TestAccRepositoryConfAuthResource
--- PASS: TestAccRepositoryConfAuthResource (15.62s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/confauth 17.200s
=== RUN   TestAccRepositoryDatamapResource
=== PAUSE TestAccRepositoryDatamapResource
=== CONT  TestAccRepositoryDatamapResource
--- PASS: TestAccRepositoryDatamapResource (21.60s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/datamap  23.415s
=== RUN   TestAccRepositoryNetworkAccessPolicyResource
=== PAUSE TestAccRepositoryNetworkAccessPolicyResource
=== CONT  TestAccRepositoryNetworkAccessPolicyResource
--- PASS: TestAccRepositoryNetworkAccessPolicyResource (21.54s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/network  22.970s
=== RUN   TestAccRepositoryUserAccountResource
=== PAUSE TestAccRepositoryUserAccountResource
=== CONT  TestAccRepositoryUserAccountResource
--- PASS: TestAccRepositoryUserAccountResource (46.19s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/useraccount      47.631s
=== RUN   TestAccRoleDataSource
=== PAUSE TestAccRoleDataSource
=== RUN   TestAccRoleResource
=== PAUSE TestAccRoleResource
=== CONT  TestAccRoleDataSource
=== CONT  TestAccRoleResource
--- PASS: TestAccRoleDataSource (8.08s)
--- PASS: TestAccRoleResource (17.29s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/role        18.885s
=== RUN   TestAccRoleSSOGroupsResource
=== PAUSE TestAccRoleSSOGroupsResource
=== RUN   TestRoleSSOGroupsResourceUpgradeV0
--- PASS: TestRoleSSOGroupsResourceUpgradeV0 (0.00s)
=== CONT  TestAccRoleSSOGroupsResource
--- PASS: TestAccRoleSSOGroupsResource (15.44s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/role/ssogroups      17.332s
=== RUN   TestAccSAMLCertificateDataSource
=== PAUSE TestAccSAMLCertificateDataSource
=== CONT  TestAccSAMLCertificateDataSource
--- PASS: TestAccSAMLCertificateDataSource (4.06s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/samlcertificate     5.473s
=== RUN   TestAccServiceAccountResource
=== PAUSE TestAccServiceAccountResource
=== CONT  TestAccServiceAccountResource
--- PASS: TestAccServiceAccountResource (20.90s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/serviceaccount      22.319s
=== RUN   TestAccSidecarBoundPortsDataSource
=== PAUSE TestAccSidecarBoundPortsDataSource
=== RUN   TestAccSidecarIDDataSource
=== PAUSE TestAccSidecarIDDataSource
=== RUN   TestAccSidecarResource
=== PAUSE TestAccSidecarResource
=== CONT  TestAccSidecarResource
=== CONT  TestAccSidecarIDDataSource
=== CONT  TestAccSidecarBoundPortsDataSource
--- PASS: TestAccSidecarIDDataSource (7.23s)
--- PASS: TestAccSidecarBoundPortsDataSource (17.31s)
--- PASS: TestAccSidecarResource (25.09s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/sidecar     26.537s
=== RUN   TestAccSidecarCredentialsResource
=== PAUSE TestAccSidecarCredentialsResource
=== CONT  TestAccSidecarCredentialsResource
--- PASS: TestAccSidecarCredentialsResource (5.93s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/sidecar/credentials 7.362s
=== RUN   TestAccSidecarHealthDataSource
=== PAUSE TestAccSidecarHealthDataSource
=== CONT  TestAccSidecarHealthDataSource
--- PASS: TestAccSidecarHealthDataSource (6.16s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/sidecar/health      7.585s
=== RUN   TestAccSidecarInstanceDataSource
=== PAUSE TestAccSidecarInstanceDataSource
=== CONT  TestAccSidecarInstanceDataSource
--- PASS: TestAccSidecarInstanceDataSource (6.74s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/sidecar/instance    8.168s
=== RUN   TestAccSidecarInstanceStatsDataSource
=== PAUSE TestAccSidecarInstanceStatsDataSource
=== CONT  TestAccSidecarInstanceStatsDataSource
--- PASS: TestAccSidecarInstanceStatsDataSource (4.36s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/sidecar/instance/stats      5.819s
=== RUN   TestAccSidecarListenerDataSource
=== PAUSE TestAccSidecarListenerDataSource
=== RUN   TestSidecarListenerResource
=== PAUSE TestSidecarListenerResource
=== CONT  TestSidecarListenerResource
=== CONT  TestAccSidecarListenerDataSource
--- PASS: TestAccSidecarListenerDataSource (18.46s)
--- PASS: TestSidecarListenerResource (34.85s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/sidecar/listener    36.308s
testing: warning: no tests to run
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/sweep       1.376s [no tests to run]
=== RUN   TestAccSystemInfoDataSource
=== PAUSE TestAccSystemInfoDataSource
=== CONT  TestAccSystemInfoDataSource
--- PASS: TestAccSystemInfoDataSource (3.82s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/systeminfo  5.241s
=== RUN   TestAccAccessTokenSettingsResource
=== PAUSE TestAccAccessTokenSettingsResource
=== CONT  TestAccAccessTokenSettingsResource
--- PASS: TestAccAccessTokenSettingsResource (13.97s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/tokensettings       15.401s
=== RUN   TestAccProvider
--- PASS: TestAccProvider (0.01s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/provider     1.323s
=== RUN   TestElementsMatch
--- PASS: TestElementsMatch (0.00s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/utils        (cached)
```