### PR TITLE
ENG-14351: Fix invalid TLS option check

### DIFF
--- a/cyral/internal/repository/confauth/constants.go
+++ b/cyral/internal/repository/confauth/constants.go
@@ -1,11 +1,45 @@
 package confauth
 
-const (
-	resourceName = "cyral_repository_conf_auth"
+import "github.com/cyralinc/terraform-provider-cyral/cyral/utils"
 
-	DefaultClientTLS    = "disable"
-	DefaultRepoTLS      = "disable"
+const (
+	resourceName        = "cyral_repository_conf_auth"
 	AccessTokenAuthType = "ACCESS_TOKEN"
 	AwsIAMAuthType      = "AWS_IAM"
 	DefaultAuthType     = AccessTokenAuthType
 )
+
+const (
+	TLSEnable              = TLSType("enable")
+	TLSEnableAndVerifyCert = TLSType("enableAndVerifyCert")
+	TLSDisable             = TLSType("disable")
+)
+
+type TLSType string
+
+func ClientTLSTypes() []TLSType {
+	return []TLSType{
+		TLSEnable,
+		TLSDisable,
+	}
+}
+
+func ClientTLSTypesAsString() []string {
+	return utils.ToSliceOfString[TLSType](ClientTLSTypes(), func(t TLSType) string {
+		return string(t)
+	})
+}
+
+func RepoTLSTypes() []TLSType {
+	return []TLSType{
+		TLSEnable,
+		TLSEnableAndVerifyCert,
+		TLSDisable,
+	}
+}
+
+func RepoTLSTypesAsString() []string {
+	return utils.ToSliceOfString[TLSType](RepoTLSTypes(), func(t TLSType) string {
+		return string(t)
+	})
+}

--- a/cyral/internal/repository/confauth/model.go
+++ b/cyral/internal/repository/confauth/model.go
@@ -1,8 +1,6 @@
 package confauth
 
 import (
-	"errors"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -26,21 +24,9 @@ func (data RepositoryConfAuthData) WriteToSchema(d *schema.ResourceData) error {
 	}
 
 	d.Set("allow_native_auth", data.AllowNativeAuth)
-
-	if err := data.isClientTLSValid(); err != nil {
-		panic(err)
-	}
-
 	d.Set("client_tls", data.ClientTLS)
-
 	d.Set("identity_provider", data.IdentityProvider)
-
-	if err := data.isRepoTLSValid(); err != nil {
-		panic(err)
-	}
-
 	d.Set("repo_tls", data.RepoTLS)
-
 	d.Set("auth_type", data.AuthType)
 
 	return nil
@@ -58,20 +44,6 @@ func (data *RepositoryConfAuthData) ReadFromSchema(d *schema.ResourceData) error
 	data.IdentityProvider = d.Get("identity_provider").(string)
 	data.RepoTLS = d.Get("repo_tls").(string)
 
-	return nil
-}
-
-func (data RepositoryConfAuthData) isClientTLSValid() error {
-	if !(data.ClientTLS == "enable" || data.ClientTLS == "disable" || data.ClientTLS == "enabledAndVerifyCertificate") {
-		return errors.New("invalid option to client_tls")
-	}
-	return nil
-}
-
-func (data RepositoryConfAuthData) isRepoTLSValid() error {
-	if !(data.RepoTLS == "enable" || data.RepoTLS == "disable" || data.RepoTLS == "enabledAndVerifyCertificate") {
-		return errors.New("invalid option to repo_tls")
-	}
 	return nil
 }
 

--- a/cyral/internal/repository/confauth/resource.go
+++ b/cyral/internal/repository/confauth/resource.go
@@ -106,7 +106,7 @@ func repositoryConfAuthResourceSchemaV0() *schema.Resource {
 			"client_tls": {
 				Description: fmt.Sprintf(
 					"Specifies whether the sidecar will require TLS communication with clients."+
-						" Defaults to `%q`. List of supported values: %q", TLSDisable, utils.SupportedValuesAsMarkdown(ClientTLSTypesAsString())),
+						" Defaults to `%s`. List of supported values: %s", TLSDisable, utils.SupportedValuesAsMarkdown(ClientTLSTypesAsString())),
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      TLSDisable,

--- a/cyral/internal/repository/confauth/resource.go
+++ b/cyral/internal/repository/confauth/resource.go
@@ -104,10 +104,13 @@ func repositoryConfAuthResourceSchemaV0() *schema.Resource {
 				Optional:    true,
 			},
 			"client_tls": {
-				Description: fmt.Sprintf("Is the repo Client using TLS? Default is %q.", DefaultClientTLS),
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     DefaultClientTLS,
+				Description: fmt.Sprintf(
+					"Specifies whether the sidecar will require TLS communication with clients."+
+						" Defaults to `%q`. List of supported values: %q", TLSDisable, utils.SupportedValuesAsMarkdown(ClientTLSTypesAsString())),
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      TLSDisable,
+				ValidateFunc: validation.StringInSlice(append(ClientTLSTypesAsString(), ""), false),
 			},
 			"identity_provider": {
 				Description: fmt.Sprintf(
@@ -127,10 +130,13 @@ func repositoryConfAuthResourceSchemaV0() *schema.Resource {
 				Optional: true,
 			},
 			"repo_tls": {
-				Description: fmt.Sprintf("Is TLS enabled for the repository? Default is %q.", DefaultRepoTLS),
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     DefaultRepoTLS,
+				Description: fmt.Sprintf(
+					"Specifies whether the sidecar will communicate with the repository using TLS."+
+						" Defaults to `%q`. List of supported values: %q", TLSDisable, utils.SupportedValuesAsMarkdown(RepoTLSTypesAsString())),
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      TLSDisable,
+				ValidateFunc: validation.StringInSlice(append(RepoTLSTypesAsString(), ""), false),
 			},
 			"auth_type": {
 				Description: fmt.Sprintf("Authentication type for this repository. **Note**: `%s` is currently "+

--- a/cyral/internal/repository/confauth/resource.go
+++ b/cyral/internal/repository/confauth/resource.go
@@ -132,7 +132,7 @@ func repositoryConfAuthResourceSchemaV0() *schema.Resource {
 			"repo_tls": {
 				Description: fmt.Sprintf(
 					"Specifies whether the sidecar will communicate with the repository using TLS."+
-						" Defaults to `%q`. List of supported values: %q", TLSDisable, utils.SupportedValuesAsMarkdown(RepoTLSTypesAsString())),
+						" Defaults to `%s`. List of supported values: %s", TLSDisable, utils.SupportedValuesAsMarkdown(RepoTLSTypesAsString())),
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      TLSDisable,

--- a/cyral/internal/repository/confauth/resource_test.go
+++ b/cyral/internal/repository/confauth/resource_test.go
@@ -29,8 +29,8 @@ func repositoryConfAuthDependencyConfig() string {
 func initialRepositoryConfAuthConfig() auth.RepositoryConfAuthData {
 	return auth.RepositoryConfAuthData{
 		AllowNativeAuth: false,
-		ClientTLS:       "disable",
-		RepoTLS:         "enable",
+		ClientTLS:       string(auth.TLSDisable),
+		RepoTLS:         string(auth.TLSEnable),
 		AuthType:        "ACCESS_TOKEN",
 	}
 }
@@ -38,8 +38,8 @@ func initialRepositoryConfAuthConfig() auth.RepositoryConfAuthData {
 func update1RepositoryConfAuthConfig() auth.RepositoryConfAuthData {
 	return auth.RepositoryConfAuthData{
 		AllowNativeAuth: true,
-		ClientTLS:       "enable",
-		RepoTLS:         "disable",
+		ClientTLS:       string(auth.TLSEnable),
+		RepoTLS:         string(auth.TLSDisable),
 		AuthType:        "AWS_IAM",
 	}
 }
@@ -47,8 +47,8 @@ func update1RepositoryConfAuthConfig() auth.RepositoryConfAuthData {
 func update2RepositoryConfAuthConfig() auth.RepositoryConfAuthData {
 	return auth.RepositoryConfAuthData{
 		AllowNativeAuth: false,
-		ClientTLS:       "enable",
-		RepoTLS:         "disable",
+		ClientTLS:       string(auth.TLSEnable),
+		RepoTLS:         string(auth.TLSDisable),
 		AuthType:        "ACCESS_TOKEN",
 	}
 }
@@ -69,8 +69,8 @@ func repositoryConfAuthMinimalConfigTest(resName string) resource.TestStep {
 		Check: setupRepositoryConfAuthCheck(
 			resName,
 			auth.RepositoryConfAuthData{
-				ClientTLS: auth.DefaultClientTLS,
-				RepoTLS:   auth.DefaultRepoTLS,
+				ClientTLS: string(auth.TLSDisable),
+				RepoTLS:   string(auth.TLSDisable),
 				AuthType:  auth.DefaultAuthType,
 			},
 		),

--- a/cyral/internal/repository/confauth/resource_test.go
+++ b/cyral/internal/repository/confauth/resource_test.go
@@ -48,7 +48,7 @@ func update2RepositoryConfAuthConfig() auth.RepositoryConfAuthData {
 	return auth.RepositoryConfAuthData{
 		AllowNativeAuth: false,
 		ClientTLS:       string(auth.TLSEnable),
-		RepoTLS:         string(auth.TLSDisable),
+		RepoTLS:         string(auth.TLSEnableAndVerifyCert),
 		AuthType:        "ACCESS_TOKEN",
 	}
 }

--- a/docs/resources/repository_conf_auth.md
+++ b/docs/resources/repository_conf_auth.md
@@ -30,7 +30,9 @@ resource "cyral_repository_conf_auth" "some_resource_name" {
 -   `auth_type` (String) Authentication type for this repository. **Note**: `AWS_IAM` is currently only supported by `mongodb` repo type. List of supported values:
     -   `ACCESS_TOKEN`
     -   `AWS_IAM`
--   `client_tls` (String) Specifies whether the sidecar will require TLS communication with clients. Defaults to `"disable"`. List of supported values: "\n - `enable`\n - `disable`"
+-   `client_tls` (String) Specifies whether the sidecar will require TLS communication with clients. Defaults to `disable`. List of supported values:
+    -   `enable`
+    -   `disable`
 -   `identity_provider` (String) The semantics of this field changed in control planes `v4.13` and later. See how it should be configured depending on your control plane version:
     -   `v4.12` and below:
         -   Provide the ID (Alias) of the identity provider integration to allow user authentication using an IdP.

--- a/docs/resources/repository_conf_auth.md
+++ b/docs/resources/repository_conf_auth.md
@@ -30,7 +30,7 @@ resource "cyral_repository_conf_auth" "some_resource_name" {
 -   `auth_type` (String) Authentication type for this repository. **Note**: `AWS_IAM` is currently only supported by `mongodb` repo type. List of supported values:
     -   `ACCESS_TOKEN`
     -   `AWS_IAM`
--   `client_tls` (String) Is the repo Client using TLS? Default is "disable".
+-   `client_tls` (String) Specifies whether the sidecar will require TLS communication with clients. Defaults to `"disable"`. List of supported values: "\n - `enable`\n - `disable`"
 -   `identity_provider` (String) The semantics of this field changed in control planes `v4.13` and later. See how it should be configured depending on your control plane version:
     -   `v4.12` and below:
         -   Provide the ID (Alias) of the identity provider integration to allow user authentication using an IdP.
@@ -38,7 +38,7 @@ resource "cyral_repository_conf_auth" "some_resource_name" {
         -   If not supplied, then end-user authentication is disabled.
         -   If end-user authentication with Cyral Access Token is desired, then set to `ACCESS_TOKEN` or any other non-empty string.
         -   If end-user authentication with AWS IAM is desired, then this must be the ID of an AWS IAM integration, and the `auth_type` attribute must be set to `AWS_IAM`.
--   `repo_tls` (String) Is TLS enabled for the repository? Default is "disable".
+-   `repo_tls` (String) Specifies whether the sidecar will communicate with the repository using TLS. Defaults to `"disable"`. List of supported values: "\n - `enable`\n - `enableAndVerifyCert`\n - `disable`"
 
 ### Read-Only
 

--- a/docs/resources/repository_conf_auth.md
+++ b/docs/resources/repository_conf_auth.md
@@ -38,7 +38,10 @@ resource "cyral_repository_conf_auth" "some_resource_name" {
         -   If not supplied, then end-user authentication is disabled.
         -   If end-user authentication with Cyral Access Token is desired, then set to `ACCESS_TOKEN` or any other non-empty string.
         -   If end-user authentication with AWS IAM is desired, then this must be the ID of an AWS IAM integration, and the `auth_type` attribute must be set to `AWS_IAM`.
--   `repo_tls` (String) Specifies whether the sidecar will communicate with the repository using TLS. Defaults to `"disable"`. List of supported values: "\n - `enable`\n - `enableAndVerifyCert`\n - `disable`"
+-   `repo_tls` (String) Specifies whether the sidecar will communicate with the repository using TLS. Defaults to `disable`. List of supported values:
+    -   `enable`
+    -   `enableAndVerifyCert`
+    -   `disable`
 
 ### Read-Only
 

--- a/docs/resources/repository_network_access_policy.md
+++ b/docs/resources/repository_network_access_policy.md
@@ -4,8 +4,7 @@ page_title: "cyral_repository_network_access_policy Resource - terraform-provide
 subcategory: ""
 description: |-
     Manages the network access policy of a repository. Network access policies are also known as the Network Shield https://cyral.com/docs/manage-repositories/network-shield/. This feature is supported for the following repository types:
-      - sqlserver
-      - oracle
+    sqlserveroracle
     -> Note If you also use the resource cyral_repository_conf_auth for the same repository, create a depends_on relationship from this resource to the cyral_repository_conf_auth to avoid errors when running terraform destroy.
 ---
 


### PR DESCRIPTION
## Description of the change

Fix invalid repo TLS option check in `cyral_repository_conf_auth`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

All tests ran successfully in a `v4.16` CP:

```
make local/test
go test github.com/cyralinc/terraform-provider-cyral/... -v -race -timeout 20m
?       github.com/cyralinc/terraform-provider-cyral    [no test files]
?       github.com/cyralinc/terraform-provider-cyral/cyral/core [no test files]
?       github.com/cyralinc/terraform-provider-cyral/cyral/core/types/operationtype     [no test files]
?       github.com/cyralinc/terraform-provider-cyral/cyral/core/types/resourcetype      [no test files]
=== RUN   TestNewClient_WhenTLSSkipVerifyIsEnabled_ThenInsecureSkipVerifyIsTrue
--- PASS: TestNewClient_WhenTLSSkipVerifyIsEnabled_ThenInsecureSkipVerifyIsTrue (0.00s)
=== RUN   TestNewClient_WhenTLSSkipVerifyIsDisabled_ThenInsecureSkipVerifyIsFalse
--- PASS: TestNewClient_WhenTLSSkipVerifyIsDisabled_ThenInsecureSkipVerifyIsFalse (0.00s)
=== RUN   TestNewClient_WhenClientIDIsEmpty_ThenThrowError
--- PASS: TestNewClient_WhenClientIDIsEmpty_ThenThrowError (0.00s)
=== RUN   TestNewClient_WhenClientSecretIsEmpty_ThenThrowError
--- PASS: TestNewClient_WhenClientSecretIsEmpty_ThenThrowError (0.00s)
=== RUN   TestNewClient_WhenControlPlaneIsEmpty_ThenThrowError
--- PASS: TestNewClient_WhenControlPlaneIsEmpty_ThenThrowError (0.00s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/client       (cached)
?       github.com/cyralinc/terraform-provider-cyral/cyral/internal/datalabel/classificationrule        [no test files]
?       github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/confextension   [no test files]
=== RUN   TestAccDatalabelDataSource
=== PAUSE TestAccDatalabelDataSource
=== RUN   TestAccDatalabelResource
--- PASS: TestAccDatalabelResource (3.07s)
=== CONT  TestAccDatalabelDataSource
--- PASS: TestAccDatalabelDataSource (24.74s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/datalabel   29.383s
=== RUN   TestAccSAMLConfigurationDataSource
=== PAUSE TestAccSAMLConfigurationDataSource
=== RUN   TestAccSidecarInstanceIDsDataSource
=== PAUSE TestAccSidecarInstanceIDsDataSource
=== RUN   TestIntegrationsData_GetValue_Default
--- PASS: TestIntegrationsData_GetValue_Default (0.00s)
=== RUN   TestIntegrationsData_GetValue_Splunk
--- PASS: TestIntegrationsData_GetValue_Splunk (0.00s)
=== RUN   TestAccDatadogIntegrationResource
=== PAUSE TestAccDatadogIntegrationResource
=== RUN   TestAccELKIntegrationResource
=== PAUSE TestAccELKIntegrationResource
=== RUN   TestAccIdPIntegrationResource
=== PAUSE TestAccIdPIntegrationResource
=== RUN   TestAccLogstashIntegrationResource
=== PAUSE TestAccLogstashIntegrationResource
=== RUN   TestAccLookerIntegrationResource
=== PAUSE TestAccLookerIntegrationResource
=== RUN   TestAccSplunkIntegrationResource
=== PAUSE TestAccSplunkIntegrationResource
=== RUN   TestAccSumoLogicIntegrationResource
=== PAUSE TestAccSumoLogicIntegrationResource
=== CONT  TestAccSAMLConfigurationDataSource
=== CONT  TestAccIdPIntegrationResource
=== CONT  TestAccLookerIntegrationResource
=== CONT  TestAccELKIntegrationResource
=== CONT  TestAccDatadogIntegrationResource
=== CONT  TestAccSidecarInstanceIDsDataSource
=== CONT  TestAccSumoLogicIntegrationResource
=== CONT  TestAccLogstashIntegrationResource
=== CONT  TestAccSplunkIntegrationResource
--- PASS: TestAccELKIntegrationResource (13.35s)
--- PASS: TestAccLookerIntegrationResource (13.51s)
--- PASS: TestAccSplunkIntegrationResource (13.78s)
--- PASS: TestAccDatadogIntegrationResource (13.82s)
--- PASS: TestAccSumoLogicIntegrationResource (13.85s)
--- PASS: TestAccLogstashIntegrationResource (20.57s)
--- PASS: TestAccSAMLConfigurationDataSource (20.58s)
--- PASS: TestAccSidecarInstanceIDsDataSource (25.06s)
--- PASS: TestAccIdPIntegrationResource (60.42s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/deprecated  65.486s
=== RUN   TestAccPolicyResource
=== PAUSE TestAccPolicyResource
=== CONT  TestAccPolicyResource
--- PASS: TestAccPolicyResource (10.07s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/deprecated/policy   13.609s
=== RUN   TestIntegrationAWSIAMAuthN
=== PAUSE TestIntegrationAWSIAMAuthN
=== CONT  TestIntegrationAWSIAMAuthN
--- PASS: TestIntegrationAWSIAMAuthN (22.65s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/awsiam  26.696s
=== RUN   TestAccDuoMFAIntegrationResource
=== PAUSE TestAccDuoMFAIntegrationResource
=== CONT  TestAccDuoMFAIntegrationResource
--- PASS: TestAccDuoMFAIntegrationResource (9.31s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/confextension/mfaduo    11.834s
=== RUN   TestAccPagerDutyIntegrationResource
=== PAUSE TestAccPagerDutyIntegrationResource
=== CONT  TestAccPagerDutyIntegrationResource
--- PASS: TestAccPagerDutyIntegrationResource (10.59s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/confextension/pagerduty 13.616s
=== RUN   TestAccHCVaultIntegrationResource
=== PAUSE TestAccHCVaultIntegrationResource
=== CONT  TestAccHCVaultIntegrationResource
--- PASS: TestAccHCVaultIntegrationResource (10.09s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/hcvault 12.109s
=== RUN   TestAccIntegrationIdPSAMLDataSource
=== PAUSE TestAccIntegrationIdPSAMLDataSource
=== RUN   TestAccIntegrationIdPSAMLResource
=== PAUSE TestAccIntegrationIdPSAMLResource
=== CONT  TestAccIntegrationIdPSAMLDataSource
=== CONT  TestAccIntegrationIdPSAMLResource
--- PASS: TestAccIntegrationIdPSAMLDataSource (37.12s)
--- PASS: TestAccIntegrationIdPSAMLResource (39.64s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/idpsaml 44.192s
=== RUN   TestAccIntegrationIdPSAMLDraftResource
=== PAUSE TestAccIntegrationIdPSAMLDraftResource
=== CONT  TestAccIntegrationIdPSAMLDraftResource
--- PASS: TestAccIntegrationIdPSAMLDraftResource (16.19s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/idpsaml/draft   21.232s
=== RUN   TestAccLoggingIntegrationDataSource
=== PAUSE TestAccLoggingIntegrationDataSource
=== RUN   TestAccLogsIntegrationResourceCloudWatch
=== PAUSE TestAccLogsIntegrationResourceCloudWatch
=== RUN   TestAccLogsIntegrationResourceDataDog
=== PAUSE TestAccLogsIntegrationResourceDataDog
=== RUN   TestAccLogsIntegrationResourceElk
=== PAUSE TestAccLogsIntegrationResourceElk
=== RUN   TestAccLogsIntegrationResourceElkEmptyEsCredentials
=== PAUSE TestAccLogsIntegrationResourceElkEmptyEsCredentials
=== RUN   TestAccLogsIntegrationResourceSplunk
=== PAUSE TestAccLogsIntegrationResourceSplunk
=== RUN   TestAccLogsIntegrationResourceSumologic
=== PAUSE TestAccLogsIntegrationResourceSumologic
=== RUN   TestAccLogsIntegrationResourceFluentbit
=== PAUSE TestAccLogsIntegrationResourceFluentbit
=== CONT  TestAccLoggingIntegrationDataSource
=== CONT  TestAccLogsIntegrationResourceSplunk
=== CONT  TestAccLogsIntegrationResourceElk
=== CONT  TestAccLogsIntegrationResourceDataDog
=== CONT  TestAccLogsIntegrationResourceFluentbit
=== CONT  TestAccLogsIntegrationResourceSumologic
=== CONT  TestAccLogsIntegrationResourceElkEmptyEsCredentials
=== CONT  TestAccLogsIntegrationResourceCloudWatch
--- PASS: TestAccLogsIntegrationResourceFluentbit (12.43s)
--- PASS: TestAccLogsIntegrationResourceDataDog (12.61s)
--- PASS: TestAccLogsIntegrationResourceSplunk (13.73s)
--- PASS: TestAccLogsIntegrationResourceElk (13.84s)
--- PASS: TestAccLogsIntegrationResourceSumologic (13.84s)
--- PASS: TestAccLogsIntegrationResourceElkEmptyEsCredentials (14.05s)
--- PASS: TestAccLogsIntegrationResourceCloudWatch (14.13s)
--- PASS: TestAccLoggingIntegrationDataSource (17.27s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/logging 22.755s
=== RUN   TestAccSlackAlertsIntegrationResource
=== PAUSE TestAccSlackAlertsIntegrationResource
=== CONT  TestAccSlackAlertsIntegrationResource
--- PASS: TestAccSlackAlertsIntegrationResource (8.04s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/slack   9.660s
=== RUN   TestAccMsTeamsIntegrationResource
=== PAUSE TestAccMsTeamsIntegrationResource
=== CONT  TestAccMsTeamsIntegrationResource
--- PASS: TestAccMsTeamsIntegrationResource (10.16s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/integration/teams   11.741s
=== RUN   TestAccPermissionDataSource
=== PAUSE TestAccPermissionDataSource
=== CONT  TestAccPermissionDataSource
--- PASS: TestAccPermissionDataSource (5.65s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/permission  7.248s
=== RUN   TestAccPolicyRuleResource
=== PAUSE TestAccPolicyRuleResource
=== RUN   TestPolicyRuleResourceUpgradeV0
--- PASS: TestPolicyRuleResourceUpgradeV0 (0.00s)
=== CONT  TestAccPolicyRuleResource
--- PASS: TestAccPolicyRuleResource (19.67s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/policy/rule 21.448s
=== RUN   TestAccPolicyV2Resource
--- PASS: TestAccPolicyV2Resource (5.43s)
=== RUN   TestAccMinimalPolicyV2Resource
--- PASS: TestAccMinimalPolicyV2Resource (4.30s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/policy/v2   11.299s
=== RUN   TestAccRegoPolicyInstanceResource
=== PAUSE TestAccRegoPolicyInstanceResource
=== CONT  TestAccRegoPolicyInstanceResource
--- PASS: TestAccRegoPolicyInstanceResource (6.67s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/regopolicy  8.729s
=== RUN   TestAccRepositoryDataSource
=== PAUSE TestAccRepositoryDataSource
=== RUN   TestAccRepositoryResource
=== PAUSE TestAccRepositoryResource
=== CONT  TestAccRepositoryDataSource
=== CONT  TestAccRepositoryResource
--- PASS: TestAccRepositoryDataSource (16.06s)
--- PASS: TestAccRepositoryResource (23.50s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository  25.835s
=== RUN   TestAccRepositoryAccessGatewayResource
=== PAUSE TestAccRepositoryAccessGatewayResource
=== CONT  TestAccRepositoryAccessGatewayResource
--- PASS: TestAccRepositoryAccessGatewayResource (21.29s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/accessgateway    22.862s
=== RUN   TestAccRepositoryAccessRulesResource
=== PAUSE TestAccRepositoryAccessRulesResource
=== CONT  TestAccRepositoryAccessRulesResource
--- PASS: TestAccRepositoryAccessRulesResource (14.20s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/accessrules      15.763s
=== RUN   TestAccRepositoryBindingResource
=== PAUSE TestAccRepositoryBindingResource
=== CONT  TestAccRepositoryBindingResource
--- PASS: TestAccRepositoryBindingResource (13.57s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/binding  15.136s
=== RUN   TestAccRepositoryConfAnalysisResource
=== PAUSE TestAccRepositoryConfAnalysisResource
=== RUN   TestRepositoryConfAnalysisResourceUpgradeV0
--- PASS: TestRepositoryConfAnalysisResourceUpgradeV0 (0.00s)
=== CONT  TestAccRepositoryConfAnalysisResource
--- PASS: TestAccRepositoryConfAnalysisResource (8.72s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/confanalysis     10.298s
=== RUN   TestAccRepositoryConfAuthResource
=== PAUSE TestAccRepositoryConfAuthResource
=== RUN   TestRepositoryConfAuthResourceUpgradeV0
--- PASS: TestRepositoryConfAuthResourceUpgradeV0 (0.00s)
=== CONT  TestAccRepositoryConfAuthResource
--- PASS: TestAccRepositoryConfAuthResource (15.24s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/confauth 16.804s
=== RUN   TestAccRepositoryDatamapResource
=== PAUSE TestAccRepositoryDatamapResource
=== CONT  TestAccRepositoryDatamapResource
--- PASS: TestAccRepositoryDatamapResource (18.90s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/datamap  20.462s
=== RUN   TestAccRepositoryNetworkAccessPolicyResource
=== PAUSE TestAccRepositoryNetworkAccessPolicyResource
=== CONT  TestAccRepositoryNetworkAccessPolicyResource
--- PASS: TestAccRepositoryNetworkAccessPolicyResource (18.55s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/network  20.128s
=== RUN   TestAccRepositoryUserAccountResource
=== PAUSE TestAccRepositoryUserAccountResource
=== CONT  TestAccRepositoryUserAccountResource
--- PASS: TestAccRepositoryUserAccountResource (41.54s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/repository/useraccount      43.143s
=== RUN   TestAccRoleDataSource
=== PAUSE TestAccRoleDataSource
=== RUN   TestAccRoleResource
=== PAUSE TestAccRoleResource
=== CONT  TestAccRoleResource
=== CONT  TestAccRoleDataSource
--- PASS: TestAccRoleResource (26.86s)
--- PASS: TestAccRoleDataSource (83.98s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/role        85.574s
=== RUN   TestAccRoleSSOGroupsResource
=== PAUSE TestAccRoleSSOGroupsResource
=== RUN   TestRoleSSOGroupsResourceUpgradeV0
--- PASS: TestRoleSSOGroupsResourceUpgradeV0 (0.00s)
=== CONT  TestAccRoleSSOGroupsResource
--- PASS: TestAccRoleSSOGroupsResource (16.97s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/role/ssogroups      18.552s
=== RUN   TestAccSAMLCertificateDataSource
=== PAUSE TestAccSAMLCertificateDataSource
=== CONT  TestAccSAMLCertificateDataSource
--- PASS: TestAccSAMLCertificateDataSource (4.02s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/samlcertificate     5.593s
=== RUN   TestAccServiceAccountResource
=== PAUSE TestAccServiceAccountResource
=== CONT  TestAccServiceAccountResource
--- PASS: TestAccServiceAccountResource (24.13s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/serviceaccount      25.688s
=== RUN   TestAccSidecarBoundPortsDataSource
=== PAUSE TestAccSidecarBoundPortsDataSource
=== RUN   TestAccSidecarIDDataSource
=== PAUSE TestAccSidecarIDDataSource
=== RUN   TestAccSidecarResource
=== PAUSE TestAccSidecarResource
=== CONT  TestAccSidecarBoundPortsDataSource
=== CONT  TestAccSidecarResource
=== CONT  TestAccSidecarIDDataSource
--- PASS: TestAccSidecarIDDataSource (10.78s)
--- PASS: TestAccSidecarBoundPortsDataSource (15.90s)
--- PASS: TestAccSidecarResource (25.58s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/sidecar     27.148s
=== RUN   TestAccSidecarCredentialsResource
=== PAUSE TestAccSidecarCredentialsResource
=== CONT  TestAccSidecarCredentialsResource
--- PASS: TestAccSidecarCredentialsResource (11.54s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/sidecar/credentials 13.512s
=== RUN   TestAccSidecarHealthDataSource
=== PAUSE TestAccSidecarHealthDataSource
=== CONT  TestAccSidecarHealthDataSource
--- PASS: TestAccSidecarHealthDataSource (10.25s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/sidecar/health      11.816s
=== RUN   TestAccSidecarInstanceDataSource
=== PAUSE TestAccSidecarInstanceDataSource
=== CONT  TestAccSidecarInstanceDataSource
--- PASS: TestAccSidecarInstanceDataSource (9.98s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/sidecar/instance    11.559s
=== RUN   TestAccSidecarInstanceStatsDataSource
=== PAUSE TestAccSidecarInstanceStatsDataSource
=== CONT  TestAccSidecarInstanceStatsDataSource
--- PASS: TestAccSidecarInstanceStatsDataSource (6.12s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/sidecar/instance/stats      7.692s
=== RUN   TestAccSidecarListenerDataSource
=== PAUSE TestAccSidecarListenerDataSource
=== RUN   TestSidecarListenerResource
=== PAUSE TestSidecarListenerResource
=== CONT  TestSidecarListenerResource
=== CONT  TestAccSidecarListenerDataSource
--- PASS: TestAccSidecarListenerDataSource (14.81s)
--- PASS: TestSidecarListenerResource (28.70s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/sidecar/listener    30.285s
testing: warning: no tests to run
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/sweep       (cached) [no tests to run]
=== RUN   TestAccSystemInfoDataSource
=== PAUSE TestAccSystemInfoDataSource
=== CONT  TestAccSystemInfoDataSource
--- PASS: TestAccSystemInfoDataSource (4.58s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/systeminfo  6.132s
=== RUN   TestAccAccessTokenSettingsResource
=== PAUSE TestAccAccessTokenSettingsResource
=== CONT  TestAccAccessTokenSettingsResource
--- PASS: TestAccAccessTokenSettingsResource (12.02s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/internal/tokensettings       13.972s
=== RUN   TestAccProvider
--- PASS: TestAccProvider (0.00s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/provider     (cached)
=== RUN   TestElementsMatch
--- PASS: TestElementsMatch (0.00s)
PASS
ok      github.com/cyralinc/terraform-provider-cyral/cyral/utils        (cached)
```
