### PR TITLE
Update TF EC2 module to v5

### DIFF
--- a/docs/guides/iam_auth_rds_pg.md
+++ b/docs/guides/iam_auth_rds_pg.md
@@ -246,7 +246,7 @@ module "cyral_sidecar" {
   source = "cyralinc/sidecar-ec2/aws"
 
   # Use the module version that is compatible with your sidecar.
-  version = "~> 4.3"
+  version = "~> 5.0"
 
   sidecar_id = cyral_sidecar.sidecar.id
   control_plane = local.control_plane_host

--- a/docs/guides/iam_auth_rds_pg.md
+++ b/docs/guides/iam_auth_rds_pg.md
@@ -265,11 +265,11 @@ module "cyral_sidecar" {
   load_balancer_scheme        = local.sidecar.public_sidecar ? "internet-facing" : "internal"
   associate_public_ip_address = local.sidecar.public_sidecar
 
-  sidecar_dns_hosted_zone_id = local.sidecar.dns_hosted_zone_id
-  sidecar_dns_name           = local.sidecar.dns_name
+  dns_hosted_zone_id = local.sidecar.dns_hosted_zone_id
+  dns_name           = local.sidecar.dns_name
 }
 
 output "sidecar_load_balancer_dns" {
-  value = module.cyral_sidecar.sidecar_load_balancer_dns
+  value = module.cyral_sidecar.load_balancer_dns
 }
 ```

--- a/docs/guides/mongodb_cluster_okta_idp.md
+++ b/docs/guides/mongodb_cluster_okta_idp.md
@@ -98,17 +98,6 @@ locals {
     # Name of the CloudWatch log group used to push logs
     cloudwatch_log_group_name = "cyral-example-loggroup"
 
-    # Set the parameters to access the private Cyral container
-    # registry. These parameters can be found in the sidecar
-    # Terraform template downloaded from the UI. Use the
-    # commented values to locate the variables and copy the
-    # values from the downloaded template.
-    container_registry = {
-      name         = "" # container_registry
-      username     = "" # container_registry_username
-      registry_key = "" # container_registry_key
-    }
-
     # Specify the maximum number of nodes you expect this cluster to
     # have, taking into consideration future growth. This number must be
     # at least equal to the number of nodes currently in your
@@ -254,7 +243,7 @@ module "cyral_sidecar" {
   source = "cyralinc/sidecar-ec2/aws"
 
   # Use the module version that is compatible with your sidecar.
-  version = "~> 4.0"
+  version = "~> 5.0"
 
   sidecar_version = local.sidecar.sidecar_version
 
@@ -280,22 +269,16 @@ module "cyral_sidecar" {
   load_balancer_scheme        = local.sidecar.public_sidecar ? "internet-facing" : "internal"
   associate_public_ip_address = local.sidecar.public_sidecar
 
-  deploy_secrets   = true
-  secrets_location = "/cyral/sidecars/${cyral_sidecar.sidecar.id}/secrets"
-
-  container_registry          = local.sidecar.container_registry.name
-  container_registry_username = local.sidecar.container_registry.username
-  container_registry_key      = local.sidecar.container_registry.registry_key
   client_id                   = cyral_sidecar_credentials.sidecar_credentials.client_id
   client_secret               = cyral_sidecar_credentials.sidecar_credentials.client_secret
 }
 
 output "sidecar_dns" {
-  value = module.cyral_sidecar.sidecar_dns
+  value = module.cyral_sidecar.dns
 }
 
 output "sidecar_load_balancer_dns" {
-  value = module.cyral_sidecar.sidecar_load_balancer_dns
+  value = module.cyral_sidecar.load_balancer_dns
 }
 ```
 

--- a/docs/guides/s3_browser_and_aws_cli.md
+++ b/docs/guides/s3_browser_and_aws_cli.md
@@ -252,7 +252,7 @@ module "cyral_sidecar" {
   source = "cyralinc/sidecar-ec2/aws"
 
   # Use the module version that is compatible with your sidecar.
-  version = "~> 4.3"
+  version = "~> 5.0"
 
   sidecar_id = cyral_sidecar.sidecar.id
   control_plane = local.control_plane_host
@@ -271,17 +271,16 @@ module "cyral_sidecar" {
   load_balancer_scheme        = local.sidecar.public_sidecar ? "internet-facing" : "internal"
   associate_public_ip_address = local.sidecar.public_sidecar
 
-
   load_balancer_certificate_arn = local.sidecar.load_balancer_certificate_arn
   load_balancer_tls_ports       = [
     local.repos.s3.browser_port
   ]
 
-  sidecar_dns_hosted_zone_id = local.sidecar.dns_hosted_zone_id
-  sidecar_dns_name           = local.sidecar.dns_name
+  dns_hosted_zone_id = local.sidecar.dns_hosted_zone_id
+  dns_name           = local.sidecar.dns_name
 }
 
 output "sidecar_load_balancer_dns" {
-  value = module.cyral_sidecar.sidecar_load_balancer_dns
+  value = module.cyral_sidecar.load_balancer_dns
 }
 ```

--- a/docs/guides/setup_cp_and_deploy_sidecar.md
+++ b/docs/guides/setup_cp_and_deploy_sidecar.md
@@ -70,17 +70,6 @@ locals {
     # Set the allowed CIDR block for monitoring requests to the
     # sidecar
     monitoring_inbound_cidr = ["0.0.0.0/0"]
-
-    # Set the parameters to access the private Cyral container
-    # registry. These parameters can be found in the sidecar
-    # Terraform template downloaded from the UI. Use the
-    # commented values to locate the variables and copy the
-    # values from the downloaded template.
-    container_registry = {
-      name         = "" # container_registry
-      username     = "" # container_registry_username
-      registry_key = "" # container_registry_key
-    }
   }
 }
 
@@ -159,7 +148,7 @@ module "cyral_sidecar" {
   source = "cyralinc/sidecar-ec2/aws"
 
   # Use the module version that is compatible with your sidecar.
-  version = "~> 4.0"
+  version = "~> 5.0"
 
   sidecar_version = local.sidecar.sidecar_version
 
@@ -181,23 +170,16 @@ module "cyral_sidecar" {
   load_balancer_scheme        = local.sidecar.public_sidecar ? "internet-facing" : "internal"
   associate_public_ip_address = local.sidecar.public_sidecar
 
-  deploy_secrets   = true
-  secrets_location = "/cyral/sidecars/${cyral_sidecar.sidecar.id}/secrets"
-
-  container_registry          = local.sidecar.container_registry.name
-  container_registry_username = local.sidecar.container_registry.username
-  container_registry_key      = local.sidecar.container_registry.registry_key
-
   client_id     = cyral_sidecar_credentials.sidecar_credentials.client_id
   client_secret = cyral_sidecar_credentials.sidecar_credentials.client_secret
 }
 
 output "sidecar_dns" {
-  value = module.cyral_sidecar.sidecar_dns
+  value = module.cyral_sidecar.dns
 }
 
 output "sidecar_load_balancer_dns" {
-  value = module.cyral_sidecar.sidecar_load_balancer_dns
+  value = module.cyral_sidecar.load_balancer_dns
 }
 ```
 

--- a/docs/guides/smart_ports.md
+++ b/docs/guides/smart_ports.md
@@ -93,17 +93,6 @@ locals {
     # Set the allowed CIDR block for monitoring requests to the
     # sidecar
     monitoring_inbound_cidr = ["0.0.0.0/0"]
-
-    # Set the parameters to access the private Cyral container
-    # registry. These parameters can be found in the sidecar
-    # Terraform template downloaded from the UI. Use the
-    # commented values to locate the variables and copy the
-    # values from the downloaded template.
-    container_registry = {
-      name         = "" # container_registry
-      username     = "" # container_registry_username
-      registry_key = "" # container_registry_key
-    }
   }
 }
 
@@ -316,7 +305,7 @@ module "cyral_sidecar" {
   source = "cyralinc/sidecar-ec2/aws"
 
   # Use the module version that is compatible with your sidecar.
-  version = "~> 4.0"
+  version = "~> 5.0"
 
   sidecar_version = local.sidecar.sidecar_version
 
@@ -336,19 +325,12 @@ module "cyral_sidecar" {
   load_balancer_scheme        = local.sidecar.public_sidecar ? "internet-facing" : "internal"
   associate_public_ip_address = local.sidecar.public_sidecar
 
-  deploy_secrets   = true
-  secrets_location = "/cyral/sidecars/${cyral_sidecar.sidecar.id}/secrets"
-
-  container_registry          = local.sidecar.container_registry.name
-  container_registry_username = local.sidecar.container_registry.username
-  container_registry_key      = local.sidecar.container_registry.registry_key
-
   client_id     = cyral_sidecar_credentials.sidecar_credentials.client_id
   client_secret = cyral_sidecar_credentials.sidecar_credentials.client_secret
 }
 
 output "sidecar_load_balancer_dns" {
-  value = module.cyral_sidecar.sidecar_load_balancer_dns
+  value = module.cyral_sidecar.load_balancer_dns
 }
 ```
 
@@ -429,17 +411,6 @@ locals {
     # Set the allowed CIDR block for monitoring requests to the
     # sidecar
     monitoring_inbound_cidr = ["0.0.0.0/0"]
-
-    # Set the parameters to access the private Cyral container
-    # registry. These parameters can be found in the sidecar
-    # Terraform template downloaded from the UI. Use the
-    # commented values to locate the variables and copy the
-    # values from the downloaded template.
-    container_registry = {
-      name         = "" # container_registry
-      username     = "" # container_registry_username
-      registry_key = "" # container_registry_key
-    }
   }
 }
 
@@ -588,7 +559,7 @@ module "cyral_sidecar" {
   source = "cyralinc/sidecar-ec2/aws"
 
   # Use the module version that is compatible with your sidecar.
-  version = "~> 4.0"
+  version = "~> 5.0"
 
   sidecar_version = local.sidecar.sidecar_version
 
@@ -608,18 +579,11 @@ module "cyral_sidecar" {
   load_balancer_scheme        = local.sidecar.public_sidecar ? "internet-facing" : "internal"
   associate_public_ip_address = local.sidecar.public_sidecar
 
-  deploy_secrets   = true
-  secrets_location = "/cyral/sidecars/${cyral_sidecar.sidecar.id}/secrets"
-
-  container_registry          = local.sidecar.container_registry.name
-  container_registry_username = local.sidecar.container_registry.username
-  container_registry_key      = local.sidecar.container_registry.registry_key
-
   client_id     = cyral_sidecar_credentials.sidecar_credentials.client_id
   client_secret = cyral_sidecar_credentials.sidecar_credentials.client_secret
 }
 
 output "sidecar_load_balancer_dns" {
-  value = module.cyral_sidecar.sidecar_load_balancer_dns
+  value = module.cyral_sidecar.load_balancer_dns
 }
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ terraform {
   required_providers {
     cyral = {
       source = "cyralinc/cyral"
-      version = "~> 4.1"
+      version = "~> 4.0"
     }
   }
 }

--- a/docs/resources/integration_logging.md
+++ b/docs/resources/integration_logging.md
@@ -37,7 +37,7 @@ resource "cyral_sidecar_credentials" "creds" {
 
 module "cyral_sidecar" {
   source  = "cyralinc/sidecar-ec2/aws"
-  version = "~> 4.0"
+  version = "~> 5.0"
 
   sidecar_id = cyral_sidecar.sidecar.id
 


### PR DESCRIPTION
## Description of the change

Update all references to the TF EC2 module to refer to the new major `v5`.

Depends on https://github.com/cyralinc/terraform-aws-sidecar-ec2/pull/118 and a new version `v5` of the module officially released.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

NA
