### PR TITLE
Improve examples for resources policy and policy_rules

### DIFF
--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -13,13 +13,12 @@ Manages [policies](https://cyral.com/docs/reference/policy). See also: [Policy R
 ## Example Usage
 
 ```terraform
-resource "cyral_policy" "some_resource_name" {
-  name = ""
-  description = ""
+resource "cyral_policy" "this" {
+  name = "My first policy"
+  description = "This is my first policy"
   enabled = true
-  data = [""]
-  data_label_tags = [""]
-  tags = [""]
+  data = ["EMAIL"]
+  metadata_tags = ["Risk Level 1"]
 }
 ```
 

--- a/docs/resources/policy_rule.md
+++ b/docs/resources/policy_rule.md
@@ -9,51 +9,31 @@ Manages [policy rules](https://cyral.com/docs/reference/policy/#rules). See also
 ## Example Usage
 
 ```terraform
-resource "cyral_policy_rule" "some_resource_name" {
-    policy_id = ""
-    hosts = [""]
-    identities {
-        db_roles = [""]
-        groups = [""]
-        services = [""]
-        users = [""]
-    }
-    deletes {
-        additional_checks = ""
-        data = [""]
-        dataset_rewrites {
-            dataset = ""
-            repo = ""
-            substitution = ""
-            parameters = [""]
-        }
-        rows = 1
-        severity = "low"
-    }
-    reads {
-        additional_checks = ""
-        data = [""]
-        dataset_rewrites {
-            dataset = ""
-            repo = ""
-            substitution = ""
-            parameters = [""]
-        }
-        rows = 1
-        severity = "low"
-    }
-    updates {
-        additional_checks = ""
-        data = [""]
-        dataset_rewrites {
-            dataset = ""
-            repo = ""
-            substitution = ""
-            parameters = [""]
-        }
-        rows = 1
-        severity = "low"
-    }
+# An example of a policy and a policy rule with a rego policy
+# in `additional_checks`.
+resource "cyral_policy" "this" {
+  name = "My first policy"
+  description = "This is my first policy"
+  enabled = true
+  data = ["EMAIL"]
+  metadata_tags = ["Risk Level 1"]
+}
+
+resource "cyral_policy_rule" "this" {
+  policy_id = cyral_policy.this.id
+  deletes {
+    additional_checks = <<EOT
+is_valid_request {
+  filter := request.filters[_]
+  filter.field == "entity.user.is_real"
+  filter.op == "="
+  filter.value == false
+}
+EOT
+    data = ["EMAIL"]
+    rows = -1
+    severity = "low"
+  }
 }
 ```
 

--- a/examples/resources/cyral_policy/resource.tf
+++ b/examples/resources/cyral_policy/resource.tf
@@ -1,8 +1,7 @@
-resource "cyral_policy" "some_resource_name" {
-  name = ""
-  description = ""
+resource "cyral_policy" "this" {
+  name = "My first policy"
+  description = "This is my first policy"
   enabled = true
-  data = [""]
-  data_label_tags = [""]
-  tags = [""]
+  data = ["EMAIL"]
+  metadata_tags = ["Risk Level 1"]
 }

--- a/examples/resources/cyral_policy_rule/resource.tf
+++ b/examples/resources/cyral_policy_rule/resource.tf
@@ -1,46 +1,26 @@
-resource "cyral_policy_rule" "some_resource_name" {
-    policy_id = ""
-    hosts = [""]
-    identities {
-        db_roles = [""]
-        groups = [""]
-        services = [""]
-        users = [""]
-    }
-    deletes {
-        additional_checks = ""
-        data = [""]
-        dataset_rewrites {
-            dataset = ""
-            repo = ""
-            substitution = ""
-            parameters = [""]
-        }
-        rows = 1
-        severity = "low"
-    }
-    reads {
-        additional_checks = ""
-        data = [""]
-        dataset_rewrites {
-            dataset = ""
-            repo = ""
-            substitution = ""
-            parameters = [""]
-        }
-        rows = 1
-        severity = "low"
-    }
-    updates {
-        additional_checks = ""
-        data = [""]
-        dataset_rewrites {
-            dataset = ""
-            repo = ""
-            substitution = ""
-            parameters = [""]
-        }
-        rows = 1
-        severity = "low"
-    }
+# An example of a policy and a policy rule with a rego policy
+# in `additional_checks`.
+resource "cyral_policy" "this" {
+  name = "My first policy"
+  description = "This is my first policy"
+  enabled = true
+  data = ["EMAIL"]
+  metadata_tags = ["Risk Level 1"]
+}
+
+resource "cyral_policy_rule" "this" {
+  policy_id = cyral_policy.this.id
+  deletes {
+    additional_checks = <<EOT
+is_valid_request {
+  filter := request.filters[_]
+  filter.field == "entity.user.is_real"
+  filter.op == "="
+  filter.value == false
+}
+EOT
+    data = ["EMAIL"]
+    rows = -1
+    severity = "low"
+  }
 }


### PR DESCRIPTION
## Description of the change

Improve examples for resources `cyral_policy` and `cyral_policy_rules` to show a rego policy use case. The current examples just show all fields of the resources and don't show a tangible use case. The goal for this PR is add some meaningful policy that can be read and understood by users.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

NA
