### PR TITLE
ENG-14011: Add vault_integration_id field to cyral_sidecar resource in terraform provider

### DIFF
--- a/cyral/internal/sidecar/model.go
+++ b/cyral/internal/sidecar/model.go
@@ -47,6 +47,9 @@ func (r *SidecarData) WriteToSchema(d *schema.ResourceData) error {
 		if err := d.Set("diagnostic_log_integration_id", r.SidecarProperties.DiagnosticLogIntegrationID); err != nil {
 			return fmt.Errorf("error setting 'diagnostic_log_integration_id' field: %w", err)
 		}
+		if err := d.Set("vault_integration_id", r.SidecarProperties.VaultIntegrationID); err != nil {
+			return fmt.Errorf("error setting 'vault_integration_id' field: %w", err)
+		}
 	}
 	if err := d.Set("labels", r.Labels); err != nil {
 		return fmt.Errorf("error setting 'labels' field: %w", err)
@@ -87,6 +90,7 @@ func (r *SidecarData) ReadFromSchema(d *schema.ResourceData) error {
 		DeploymentMethod:           d.Get("deployment_method").(string),
 		LogIntegrationID:           activityLogIntegrationID,
 		DiagnosticLogIntegrationID: d.Get("diagnostic_log_integration_id").(string),
+		VaultIntegrationID:         d.Get("vault_integration_id").(string),
 	}
 	r.ServicesConfig = SidecarServicesConfig{
 		"dispatcher": map[string]string{
@@ -103,6 +107,7 @@ type SidecarProperties struct {
 	DeploymentMethod           string `json:"deploymentMethod"`
 	LogIntegrationID           string `json:"logIntegrationID,omitempty"`
 	DiagnosticLogIntegrationID string `json:"diagnosticLogIntegrationID,omitempty"`
+	VaultIntegrationID         string `json:"vaultIntegrationID,omitempty"`
 }
 
 type SidecarServicesConfig map[string]map[string]string

--- a/cyral/internal/sidecar/resource.go
+++ b/cyral/internal/sidecar/resource.go
@@ -116,7 +116,7 @@ func resourceSchema() *schema.Resource {
 				Optional:    true,
 			},
 			"vault_integration_id": {
-				Description: "ID of the HashiCorp Vault integration mapped to this sidecar, used for vault user account authentication.",
+				Description: "ID of the HashiCorp Vault integration to associate to this sidecar to be used for database account authentication.",
 				Type:        schema.TypeString,
 				Optional:    true,
 			},

--- a/cyral/internal/sidecar/resource.go
+++ b/cyral/internal/sidecar/resource.go
@@ -115,6 +115,11 @@ func resourceSchema() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 			},
+			"vault_integration_id": {
+				Description: "ID of the HashiCorp Vault integration mapped to this sidecar, used for vault user account authentication.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
 			"labels": {
 				Description: "Labels that can be attached to the sidecar and shown in the `Tags` field in the UI.",
 				Type:        schema.TypeList,

--- a/docs/resources/sidecar.md
+++ b/docs/resources/sidecar.md
@@ -40,7 +40,7 @@ resource "cyral_sidecar" "some_resource_name" {
 -   `labels` (List of String) Labels that can be attached to the sidecar and shown in the `Tags` field in the UI.
 -   `log_integration_id` (String, Deprecated) ID of the log integration mapped to this sidecar, used for Cyral activity logs.
 -   `user_endpoint` (String) User-defined endpoint (also referred as `alias`) that can be used to override the sidecar DNS endpoint shown in the UI.
--   `vault_integration_id` (String) ID of the HashiCorp Vault integration mapped to this sidecar, used for vault user account authentication.
+-   `vault_integration_id` (String) ID of the HashiCorp Vault integration to associate to this sidecar to be used for database account authentication.
 
 ### Read-Only
 

--- a/docs/resources/sidecar.md
+++ b/docs/resources/sidecar.md
@@ -40,6 +40,7 @@ resource "cyral_sidecar" "some_resource_name" {
 -   `labels` (List of String) Labels that can be attached to the sidecar and shown in the `Tags` field in the UI.
 -   `log_integration_id` (String, Deprecated) ID of the log integration mapped to this sidecar, used for Cyral activity logs.
 -   `user_endpoint` (String) User-defined endpoint (also referred as `alias`) that can be used to override the sidecar DNS endpoint shown in the UI.
+-   `vault_integration_id` (String) ID of the HashiCorp Vault integration mapped to this sidecar, used for vault user account authentication.
 
 ### Read-Only
 


### PR DESCRIPTION
## Description of the change

[ENG-14011](https://cyralinc.atlassian.net/browse/ENG-14011): Add vault_integration_id field to cyral_sidecar resource in terraform provider

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Jira issue referenced in commit message and/or PR title

### Testing

Running acceptance tests and testing the sidecar resource using local changes.


[ENG-14011]: https://cyralinc.atlassian.net/browse/ENG-14011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ