### PR TITLE
Fix wrong doc parameters in repo conf auth

### DIFF
--- a/docs/resources/repository_conf_auth.md
+++ b/docs/resources/repository_conf_auth.md
@@ -10,9 +10,9 @@ Manages Repository Analysis Configuration. This resource allows configuring both
 resource "cyral_repository_conf_auth" "some_resource_name" {
     repository_id = ""
     allow_native_auth = true
-    client_tls = "enable|disable|enabledAndVerifyCertificate"
+    client_tls = "enable|disable"
     identity_provider = ""
-    repo_tls = "enable|disable|enabledAndVerifyCertificate"
+    repo_tls = "enable|disable|enableAndVerifyCert"
 }
 ```
 

--- a/examples/resources/cyral_repository_conf_auth/resource.tf
+++ b/examples/resources/cyral_repository_conf_auth/resource.tf
@@ -1,7 +1,7 @@
 resource "cyral_repository_conf_auth" "some_resource_name" {
     repository_id = ""
     allow_native_auth = true
-    client_tls = "enable|disable|enabledAndVerifyCertificate"
+    client_tls = "enable|disable"
     identity_provider = ""
-    repo_tls = "enable|disable|enabledAndVerifyCertificate"
+    repo_tls = "enable|disable|enableAndVerifyCert"
 }


### PR DESCRIPTION
## Description of the change

Fix wrong documentation parameters in `cyral_repository_conf_auth`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

NA